### PR TITLE
packet: remove node_private_cidr variable

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -151,9 +151,6 @@ module "controller" {
   management_cidrs = [
     "0.0.0.0/0",       # Instances can be SSH-ed into from anywhere on the internet.
   ]
-
-  # This is different for each project on Packet and depends on the packet facility/region. Check yours from the `IPs & Networks` tab from your Packet.net account. If an IP block is not allocated yet, try provisioning an instance from the console in that region. Packet will allocate a public IP CIDR.
-  node_private_cidr = "10.128.156.0/25"
 }
 
 module "worker-pool-helium" {
@@ -264,7 +261,6 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | worker_count | Total number of workers across all worker pools | 2 |
 | worker_nodes_hostnames | List of hostnames of all worker nodes | ["foo-pool1-worker-0", "foo-pool1-worker-1"]
 | management_cidrs | List of CIDRs to allow SSH access to the nodes | ["153.79.80.1/16", "59.60.10.1/32"] |
-| node_private_cidr | Private CIDR obtained from Packet for the project and facility | 10.128.16.32/25 |
 
 #### Worker module
 

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -13,7 +13,7 @@ module "bootkube" {
 
   # Select private Packet NIC by using the can-reach Calico autodetection option with the first
   # host in our private CIDR.
-  network_ip_autodetection_method = "can-reach=${cidrhost(var.node_private_cidr, 1)}"
+  network_ip_autodetection_method = "can-reach=${cidrhost(data.packet_precreated_ip_block.project_ip_block.cidr_notation, 1)}"
 
   pod_cidr              = "${var.pod_cidr}"
   service_cidr          = "${var.service_cidr}"

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -103,3 +103,11 @@ data "template_file" "etcds" {
     dns_zone     = "${var.dns_zone}"
   }
 }
+
+# Node private CIDR in this project
+data "packet_precreated_ip_block" "project_ip_block" {
+  facility       = "${var.facility}"
+  project_id     = "${var.project_id}"
+  address_family = 4
+  public         = false
+}

--- a/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/packet/flatcar-linux/kubernetes/ssh.tf
@@ -119,7 +119,7 @@ data "template_file" "host_protection_policy" {
     controller_host_endpoints = "${join("\n", data.template_file.controller_host_endpoints.*.rendered)}"
     worker_host_endpoints     = "${join("\n", data.template_file.worker_host_endpoints.*.rendered)}"
     management_cidrs          = "${jsonencode("${var.management_cidrs}")}"
-    cluster_internal_cidrs    = "${jsonencode(list("${var.node_private_cidr}", "${var.pod_cidr}", "${var.service_cidr}"))}"
+    cluster_internal_cidrs    = "${jsonencode(list("${data.packet_precreated_ip_block.project_ip_block.cidr_notation}", "${var.pod_cidr}", "${var.service_cidr}"))}"
     etcd_server_cidrs         = "${jsonencode("${packet_device.controllers.*.access_private_ipv4}")}"
   }
 }

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -136,11 +136,6 @@ variable "management_cidrs" {
   type        = "list"
 }
 
-variable "node_private_cidr" {
-  description = "Private IPv4 CIDR of the nodes used to allow inter-node traffic"
-  type        = "string"
-}
-
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
   type        = "string"


### PR DESCRIPTION
This variable was causing some confusion, also the fact that it was dependent on the region was a little bit annoying IMHO.

While studying the packet terraform provider I realized it was possible to get that value from it, so why not?