### PR TITLE
docs: aws: default os_image is flatcar, not coreos

### DIFF
--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -235,7 +235,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | EC2 instance type for controllers | "t3.small" | See below |
 | worker_type | EC2 instance type for workers | "t3.small" | See below |
-| os_image | AMI channel for a Flatcar Linux derivative | coreos-stable | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha |
+| os_image | AMI channel for a Flatcar Linux derivative | flatcar-stable | coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha |
 | disk_size | Size of the EBS volume in GB | "40" | "100" |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
 | disk_iops | IOPS of the EBS volume | "0" (i.e. auto) | "400" |


### PR DESCRIPTION
The default os_image is defined at [aws/flatcar-linux/kubernetes/variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/15e08a4383b613dac0c3fff5479ca75fb4b16f2d/aws/flatcar-linux/kubernetes/variables.tf#L44-L48) and it defaults to "flatcar-stable"
```
variable "os_image" {
  type        = "string"
  default     = "flatcar-stable"
  description = "AMI channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
}
```

This patch changes the documentation to match the implementation.