### PR TITLE
azure: Update deprecated azurerm_autoscale_setting

### DIFF
--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -75,7 +75,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
 }
 
 # Scale up or down to maintain desired number, tolerating deallocations.
-resource "azurerm_autoscale_setting" "workers" {
+resource "azurerm_monitor_autoscale_setting" "workers" {
   resource_group_name = "${var.resource_group_name}"
 
   name     = "${var.name}-maintain-desired"


### PR DESCRIPTION
`azurerm_autoscale_setting` was deprecated and replaced by `azurerm_monitor_autoscale_setting`.