### PR TITLE
azure: make workers compatible with OpenEBS

### DIFF
--- a/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -5,6 +5,9 @@ systemd:
       enable: true
     - name: locksmithd.service
       mask: true
+    - name: iscsid.service
+      enable: true
+      enabled: true
     - name: wait-for-dns.service
       enable: true
       contents: |

--- a/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -40,6 +40,8 @@ systemd:
           --mount volume=opt-cni-bin,target=/opt/cni/bin \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log \
+          --volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
+          --mount volume=iscsiadm,target=/usr/sbin/iscsiadm \
           --insecure-options=image"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests


### PR DESCRIPTION
We have the same patches for worker pools for other providers, they are required to run OpenEBS.