### PR TITLE
Raid setup improvements

### DIFF
--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -73,11 +73,17 @@ storage:
             )
             local count=$(echo "$disks" | wc -w)
 
-            # Exit if we have less than 2 RAID-eligible disks.
-            [ $count -lt 2 ] && return 0
+            # Exit if we don't have any disks to create an array
+            [ $count -lt 1 ] && return 0
 
             # Create, format and mount array.
-            mdadm --create --verbose /dev/md/node-local-storage --level=0 --raid-devices="$${count}" $${disks}
+            local extra_opts=""
+            if [ $count -lt 2 ]; then
+              # Force array creation even with one disk
+              extra_opts="--force"
+            fi
+
+            mdadm --create $$extra_opts --verbose /dev/md/node-local-storage --level=0 --raid-devices="$${count}" $${disks}
             cat /proc/mdstat
             mkfs.ext4 /dev/md/node-local-storage
           }

--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -83,7 +83,7 @@ storage:
               extra_opts="--force"
             fi
 
-            mdadm --create /dev/md/node-local-storage $$extra_opts --verbose --level=0 --raid-devices="$${count}" $${disks}
+            mdadm --create /dev/md/node-local-storage --homehost=any $$extra_opts --verbose --name=node-local-storage --level=0 --raid-devices="$${count}" $${disks}
             cat /proc/mdstat
             mkfs.ext4 /dev/md/node-local-storage
           }

--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -83,7 +83,7 @@ storage:
               extra_opts="--force"
             fi
 
-            mdadm --create $$extra_opts --verbose /dev/md/node-local-storage --level=0 --raid-devices="$${count}" $${disks}
+            mdadm --create /dev/md/node-local-storage $$extra_opts --verbose --level=0 --raid-devices="$${count}" $${disks}
             cat /proc/mdstat
             mkfs.ext4 /dev/md/node-local-storage
           }

--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -71,14 +71,14 @@ storage:
               | grep -vE "^$${osdisk} " \
               | awk '{x=$1 " " x;} END{print x}'
             )
-            local count=$(echo "$disks" | wc -w)
+            local count=$(echo "$$disks" | wc -w)
 
             # Exit if we don't have any disks to create an array
-            [ $count -lt 1 ] && return 0
+            [ $$count -lt 1 ] && return 0
 
             # Create, format and mount array.
             local extra_opts=""
-            if [ $count -lt 2 ]; then
+            if [ $$count -lt 2 ]; then
               # Force array creation even with one disk
               extra_opts="--force"
             fi


### PR DESCRIPTION
This PR includes 3 commits:
 * One to fix MD arrays renames that sometimes happen on reboot
 * To escape dollar sign in template correctly
 * And the interesting one: to force RAID 0 creation even if 1 disk is available.

I paste the commit message form the last one, as it is the most interesting one. Please have a look at the rename fix commit message too, but I think that is mostly straight forward.

Here c&p the commit message for using RAID 0 even with 1 disk:

    Even if it is only one spare disk, it makes sense to create a RAID 0
    array because the user might want to use that local disk, it adds no
    performance penalty, and it is uniform with other setups where more
    disks are involved (from the maintenance point of view).
    
    The other option would be to provide a totally different way to access
    the disk (without RAID), but that means more complicated provisioning
    code for a use case we are not fans of.
    
    Let's extend the RAID 0 to these cases, that also doesn't expand the
    test-matrix, and if there is any problem with the approach we can
    re-evaluate later.