### PR TITLE
docs: Fix broken links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,11 +55,11 @@ nav:
     - 'Bare-Metal': 'architecture/bare-metal.md'
     - 'Google Cloud': 'architecture/google-cloud.md'
   - 'Flatcar Linux':
-    - 'AWS': 'cl/aws.md'
-    - 'Azure': 'cl/azure.md'
-    - 'Bare-Metal': 'cl/bare-metal.md'
-    - 'Google Cloud': 'cl/google-cloud.md'
-    - 'Packet': 'flatcar/packet.md'
+    - 'AWS': 'flatcar-linux/aws.md'
+    - 'Azure': 'flatcar-linux/azure.md'
+    - 'Bare-Metal': 'flatcar-linux/bare-metal.md'
+    - 'Google Cloud': 'flatcar-linux/google-cloud.md'
+    - 'Packet': 'flatcar-linux/packet.md'
   - 'Topics':
     - 'Maintenance': 'topics/maintenance.md'
     - 'Hardware': 'topics/hardware.md'


### PR DESCRIPTION
Following 34bab7e7cb403a36fed145f3c202d52f56e04835 we need to update the doc locations in `mkdocs.yaml` as well.

## Testing

Run the following to render the docs.

```bash
virtualenv venv
source venv/bin/activate
pip install -r requirements.txt
mkdocs serve
```

Browse http://127.0.0.1:8000.