### PR TITLE
Introduce kvm-libvirt platform

### DIFF
--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -1,0 +1,369 @@
+# KVM libvirt
+
+In this tutorial, we'll create a Kubernetes cluster with Flatcar Linux inside VMs on our local machine.
+
+We'll declare the cluster using the Lokomotive Terraform module for the KVM libvirt platform.
+
+Controllers are provisioned to run an `etcd-member` peer and a `kubelet` service.
+Workers run just a `kubelet` service. A one-time [bootkube](https://github.com/kubernetes-incubator/bootkube)
+bootstrap schedules the `apiserver`, `scheduler`, `controller-manager`, and `coredns` on controllers
+and schedules `kube-proxy` and `calico` (or `flannel`) on every node.
+A generated `kubeconfig` provides `kubectl` access to the cluster.
+
+## Requirements
+
+* `qemu-img`, `wget`, and `bunzip2` binaries installed
+* At least 4 GB of free RAM
+* Running libvirtd system service, see [libvirtd Setup](#libvirtd-setup)
+* A user in the `libvirt` group (to create virtual machines with libvirt and access `/dev/kvm`), see [User Setup]
+* Terraform v0.11.x, [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct),
+  and [terraform-provider-libvirt](https://github.com/dmacvicar/terraform-provider-libvirt)
+  installed locally
+
+## Prepare VM Image
+
+Download the Flatcar image. The example below uses the "Edge" Flatcar channel.
+You need to increase its size depending on your use case because the initial size
+is only enough for some small pods to be loaded. Starting pods with normal-sized
+container images may already fail because the disk space will be filled.
+That's why the example below directly increases the image size by 5 GB to make
+sure that a couple of container images fit on the node.
+
+```sh
+$ sudo dnf install wget bzip2 qemu-img  # or sudo apt install wget bzip2 qemu-utils
+$ wget https://edge.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
+$ bunzip2 flatcar_production_qemu_image.img.bz2
+$ qemu-img resize flatcar_production_qemu_image.img +5G
+```
+
+## libvirtd Setup
+
+Ensure that libvirtd is set up.
+The examples in this guide use Fedora's `dnf`
+but for example in Ubuntu you would use `apt` as stated in the comment in the same line.
+
+```sh
+$ sudo dnf install libvirt-daemon  # or sudo apt install libvirt-daemon
+$ sudo systemctl start libvirtd
+```
+
+### Apparmor and libvirt issues
+
+If you use Ubuntu or Debian with apparmor, you need to disable apparmor because it disallows
+to use temporary paths for the storage pool. Open `/etc/libvirt/qemu.conf` and add the
+following line below any existing commented `#security_driver = "selinux"` line.
+
+```
+security_driver = "none"
+```
+
+Now restart the libvirtd through `sudo systemctl restart libvirtd`.
+
+## User Setup
+
+Ensure that libvirt is accessible for the current user:
+
+```sh
+$ sudo usermod -a -G libvirt $(whoami)
+$ newgrp libvirt
+```
+
+## Terraform Setup
+
+Install [Terraform](https://www.terraform.io/downloads.html) v0.11.x on your system.
+
+```sh
+$ terraform version
+Terraform v0.11.13
+```
+
+Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system
+to `~/.terraform.d/plugins/`, noting the `_v0.3.1` suffix.
+
+```sh
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+```
+
+Add the [terraform-provider-libvirt](https://github.com/dmacvicar/terraform-provider-libvirt) plugin binary for your system
+to `~/.terraform.d/plugins/`, noting the `_v0.5.2` suffix.
+You should use the 0.5.2 release because it includes the experimental
+[pool definition feature](https://github.com/dmacvicar/terraform-provider-libvirt/commit/9f00f3d46c489f24c71d02fde816f5fda34d3f7c)
+but building from source is also an option.
+
+Use the tar file for your distribution when you download it from the [release page](https://github.com/dmacvicar/terraform-provider-libvirt/releases).
+When building from source, you would do a final `mv $GOPATH/bin/terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.2`.
+
+```sh
+wget https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.5.2/terraform-provider-libvirt-0.5.2.Fedora_28.x86_64.tar.gz
+# or, e.g., https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.5.2/terraform-provider-libvirt-0.5.2.Ubuntu_18.04.amd64.tar.gz
+tar xzf terraform-provider-libvirt-0.5.2.Fedora_28.x86_64.tar.gz
+mv terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.2
+```
+
+
+Read [concepts](/docs/architecture/concepts.md) to learn about Terraform, modules, and organizing resources if the following confuses you.
+
+A Terraform project should be created in a new clean directory.
+Assuming there is a parent directory `infra` for all the terraform projects, we create a new subdirectory `vmcluster`.
+
+```sh
+mkdir vmcluster
+cd vmcluster
+```
+
+## Provider
+
+Create a file named `provider.tf` with the following contents:
+
+```tf
+provider "ct" {
+  version = "0.3.1"
+}
+
+provider "local" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "null" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "template" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "tls" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "libvirt" {
+  version = "~> 0.5.2"
+  uri = "qemu:///system"
+  alias = "default"
+}
+```
+
+## Cluster
+
+Follow the below steps to define a Kubernetes cluster using the module
+[kvm-libvirt/flatcar-linux/kubernetes](https://github.com/kinvolk/lokomotive-kubernetes/tree/master/kvm-libvirt/flatcar-linux/kubernetes).
+
+Create a file called `mycluster.tf` with these contents but remember to change the `path/to` and `AAAA...` values:
+
+```tf
+module "controller" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//kvm-libvirt/flatcar-linux/kubernetes"
+
+  providers = {
+    local    = "local.default"
+    null     = "null.default"
+    template = "template.default"
+    tls      = "tls.default"
+    libvirt  = "libvirt.default"
+  }
+
+  # Path to where the image was prepared, note the tripple slash for the absolute path
+  os_image_unpacked = "file:///path/to/flatcar_production_qemu_image.img"
+
+  # Your SSH public key
+  ssh_keys = [
+    "ssh-rsa AAAA...",
+  ]
+
+  # Where you want the terraform assets to be saved for KUBECONFIG
+  asset_dir = "/path/to/clusters/asset"
+
+  machine_domain = "vmcluster.k8s"
+  cluster_name = "vmcluster"
+  node_ip_pool = "192.168.192.0/24"
+
+  controller_count = 1
+
+}
+
+module "worker-pool-one" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//kvm-libvirt/flatcar-linux/kubernetes/workers"
+
+  providers = {
+    local    = "local.default"
+    template = "template.default"
+    tls      = "tls.default"
+    libvirt  = "libvirt.default"
+  }
+
+  ssh_keys = "${module.controller.ssh_keys}"
+
+  machine_domain = "${module.controller.machine_domain}"
+  cluster_name = "${module.controller.cluster_name}"
+  libvirtpool = "${module.controller.libvirtpool}"
+  libvirtbaseid = "${module.controller.libvirtbaseid}"
+
+  pool_name = "one"
+
+  count = 1
+
+  kubeconfig = "${module.controller.kubeconfig}"
+
+  labels = "node.supernova.io/role=backend,node-role.kubernetes.io/backend="
+}
+```
+
+Now check the contents of `mycluster.tf`.
+Change at least the `ssh_keys` entry to match the content of your `~/.ssh/id_rsa.pub` and
+change the `os_image_unpacked` path to point to the image location from the VM image preparation.
+
+Reference the [variables docs](#variables) or the
+[variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/master/kvm-libvirt/flatcar-linux/kubernetes/variables.tf)
+source.
+
+## ssh-agent
+
+Initial bootstrapping requires `bootkube.service` to be started on one controller node.
+Terraform uses `ssh-agent` to automate this step.
+Add your SSH private key to `ssh-agent` so that it is unlocked if it was secured with a passphrase
+(you can skip this if the key was created with the GNOME Passwords and Keys tool).
+
+```sh
+exec /usr/bin/ssh-agent $SHELL
+ssh-add ~/.ssh/id_rsa
+ssh-add -L
+```
+
+## Apply
+
+Initialize the config directory since this is the first use with Terraform.
+
+```sh
+terraform init
+```
+
+Plan the resources to be created.
+
+```sh
+$ terraform plan
+Plan: 68 to add, 0 to change, 0 to destroy.
+```
+
+Apply the changes to create the cluster (type `yes` when prompted).
+
+```sh
+$ terraform apply
+...
+module.controller.null_resource.bootkube-start: Still creating... (2m50s elapsed)
+module.controller.null_resource.bootkube-start: Still creating... (3m0s elapsed)
+module.controller.null_resource.bootkube-start: Creation complete after 3m20s
+
+Apply complete! Resources: 68 added, 0 changed, 0 destroyed.
+```
+
+In 3-6 minutes, the Kubernetes cluster will be ready, depending on your downlink speed and system performance.
+
+## Verify that it works
+
+[Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your system.
+Use the generated `kubeconfig` credentials to access the Kubernetes cluster and list nodes.
+
+```
+$ export KUBECONFIG=/path/to/clusters/asset/auth/kubeconfig  # matching the asset_dir from the config file
+$ kubectl get nodes
+NAME                                   STATUS   ROLES               AGE     VERSION
+vmcluster-controller-0.vmcluster.k8s   Ready    controller,master   5h28m   v1.14.1
+vmcluster-one-worker-0.vmcluster.k8s   Ready    node                5h28m   v1.14.1
+```
+
+List the pods.
+
+```
+$ kubectl get pods --all-namespaces
+kube-system   calico-node-x5cgr                          1/1     Running   0          5h28m
+kube-system   calico-node-zp2bl                          1/1     Running   0          5h28m
+kube-system   coredns-5644c585c9-58w2r                   1/1     Running   2          5h28m
+kube-system   coredns-5644c585c9-vtknk                   1/1     Running   1          5h28m
+kube-system   kube-apiserver-8fxjs                       1/1     Running   3          5h28m
+kube-system   kube-controller-manager-865f9f995d-cj8hp   1/1     Running   1          5h28m
+kube-system   kube-controller-manager-865f9f995d-jtmqf   1/1     Running   1          5h28m
+kube-system   kube-proxy-jxsz4                           1/1     Running   0          5h28m
+kube-system   kube-proxy-r24jn                           1/1     Running   0          5h28m
+kube-system   kube-scheduler-57c444dcc8-54zpq            1/1     Running   1          5h28m
+kube-system   kube-scheduler-57c444dcc8-6gv94            1/1     Running   0          5h28m
+kube-system   pod-checkpointer-8qdrt                     1/1     Running   0          5h28m
+```
+
+## Variables
+
+Check the
+[variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/master/kvm-libvirt/flatcar-linux/kubernetes/variables.tf)
+source.
+
+### Controller
+
+#### Required
+
+| Name | Description | Example |
+|:-----|:------------|:--------|
+| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "/home/user/infra/assets" |
+| cluster_name | Unique cluster name | "vmcluster" |
+| machine_domain | DNS zone | "vmcluster.k8s" |
+| os_image_unpacked | Path to unpacked Flatcar image (probably after a qemu-img resize IMG +5G) | "file:///home/user/infra/flatcar_production_qemu_image.img" |
+| ssh_keys | List of SSH public keys for user 'core' | ["ssh-rsa AAAAB3NZ..."] |
+
+#### Optional
+| Name | Description | Default |
+|:-----|:------------|:--------|
+| cluster_domain_suffix | Queries for domains with the suffix will be answered by coredns | "cluster.local" |
+| controller_count | Number of controller VMs | "1" |
+| enable_aggregation | Enable the Kubernetes Aggregation Layer | "false" |
+| enable_reporting | Enable usage or analytics reporting to upstreams (Calico) | "false" |
+| network_mtu | CNI interface MTU (applies to calico only) | "1480" |
+| network_ip_autodetection_method | Method to autodetect the host IPv4 address (applies to calico only) | "first-found" or "can-reach=192.168.192.1" |
+| networking | Choice of networking provider | "calico" | "calico" or "flannel" |
+| node_ip_pool | Unique VM IP CIDR (different per cluster) | "192.168.192.0/24" |
+| pod_cidr | CIDR IPv4 range to assign Kubernetes pods | "10.1.0.0/16" |
+| service_cidr | CIDR IPv4 range to assign Kubernetes services. The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns. | "10.2.0.0/16" |
+| virtual_cpus | Number of virtual CPUs | "1" |
+| virtual_memory | Virtual RAM in MB | "2048" |
+
+### Worker
+
+#### Required
+
+| Name | Description | Example |
+|:-----|:------------|:--------|
+| cluster_name | Cluster to join | "${module.controller.cluster_name}" |
+| kubeconfig | Kubeconfig file generated for the controller | "${module.controller.kubeconfig}" |
+| libvirtbaseid | The cluster's OS volume to use for copy-on-write | "${module.controller.libvirtbaseid}" |
+| libvirtpool | The cluster's disk volume pool to use | "${module.controller.libvirtpool}" |
+| machine_domain | DNS zone | "${module.controller.machine_domain}" |
+| os_image_unpacked | Path to unpacked Flatcar image (probably after a qemu-img resize IMG +5G) | "file:///home/user/infra/flatcar_production_qemu_image.img" |
+| pool_name | Worker pool name | "one" |
+| ssh_keys | List of SSH public keys for user 'core' | "${module.controller.ssh_keys}" |
+
+#### Optional
+| Name | Description | Default |
+|:-----|:------------|:--------|
+| count | Number of worker VMs | "1" |
+| cluster_domain_suffix | The cluster's suffix answered by coredns | "cluster.local" |
+| labels | Custom label to assign to worker nodes. Provide comma separated key=value pairs as labels. e.g. 'foo=oof,bar=,baz=zab'" | "" |
+| service_cidr | CIDR IPv4 range to assign Kubernetes services. The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns. | "10.2.0.0/16" |
+| virtual_cpus | Number of virtual CPUs | "1" |
+| virtual_memory | Virtual RAM in MB | "2048" |
+
+#### Closing Notes
+
+The generated kubeconfig contains the node's public IP. If you want to use the names,
+you have to resolve them over the libvirt DNS server `192.168.192.1`.
+
+If you need a reproducible setup, please add ?ref=HASH to the end of
+each `git::` path in the `source = "git::…"` imports.
+
+You can consider to change the Terraform modules provided by Lokomotive
+if they don't meet your demands
+(change the `source = "git:…"` import to your fork or a relative path with `source = "./libvirt-kubernetes"`).
+Additional configuration options you may specify there for libvirt are described in the `libvirt` provider
+[docs](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/website/docs/index.html.markdown).

--- a/kvm-libvirt/flatcar-linux/kubernetes/README.md
+++ b/kvm-libvirt/flatcar-linux/kubernetes/README.md
@@ -1,0 +1,1 @@
+Read how to set up a cluster with libvirt on KVM in the [docs](/docs/flatcar-linux/kvm-libvirt.md).

--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -1,0 +1,33 @@
+module "bootkube" {
+  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=0d3951ff08eeaa617e5aa83da5db19ef2e12324f"  # currently in PR #12
+
+  cluster_name = "${var.cluster_name}"
+
+  # Cannot use cyclic dependencies on controllers or their DNS records
+  api_servers          = ["${data.template_file.controllernames.0.rendered}"]
+  api_servers_external = "${libvirt_domain.controller-machine.*.network_interface.0.addresses.0}"
+  api_servers_ips      = "${libvirt_domain.controller-machine.*.network_interface.0.addresses.0}"
+  etcd_servers         = ["${data.template_file.controllernames.*.rendered}"]
+  asset_dir            = "${var.asset_dir}"
+  networking           = "${var.networking}"
+  network_mtu          = "${var.network_mtu}"
+
+  network_ip_autodetection_method = "${var.network_ip_autodetection_method}"
+
+  pod_cidr              = "${var.pod_cidr}"
+  service_cidr          = "${var.service_cidr}"
+  cluster_domain_suffix = "${var.cluster_domain_suffix}"
+  enable_reporting      = "${var.enable_reporting}"
+  enable_aggregation    = "${var.enable_aggregation}"
+}
+
+data "template_file" "controllernames" {
+  count    = "${var.controller_count}"
+  template = "$${cluster_name}-controller-$${index}.$${machine_domain}"
+
+  vars {
+    index          = "${count.index}"
+    cluster_name   = "${var.cluster_name}"
+    machine_domain = "${var.machine_domain}"
+  }
+}

--- a/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -1,0 +1,182 @@
+---
+systemd:
+  units:
+    - name: etcd-member.service
+      enable: true
+      dropins:
+        - name: 40-etcd-cluster.conf
+          contents: |
+            [Service]
+            Environment="ETCD_IMAGE_TAG=v3.3.13"
+            Environment="ETCD_NAME=${etcd_name}"
+            Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
+            Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"
+            Environment="ETCD_LISTEN_CLIENT_URLS=https://0.0.0.0:2379"
+            Environment="ETCD_LISTEN_PEER_URLS=https://0.0.0.0:2380"
+            Environment="ETCD_LISTEN_METRICS_URLS=http://0.0.0.0:2381"
+            Environment="ETCD_INITIAL_CLUSTER=${etcd_initial_cluster}"
+            Environment="ETCD_STRICT_RECONFIG_CHECK=true"
+            Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
+            Environment="ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/server-ca.crt"
+            Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd/server.crt"
+            Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd/server.key"
+            Environment="ETCD_CLIENT_CERT_AUTH=true"
+            Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/peer-ca.crt"
+            Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt"
+            Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
+            Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
+    - name: docker.service
+      enable: true
+    - name: locksmithd.service
+      mask: true
+    - name: wait-for-dns.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Wait for DNS entries
+        Wants=systemd-resolved.service
+        Before=kubelet.service
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'
+        [Install]
+        RequiredBy=kubelet.service
+        RequiredBy=etcd-member.service
+    - name: kubelet.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Kubelet via Hyperkube
+        Wants=rpc-statd.service
+        [Service]
+        EnvironmentFile=/etc/kubernetes/kubelet.env
+        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
+          --volume=resolv,kind=host,source=/etc/resolv.conf \
+          --mount volume=resolv,target=/etc/resolv.conf \
+          --volume var-lib-cni,kind=host,source=/var/lib/cni \
+          --mount volume=var-lib-cni,target=/var/lib/cni \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --mount volume=var-lib-calico,target=/var/lib/calico \
+          --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
+          --mount volume=opt-cni-bin,target=/opt/cni/bin \
+          --volume var-log,kind=host,source=/var/log \
+          --mount volume=var-log,target=/var/log \
+          --insecure-options=image"
+        ExecStartPre=/bin/mkdir -p /opt/cni/bin
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
+        ExecStartPre=/bin/mkdir -p /var/lib/cni
+        ExecStartPre=/bin/mkdir -p /var/lib/calico
+        ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins
+        ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
+        ExecStartPre=/etc/kubernetes/configure-kubelet-cgroup-driver
+        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
+        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+          --anonymous-auth=false \
+          --authentication-token-webhook \
+          --authorization-mode=Webhook \
+          --client-ca-file=/etc/kubernetes/ca.crt \
+          --cluster_dns=${cluster_dns_service_ip} \
+          --cluster_domain=${cluster_domain_suffix} \
+          --cni-conf-dir=/etc/kubernetes/cni/net.d \
+          --config=/etc/kubernetes/kubelet.config \
+          --exit-on-lock-contention \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
+          --lock-file=/var/run/lock/kubelet.lock \
+          --hostname-override=${etcd_domain} \
+          --network-plugin=cni \
+          --node-labels=node-role.kubernetes.io/master \
+          --node-labels=node-role.kubernetes.io/controller="true" \
+          --pod-manifest-path=/etc/kubernetes/manifests \
+          --read-only-port=0 \
+          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
+        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+    - name: bootkube.service
+      contents: |
+        [Unit]
+        Description=Bootstrap a Kubernetes cluster
+        ConditionPathExists=!/opt/bootkube/init_bootkube.done
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        WorkingDirectory=/opt/bootkube
+        ExecStart=/opt/bootkube/bootkube-start
+        ExecStartPost=/bin/touch /opt/bootkube/init_bootkube.done
+        [Install]
+        WantedBy=multi-user.target
+storage:
+  files:
+    - path: /etc/kubernetes/kubeconfig
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          ${kubeconfig}
+    - path: /etc/kubernetes/kubelet.env
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
+          KUBELET_IMAGE_TAG=v1.14.1
+    - path: /etc/sysctl.d/max-user-watches.conf
+      filesystem: root
+      contents:
+        inline: |
+          fs.inotify.max_user_watches=16184
+    - path: /etc/hostname
+      filesystem: root
+      mode: 0644
+      contents:
+        inline:
+          ${etcd_domain}
+    - path: /opt/bootkube/bootkube-start
+      filesystem: root
+      mode: 0544
+      user:
+        id: 500
+      group:
+        id: 500
+      contents:
+        inline: |
+          #!/bin/bash
+          # Wrapper for bootkube start
+          set -e
+          # Move experimental manifests
+          [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
+          exec /usr/bin/rkt run \
+            --trust-keys-from-https \
+            --volume assets,kind=host,source=/opt/bootkube/assets \
+            --mount volume=assets,target=/assets \
+            --volume bootstrap,kind=host,source=/etc/kubernetes \
+            --mount volume=bootstrap,target=/etc/kubernetes \
+            $${RKT_OPTS} \
+            quay.io/coreos/bootkube:v0.14.0 \
+            --net=host \
+            --dns=host \
+            --exec=/bootkube -- start --asset-dir=/assets "$@"
+    - path: /etc/kubernetes/configure-kubelet-cgroup-driver
+      filesystem: root
+      mode: 0744
+      contents:
+        inline: |
+          #!/bin/bash
+          set -e
+          readonly docker_cgroup_driver="$(docker info | awk '/^Cgroup Driver/ { print $3 }')"
+          cat <<EOF >/etc/kubernetes/kubelet.config
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          kind: KubeletConfiguration
+          cgroupDriver: "$${docker_cgroup_driver}"
+          EOF
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys: ${ssh_keys}

--- a/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
@@ -1,0 +1,101 @@
+resource "random_string" "volumepath" {
+  length = 6
+  special = false
+}
+
+resource "libvirt_pool" "volumetmp" {
+  name = "vms${random_string.volumepath.result}"
+  type = "dir"
+  path = "/var/tmp/vms${random_string.volumepath.result}"
+}
+
+resource "libvirt_volume" "base" {
+  name   = "${var.cluster_name}-base"
+  source = "${var.os_image_unpacked}"
+  pool   = "${libvirt_pool.volumetmp.name}"
+  format = "qcow2"
+}
+
+resource "libvirt_volume" "controller-disk" {
+  name             = "${var.cluster_name}-controller-${count.index}.qcow2"
+  count            = "${var.controller_count}"
+  base_volume_id   = "${libvirt_volume.base.id}"
+  pool             = "${libvirt_pool.volumetmp.name}"
+  format           = "qcow2"
+}
+
+
+resource "libvirt_ignition" "ignition" {
+  name    = "${var.cluster_name}-controller-${count.index}-ignition"
+  pool    = "${libvirt_pool.volumetmp.name}"
+  count   = "${var.controller_count}"
+  content = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+}
+
+resource "libvirt_network" "vmnet" {
+   name = "${var.cluster_name}"
+   mode = "nat"
+   domain = "${var.machine_domain}"
+   addresses = ["${var.node_ip_pool}"]
+   dns = {
+      local_only = true
+      # can specify local names here
+   }
+}
+
+resource "libvirt_domain" "controller-machine" {
+  count  = "${var.controller_count}"
+  name   = "${var.cluster_name}-controller-${count.index}"
+  vcpu   = "${var.virtual_cpus}"
+  memory = "${var.virtual_memory}"
+
+  coreos_ignition = "${element(libvirt_ignition.ignition.*.id, count.index)}"
+
+  disk {
+    volume_id = "${element(libvirt_volume.controller-disk.*.id, count.index)}"
+  }
+
+  graphics {
+    listen_type = "address"
+  }
+
+  network_interface {
+    network_id = "${libvirt_network.vmnet.id}"
+    hostname = "${var.cluster_name}-controller-${count.index}"
+    addresses = ["${cidrhost(var.node_ip_pool, 10 + count.index)}"]  # TODO: use as public addr in kubeconfig
+    wait_for_lease = true
+  }
+
+}
+
+data "ct_config" "controller-ignitions" {
+  count    = "${var.controller_count}"
+  content  = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+}
+
+data "template_file" "controller-configs" {
+  count    = "${var.controller_count}"
+  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+
+  vars {
+    # Cannot use cyclic dependencies on controllers or their DNS records
+    etcd_name   = "${var.cluster_name}-controller-${count.index}"
+    etcd_domain = "${var.cluster_name}-controller-${count.index}.${var.machine_domain}"
+    etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
+
+    kubeconfig             = "${indent(10, module.bootkube.kubeconfig-kubelet)}"
+    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
+    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
+    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+  }
+}
+
+data "template_file" "etcds" {
+  count    = "${var.controller_count}"
+  template = "$${cluster_name}-controller-$${index}=https://$${cluster_name}-controller-$${index}.${var.machine_domain}:2380"  # as etcd_domain above
+
+  vars {
+    index        = "${count.index}"
+    cluster_name = "${var.cluster_name}"
+  }
+}

--- a/kvm-libvirt/flatcar-linux/kubernetes/outputs.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/outputs.tf
@@ -1,0 +1,27 @@
+output "kubeconfig-admin" {
+  value = "${module.bootkube.kubeconfig-admin}"
+}
+
+output "kubeconfig" {
+  value = "${module.bootkube.kubeconfig-kubelet}"
+}
+
+output "machine_domain" {
+  value = "${var.machine_domain}"
+}
+
+output "cluster_name" {
+  value = "${var.cluster_name}"
+}
+
+output "ssh_keys" {
+  value = "${var.ssh_keys}"
+}
+
+output "libvirtpool" {
+  value = "${libvirt_pool.volumetmp.name}"
+}
+
+output "libvirtbaseid" {
+  value = "${libvirt_volume.base.id}"
+}

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -1,0 +1,31 @@
+# Terraform version and plugin versions
+
+terraform {
+  required_version = ">= 0.11.0"
+}
+
+provider "ct" {
+  version = "~> 0.3"
+}
+
+provider "local" {
+  version = "~> 1.0"
+}
+
+provider "null" {
+  version = "~> 1.0"
+}
+
+provider "template" {
+  version = "~> 1.0"
+}
+
+provider "tls" {
+  version = "~> 1.0"
+}
+
+provider "libvirt" {
+  version = "~> 0.5.2"
+  uri = "qemu:///system"
+}
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/ssh.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/ssh.tf
@@ -1,0 +1,91 @@
+# Secure copy etcd TLS assets to controllers.
+resource "null_resource" "copy-controller-secrets" {
+  count = "${var.controller_count}"
+
+  connection {
+    type    = "ssh"
+    host    =  "${element(libvirt_domain.controller-machine.*.network_interface.0.addresses.0, count.index)}"
+    user    = "core"
+    timeout = "15m"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_ca_cert}"
+    destination = "$HOME/etcd-client-ca.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_client_cert}"
+    destination = "$HOME/etcd-client.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_client_key}"
+    destination = "$HOME/etcd-client.key"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_server_cert}"
+    destination = "$HOME/etcd-server.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_server_key}"
+    destination = "$HOME/etcd-server.key"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_peer_cert}"
+    destination = "$HOME/etcd-peer.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_peer_key}"
+    destination = "$HOME/etcd-peer.key"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /etc/ssl/etcd/etcd",
+      "sudo mv etcd-client* /etc/ssl/etcd/",
+      "sudo cp /etc/ssl/etcd/etcd-client-ca.crt /etc/ssl/etcd/etcd/server-ca.crt",
+      "sudo mv etcd-server.crt /etc/ssl/etcd/etcd/server.crt",
+      "sudo mv etcd-server.key /etc/ssl/etcd/etcd/server.key",
+      "sudo cp /etc/ssl/etcd/etcd-client-ca.crt /etc/ssl/etcd/etcd/peer-ca.crt",
+      "sudo mv etcd-peer.crt /etc/ssl/etcd/etcd/peer.crt",
+      "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
+      "sudo chown -R etcd:etcd /etc/ssl/etcd",
+      "sudo chmod -R 500 /etc/ssl/etcd",
+    ]
+  }
+}
+
+# Secure copy bootkube assets to ONE controller and start bootkube to perform
+# one-time self-hosted cluster bootstrapping.
+resource "null_resource" "bootkube-start" {
+  depends_on = [
+    "module.bootkube",
+    # "module.workers",
+    "null_resource.copy-controller-secrets",
+  ]
+
+  connection {
+    type    = "ssh"
+    host    = "${libvirt_domain.controller-machine.0.network_interface.0.addresses}"
+    user    = "core"
+    timeout = "15m"
+  }
+
+  provisioner "file" {
+    source      = "${var.asset_dir}"
+    destination = "$HOME/assets"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv $HOME/assets /opt/bootkube",
+      "sudo systemctl start bootkube",
+    ]
+  }
+}
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
@@ -1,0 +1,106 @@
+# DNS records
+
+variable "cluster_name" {
+  type        = "string"
+  description = "Unique cluster name"
+}
+
+# Nodes
+
+variable "os_image_unpacked" {
+  type        = "string"
+  description = "Path to unpacked Flatcar image flatcar_production_qemu_image.img (probably after a qemu-img resize IMG +5G)"
+}
+
+variable "controller_count" {
+  type        = "string"
+  default     = "1"
+  description = "Number of controllers (i.e. masters)"
+}
+
+variable "machine_domain" {
+  type        = "string"
+  description = "Machine domain"
+}
+
+variable "node_ip_pool" {
+  type        = "string"
+  default     = "192.168.192.0/24"
+  description = "Unique VM IP CIDR"
+}
+
+variable "virtual_cpus" {
+  type        = "string"
+  default     = "1"
+  description = "Number of virtual CPUs"
+}
+
+variable "virtual_memory" {
+  type        = "string"
+  default     = "2048"
+  description = "Virtual RAM in MB"
+}
+
+# Configuration
+
+variable "ssh_keys" {
+  type        = "list"
+  description = "SSH public keys for user 'core'"
+}
+
+variable "asset_dir" {
+  description = "Path to a directory where generated assets should be placed (contains secrets)"
+  type        = "string"
+}
+
+variable "networking" {
+  description = "Choice of networking provider (flannel or calico)"
+  type        = "string"
+  default     = "calico"
+}
+
+variable "network_mtu" {
+  description = "CNI interface MTU (applies to calico only)"
+  type        = "string"
+  default     = "1480"
+}
+
+variable "network_ip_autodetection_method" {
+  description = "Method to autodetect the host IPv4 address (applies to calico only)"
+  type        = "string"
+  default     = "first-found"
+}
+
+variable "pod_cidr" {
+  description = "CIDR IPv4 range to assign Kubernetes pods"
+  type        = "string"
+  default     = "10.1.0.0/16"
+}
+
+variable "service_cidr" {
+  description = <<EOD
+CIDR IPv4 range to assign Kubernetes services.
+The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
+EOD
+
+  type    = "string"
+  default = "10.2.0.0/16"
+}
+
+variable "cluster_domain_suffix" {
+  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
+  type        = "string"
+  default     = "cluster.local"
+}
+
+variable "enable_reporting" {
+  type        = "string"
+  description = "Enable usage or analytics reporting to upstreams (Calico)"
+  default     = "false"
+}
+
+variable "enable_aggregation" {
+  description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
+  type        = "string"
+  default     = "false"
+}

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -1,0 +1,148 @@
+---
+systemd:
+  units:
+    - name: docker.service
+      enable: true
+    - name: iscsid.service
+      enable: true
+      enabled: true
+    - name: locksmithd.service
+      mask: true
+    - name: wait-for-dns.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Wait for DNS entries
+        Wants=systemd-resolved.service
+        Before=kubelet.service
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'
+        [Install]
+        RequiredBy=kubelet.service
+    - name: kubelet.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Kubelet via Hyperkube
+        Wants=rpc-statd.service
+        [Service]
+        EnvironmentFile=/etc/kubernetes/kubelet.env
+        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
+          --volume=resolv,kind=host,source=/etc/resolv.conf \
+          --mount volume=resolv,target=/etc/resolv.conf \
+          --volume var-lib-cni,kind=host,source=/var/lib/cni \
+          --mount volume=var-lib-cni,target=/var/lib/cni \
+          --volume var-lib-calico,kind=host,source=/var/lib/calico \
+          --mount volume=var-lib-calico,target=/var/lib/calico \
+          --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
+          --mount volume=opt-cni-bin,target=/opt/cni/bin \
+          --volume var-log,kind=host,source=/var/log \
+          --mount volume=var-log,target=/var/log \
+          --volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
+          --mount volume=iscsiadm,target=/usr/sbin/iscsiadm \
+          --insecure-options=image"
+        ExecStartPre=/bin/mkdir -p /opt/cni/bin
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
+        ExecStartPre=/bin/mkdir -p /var/lib/cni
+        ExecStartPre=/bin/mkdir -p /var/lib/calico
+        ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins
+        ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
+        ExecStartPre=/etc/kubernetes/configure-kubelet-cgroup-driver
+        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
+        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+          --anonymous-auth=false \
+          --authentication-token-webhook \
+          --authorization-mode=Webhook \
+          --client-ca-file=/etc/kubernetes/ca.crt \
+          --cluster_dns=${cluster_dns_service_ip} \
+          --cluster_domain=${cluster_domain_suffix} \
+          --hostname-override=${domain_name} \
+          --cni-conf-dir=/etc/kubernetes/cni/net.d \
+          --config=/etc/kubernetes/kubelet.config \
+          --exit-on-lock-contention \
+          --kubeconfig=/etc/kubernetes/kubeconfig \
+          --lock-file=/var/run/lock/kubelet.lock \
+          --network-plugin=cni \
+          --node-labels=node-role.kubernetes.io/node \
+          --pod-manifest-path=/etc/kubernetes/manifests \
+          --read-only-port=0 \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
+        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
+        Restart=always
+        RestartSec=5
+        [Install]
+        WantedBy=multi-user.target
+    - name: delete-node.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Waiting to delete Kubernetes node on shutdown
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/bin/true
+        ExecStop=/etc/kubernetes/delete-node
+        [Install]
+        WantedBy=multi-user.target
+storage:
+  files:
+    - path: /etc/kubernetes/kubeconfig
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          ${kubeconfig}
+    - path: /etc/kubernetes/kubelet.env
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
+          KUBELET_IMAGE_TAG=v1.14.1
+    - path: /etc/sysctl.d/max-user-watches.conf
+      filesystem: root
+      contents:
+        inline: |
+          fs.inotify.max_user_watches=16184
+    - path: /etc/hostname
+      filesystem: root
+      mode: 0644
+      contents:
+        inline:
+          ${domain_name}
+    - path: /etc/kubernetes/configure-kubelet-cgroup-driver
+      filesystem: root
+      mode: 0744
+      contents:
+        inline: |
+          #!/bin/bash
+          set -e
+          readonly docker_cgroup_driver="$(docker info | awk '/^Cgroup Driver/ { print $3 }')"
+          cat <<EOF >/etc/kubernetes/kubelet.config
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          kind: KubeletConfiguration
+          cgroupDriver: "$${docker_cgroup_driver}"
+          EOF
+    - path: /etc/kubernetes/delete-node
+      filesystem: root
+      mode: 0744
+      contents:
+        inline: |
+          #!/bin/bash
+          set -e
+          exec /usr/bin/rkt run \
+            --trust-keys-from-https \
+            --volume config,kind=host,source=/etc/kubernetes \
+            --mount volume=config,target=/etc/kubernetes \
+            --insecure-options=image \
+            docker://k8s.gcr.io/hyperkube:v1.14.1 \
+            --net=host \
+            --dns=host \
+            --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys: ${ssh_keys}

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
@@ -1,0 +1,27 @@
+# Terraform version and plugin versions
+
+terraform {
+  required_version = ">= 0.11.0"
+}
+
+provider "ct" {
+  version = "~> 0.3"
+}
+
+provider "local" {
+  version = "~> 1.0"
+}
+
+provider "template" {
+  version = "~> 1.0"
+}
+
+provider "tls" {
+  version = "~> 1.0"
+}
+
+provider "libvirt" {
+  version = "~> 0.5.2"
+  uri = "qemu:///system"
+}
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
@@ -1,0 +1,79 @@
+# Cluster
+
+variable "cluster_name" {
+  type        = "string"
+  description = "Unique cluster name (prepended to dns_zone)"
+}
+
+
+variable "machine_domain" {
+  type = "string"
+  description = "Machine domain"
+}
+
+variable "pool_name" {
+  type        = "string"
+  description = "Unique worker pool name (prepended to hostname)"
+}
+
+variable "count" {
+  type        = "string"
+  default     = "1"
+  description = "Number of workers"
+}
+
+variable "virtual_cpus" {
+  type        = "string"
+  default     = "1"
+  description = "Number of virtual CPUs"
+}
+
+variable "virtual_memory" {
+  type        = "string"
+  default     = "2048"
+  description = "Virtual RAM in MB"
+}
+
+# TODO: migrate to `templatefile` when Terraform `0.12` is out and use `{% for ~}`
+# to avoid specifying `--node-labels` again when the var is empty.
+variable "labels" {
+  type        = "string"
+  default     = ""
+  description = "Custom labels to assign to worker nodes. Provide comma separated key=value pairs as labels. e.g. 'foo=oof,bar=,baz=zab'"
+}
+
+variable "libvirtpool" {
+  type        = "string"
+  description = "libvirt volume pool with base image"
+}
+
+variable "libvirtbaseid" {
+  type        = "string"
+  description = "base image id for libvirt"
+}
+
+variable "cluster_domain_suffix" {
+  description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
+  type        = "string"
+  default     = "cluster.local"
+}
+
+variable "kubeconfig" {
+  description = "Kubeconfig file"
+  type        = "string"
+}
+
+variable "ssh_keys" {
+  type        = "list"
+  description = "SSH public keys for user 'core'"
+}
+
+variable "service_cidr" {
+  description = <<EOD
+CIDR IPv4 range to assign Kubernetes services.
+The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
+EOD
+
+  type    = "string"
+  default = "10.2.0.0/16"
+}

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,0 +1,56 @@
+resource "libvirt_volume" "worker-disk" {
+  name             = "${var.cluster_name}-${var.pool_name}-worker-${count.index}.qcow2"
+  count            = "${var.count}"
+  base_volume_id   = "${var.libvirtbaseid}"
+  pool             = "${var.libvirtpool}"
+  format           = "qcow2"
+}
+
+resource "libvirt_ignition" "ignition" {
+  name    = "${var.cluster_name}-${var.pool_name}-worker-${count.index}-ignition"
+  pool    = "${var.libvirtpool}"
+  count   = "${var.count}"
+  content = "${element(data.ct_config.worker-ignition.*.rendered, count.index)}"
+}
+
+resource "libvirt_domain" "worker-machine" {
+  count  = "${var.count}"
+  name   = "${var.cluster_name}-${var.pool_name}-worker-${count.index}"
+  vcpu   = "${var.virtual_cpus}"
+  memory = "${var.virtual_memory}"
+
+  coreos_ignition = "${element(libvirt_ignition.ignition.*.id, count.index)}"
+
+  disk {
+    volume_id = "${element(libvirt_volume.worker-disk.*.id, count.index)}"
+  }
+
+  graphics {
+    listen_type = "address"
+  }
+
+  network_interface {
+    network_name   = "${var.cluster_name}"
+    hostname       = "${var.cluster_name}-${var.pool_name}-worker-${count.index}"
+    wait_for_lease = true
+  }
+
+}
+
+data "ct_config" "worker-ignition" {
+  count	  = "${var.count}"
+  content = "${element(data.template_file.worker-config.*.rendered, count.index)}"
+}
+
+data "template_file" "worker-config" {
+  count    = "${var.count}"
+  template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
+
+  vars {
+    domain_name            = "${var.cluster_name}-${var.pool_name}-worker-${count.index}.${var.machine_domain}"
+    kubeconfig             = "${indent(10, "${var.kubeconfig}")}"
+    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
+    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
+    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+  }
+}


### PR DESCRIPTION
This documents how Lokomotive can be set up with nodes as VM on KVM through the libvirt Terraform provider. It provides a controller and a worker Terraform module to start with.

It provides a quick and easy way to test Lokomotive with a defined Flatcar image and doesn't require to have access to one of the cloud providers or spare hardware.

### Testing

Please test it with the steps mentioned in the documentation.

Depends on https://github.com/kinvolk/terraform-render-bootkube/pull/12