### PR TITLE
packet: Add support for reservation_ids on workers

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -328,3 +328,4 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | setup_raid | Flag to create a RAID 0 from extra disks on a Packet node | false | true |
+| reservation_ids | Specify Packet hardware_reservation_id for instances, see: https://support.packet.com/kb/articles/reserved-hardware. A map where the key format is 'worker-${index}' and the associated value is the reservation id string. Nodes not present in the map will use no reservation id. | {} | { worker-0 = "55555f20-a1fb-55bd-1e11-11af11d11111" } |

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -97,3 +97,9 @@ variable "setup_raid" {
   type        = "string"
   default     = "false"
 }
+
+variable "reservation_ids" {
+  description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'worker-${index}' and the associated value is the reservation id string. Nodes not present in the map will use no reservation id. Example: reservation_ids = { worker-0 = '<reservation_id>' }"
+  type        = "map"
+  default     = {}
+}

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -9,6 +9,9 @@ resource "packet_device" "nodes" {
   ipxe_script_url  = "${var.ipxe_script_url}"
   always_pxe       = "false"
   user_data        = "${data.ct_config.install-ignitions.rendered}"
+
+  # If not present in the map, it uses "" that means no reservation id
+  hardware_reservation_id = "${lookup(var.reservation_ids, format("worker-%v", count.index), "")}"
 }
 
 # These configs are used for the fist boot, to run flatcar-install


### PR DESCRIPTION
High level description of the change.

* This patch allows to use packet `hardware_reservation_id` on worker pools.

This is an example of how it can be used:

```
module "worker" {
 ...
  cluster_name = "cluster"
  pool_name = "test"
  count = 3
  reservation_ids = {
    worker-0 = "some-reservation-id"
    worker-2 = "some-other-reservation-id"
  }
 ...
}
```
This will create a worker pool with 3 nodes, the hostnames are: `cluster-test-worker-0`, `cluster-test-worker-1`, `cluster-test-worker-2`.

The `reservation_ids` map only uses the `worker` prefix and the index, so to assign a `hardware_reservation_id` to the first worker of the pool you use `worker-0 = "..."`. No matter the cluster nor pool name. This, of course, can be changed if you think it is better to do it in some other way.

Nodes that are not in the map will not use a `hardware_reservation_id`. The reason for this is twofold, but I'm very open to sugguestions as there are not strong reasons:

 * Sometimes you want to reserve some nodes, and add/remove on overflow. Having to c&p a worker pool doesn't sound appealing for that use case (although is not that bad either)

 * The code might be slightly more complicated if we want to enforce a worker pool to either use on all nodes a `hardware_reservation_id` or not use it on any node. And I don't see a good reason to enforce it, so I opted for simpler code (but, again, I might be missing the reson todo it :))

What do you think?

## Testing

Tested with and without a reservation_id, for all or some of the nodes, and changing it for living nodes. It all worked fine, although I didn't use a valid `hardware_reservation_id` (so it just failed that it didn't exist). Tomorrow will try to get one and test with a valid reservation id too.

UPDATE: tried with a reservation id, it works as expected :)
