### PR TITLE
packet: always restart installer if it fails

### DIFF
--- a/packet/flatcar-linux/kubernetes/cl/controller-install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller-install.yaml.tmpl
@@ -5,10 +5,14 @@ systemd:
       enable: true
       contents: |
         [Unit]
+        StartLimitBurst=5
+        StartLimitIntervalSec=3600s
         Requires=network-online.target
         After=network-online.target
         [Service]
         Type=simple
+        Restart=always
+        RestartSec=60
         ExecStart=/opt/installer
         [Install]
         WantedBy=multi-user.target

--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -5,10 +5,14 @@ systemd:
       enable: true
       contents: |
         [Unit]
+        StartLimitBurst=5
+        StartLimitIntervalSec=3600s
         Requires=network-online.target
         After=network-online.target
         [Service]
         Type=simple
+        Restart=always
+        RestartSec=60
         ExecStart=/opt/installer
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
If there are some network issues and installer fails to download
the image or GPG signature, we should restart installer and try until we
succeed.

This may increase amount of traffic on flatcar infrastructure if
installers gets stuck and downloads images all the time in a loop, but
that should be acceptable, as soon we will have our images in Packer
natively.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>