### PR TITLE
Fix required AWS provider version

### DIFF
--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -29,5 +29,5 @@ provider "packet" {
 }
 
 provider "aws" {
-  version = "~> 1.57"
+  version = ">= 1.13, < 3.0"
 }


### PR DESCRIPTION
Fixes https://github.com/kinvolk/lokomotive-kubernetes/issues/25.

`~> 1.57` was defined kind of arbitrarily. The new value is what's used by Typhoon prior to Terraform 0.12. This is also what is currently used by our AWS module.