### PR TITLE
libvirt: Reference current bootkube module

### DIFF
--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=0d3951ff08eeaa617e5aa83da5db19ef2e12324f"  # currently in PR #12
+  source = "git::https://github.com/kinvolk/terraform-render-bootkube/"
 
   cluster_name = "${var.cluster_name}"
 


### PR DESCRIPTION
The referenced bootkube [PR](https://github.com/kinvolk/terraform-render-bootkube/pull/12) commit got merged,
so that the reference is not needed anymore
but rather would cause missing features and fixes
in the future.