### PR TITLE
packet: Add support for custom taints on cluster creation

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -329,3 +329,4 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | setup_raid | Flag to create a RAID 0 from extra disks on a Packet node | false | true |
 | reservation_ids | Specify Packet hardware_reservation_id for instances, see: https://support.packet.com/kb/articles/reserved-hardware. A map where the key format is 'worker-${index}' and the associated value is the reservation id string. Nodes not present in the map will use no reservation id. | {} | { worker-0 = "55555f20-a1fb-55bd-1e11-11af11d11111" } |
+| taints | Comma separated list of custom taints for all workers in the worker pool | "" | "clusterType=staging:NoSchedule,nodeType=storage:NoSchedule" |

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -92,6 +92,7 @@ systemd:
           --node-labels=${worker_labels} \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
+          --register-with-taints=${taints} \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -36,6 +36,12 @@ variable "labels" {
   description = "Custom labels to assign to worker nodes. Provide comma separated key=value pairs as labels. e.g. 'foo=oof,bar=,baz=zab'"
 }
 
+variable "taints" {
+  type        = "string"
+  default     = ""
+  description = "Comma separated list of taints. eg. 'clusterType=staging:NoSchedule,nodeType=storage:NoSchedule'"
+}
+
 variable "ipxe_script_url" {
   type = "string"
 

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -52,5 +52,6 @@ data "template_file" "configs" {
     k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
     worker_labels         = "${var.labels}"
+    taints                = "${var.taints}"
   }
 }


### PR DESCRIPTION
## High level description of the change.

This PR adds a new optional variable `taints` to the worker pools in the packet module. The values are used to register taints at the time of cluster creation.

## Testing

1. Deploy a cluster with this branch as the source.
2. Set a value for `taint` in at least one worker pool.
3. Run `kubectl get nodes -o json | jq '.items[].spec'` (requires [jq](https://stedolan.github.io/jq/) preinstalled)
