### PR TITLE
packet: Add a configurable default for reservations ids

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -328,5 +328,6 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | setup_raid | Flag to create a RAID 0 from extra disks on a Packet node | false | true |
-| reservation_ids | Specify Packet hardware_reservation_id for instances, see: https://support.packet.com/kb/articles/reserved-hardware. A map where the key format is 'worker-${index}' and the associated value is the reservation id string. Nodes not present in the map will use no reservation id. | {} | { worker-0 = "55555f20-a1fb-55bd-1e11-11af11d11111" } |
 | taints | Comma separated list of custom taints for all workers in the worker pool | "" | "clusterType=staging:NoSchedule,nodeType=storage:NoSchedule" |
+| reservation_ids | Specify Packet hardware_reservation_id for instances, see: https://support.packet.com/kb/articles/reserved-hardware. A map where the key format is 'worker-${index}' and the associated value is the reservation id string. Nodes not present in the map will use no reservation id. | {} | { worker-0 = "55555f20-a1fb-55bd-1e11-11af11d11111" } |
+| reservation_ids_default | Value used for nodes not listed in the reservation_ids map. Note that using the empty string means using no hardware reservation and 'next-available' will choose any reservation that matches the instance type and facility this pool is running.| "" | "next-available"|

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -105,7 +105,13 @@ variable "setup_raid" {
 }
 
 variable "reservation_ids" {
-  description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'worker-${index}' and the associated value is the reservation id string. Nodes not present in the map will use no reservation id. Example: reservation_ids = { worker-0 = '<reservation_id>' }"
+  description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'worker-${index}' and the associated value is the reservation id string. Nodes not present in the map will use the value of reservation_ids_default var. Example: reservation_ids = { worker-0 = '<reservation_id>' }"
   type        = "map"
   default     = {}
+}
+
+variable "reservation_ids_default" {
+  description = "Possible values: '' and 'next-available'. Value used for nodes not listed in the reservation_ids map. Note that using the empty string means using no hardware reservation and 'next-available' will choose any reservation that matches the instance type and facility this pool is running."
+  type        = "string"
+  default     = ""
 }

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -10,8 +10,8 @@ resource "packet_device" "nodes" {
   always_pxe       = "false"
   user_data        = "${data.ct_config.install-ignitions.rendered}"
 
-  # If not present in the map, it uses "" that means no reservation id
-  hardware_reservation_id = "${lookup(var.reservation_ids, format("worker-%v", count.index), "")}"
+  # If not present in the map, it uses ${var.reservation_ids_default}
+  hardware_reservation_id = "${lookup(var.reservation_ids, format("worker-%v", count.index), var.reservation_ids_default)}"
 }
 
 # These configs are used for the fist boot, to run flatcar-install


### PR DESCRIPTION
This patch just adds support to specify what value will be used for the
hardware_reservation_id if a node is not in the reservation_ids map.

This is particularly useful when you don't really care which reservation
goes to which node, but always need reservations on that worker pool. In
that case, for example, you can do:

```
	reservation_ids_default = "next-available"
```

And it will pick the next reservation available **that matches the
facility and instance type**.

This was previously discussed here:
https://github.com/kinvolk/lokomotive-kubernetes/pull/5#issuecomment-495207900

I said there that I was not sure it was going to be needed and can be
added later if needed. It turns out invidian was right and this is
useful, in fact it is very useful for a client and they have exactly the
use case just described in this commit (need most nodes on a worker pool
to have *some* reservation, they don't care which nodes uses which
resrevation id in particular).

Also, the issue mentioned there by invidian
(https://github.com/cncf/cnf-testbed/issues/215) might be a bug that
stops us from using this. But, luckily, it seems to be already solved.

The bug mentioned by invidian has a comment,
https://github.com/cncf/cnf-testbed/issues/215#issuecomment-484135454,
that points to another issue where it is suggested that the
"next-available" option works as expected.

So, I went and tested this myself. I can see that the tfstate file is
updated with the reservation id (something like "111-sadasd-2sd") for
the instance when using "next-available" in terraform and no changes are
required by terraform on later plans/applies. Furthermore, I couldn't
reproduce none of the issues mentioned there, it really seems they are
fixed in Packet API now. I will update the bug soon.

## Testing

I've manually tested that using a 2 nodes worker pool, where one node was in the map for one node and the `reservation_ids_default` was used for the other node on the pool, whaever this values was (i.e. if reservation_ids_default was `next-available` or `""`, it worked fine).

I also tried not specifing a map and using just `reservation_ids_default` and it worked as expected too.