### PR TITLE
Upgrade to Terraform 0.12

### DIFF
--- a/aws/flatcar-linux/kubernetes/ami.tf
+++ b/aws/flatcar-linux/kubernetes/ami.tf
@@ -4,8 +4,8 @@ locals {
   # flatcar-stable -> Flatcar Linux AMI
   ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
 
-  flavor  = element(split("-", var.os_image), 0)
-  channel = element(split("-", var.os_image), 1)
+  flavor  = split("-", var.os_image)[0]
+  channel = split("-", var.os_image)[1]
 }
 
 data "aws_ami" "coreos" {

--- a/aws/flatcar-linux/kubernetes/ami.tf
+++ b/aws/flatcar-linux/kubernetes/ami.tf
@@ -2,10 +2,10 @@ locals {
   # Pick a CoreOS Container Linux derivative
   # coreos-stable -> Container Linux AMI
   # flatcar-stable -> Flatcar Linux AMI
-  ami_id = "${local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id}"
+  ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
 
-  flavor  = "${element(split("-", var.os_image), 0)}"
-  channel = "${element(split("-", var.os_image), 1)}"
+  flavor  = element(split("-", var.os_image), 0)
+  channel = element(split("-", var.os_image), 1)
 }
 
 data "aws_ami" "coreos" {
@@ -47,3 +47,4 @@ data "aws_ami" "flatcar" {
     values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-*"]
   }
 }
+

--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -4,7 +4,7 @@ module "bootkube" {
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers          = [aws_route53_record.etcds.*.fqdn]
+  etcd_servers          = aws_route53_record.etcds.*.fqdn
   asset_dir             = var.asset_dir
   networking            = var.networking
   network_mtu           = var.network_mtu

--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -2,15 +2,16 @@
 module "bootkube" {
   source = "github.com/kinvolk/terraform-render-bootkube?ref=9c1ff5a9e8b3e98922980a097c49c8b3a903437a"
 
-  cluster_name          = "${var.cluster_name}"
-  api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers          = ["${aws_route53_record.etcds.*.fqdn}"]
-  asset_dir             = "${var.asset_dir}"
-  networking            = "${var.networking}"
-  network_mtu           = "${var.network_mtu}"
-  pod_cidr              = "${var.pod_cidr}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  enable_reporting      = "${var.enable_reporting}"
-  enable_aggregation    = "${var.enable_aggregation}"
+  cluster_name          = var.cluster_name
+  api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  etcd_servers          = [aws_route53_record.etcds.*.fqdn]
+  asset_dir             = var.asset_dir
+  networking            = var.networking
+  network_mtu           = var.network_mtu
+  pod_cidr              = var.pod_cidr
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  enable_reporting      = var.enable_reporting
+  enable_aggregation    = var.enable_aggregation
 }
+

--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=d07243a9e7f6084cfe08b708731a79c26146badb"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=9c1ff5a9e8b3e98922980a097c49c8b3a903437a"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -1,87 +1,89 @@
 # Discrete DNS records for each controller's private IPv4 for etcd usage
 resource "aws_route53_record" "etcds" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   # DNS Zone where record should be created
-  zone_id = "${var.dns_zone_id}"
+  zone_id = var.dns_zone_id
 
-  name = "${format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)}"
+  name = format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)
   type = "A"
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = ["${element(aws_instance.controllers.*.private_ip, count.index)}"]
+  records = [element(aws_instance.controllers.*.private_ip, count.index)]
 }
 
 # Controller instances
 resource "aws_instance" "controllers" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   tags = {
     Name = "${var.cluster_name}-controller-${count.index}"
   }
 
-  instance_type = "${var.controller_type}"
+  instance_type = var.controller_type
 
-  ami       = "${local.ami_id}"
-  user_data = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+  ami       = local.ami_id
+  user_data = element(data.ct_config.controller-ignitions.*.rendered, count.index)
 
   # storage
   root_block_device {
-    volume_type = "${var.disk_type}"
-    volume_size = "${var.disk_size}"
-    iops        = "${var.disk_iops}"
+    volume_type = var.disk_type
+    volume_size = var.disk_size
+    iops        = var.disk_iops
   }
 
   # network
   associate_public_ip_address = true
-  subnet_id                   = "${element(aws_subnet.public.*.id, count.index)}"
-  vpc_security_group_ids      = ["${aws_security_group.controller.id}"]
+  subnet_id                   = element(aws_subnet.public.*.id, count.index)
+  vpc_security_group_ids      = [aws_security_group.controller.id]
 
   lifecycle {
     ignore_changes = [
-      "ami",
-      "user_data",
+      ami,
+      user_data,
     ]
   }
 }
 
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
-  count        = "${var.controller_count}"
-  content      = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  count = var.controller_count
+  content = element(
+    data.template_file.controller-configs.*.rendered,
+    count.index,
+  )
   pretty_print = false
-  snippets     = ["${var.controller_clc_snippets}"]
+  snippets     = var.controller_clc_snippets
 }
 
 # Controller Container Linux configs
 data "template_file" "controller-configs" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
-  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+  template = file("${path.module}/cl/controller.yaml.tmpl")
 
   vars = {
     # Cannot use cyclic dependencies on controllers or their DNS records
     etcd_name   = "etcd${count.index}"
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
-
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
-
-    kubeconfig             = "${indent(10, module.bootkube.kubeconfig-kubelet)}"
-    ssh_authorized_key     = "${var.ssh_authorized_key}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    etcd_initial_cluster   = join(",", data.template_file.etcds.*.rendered)
+    kubeconfig             = indent(10, module.bootkube.kubeconfig-kubelet)
+    ssh_authorized_key     = var.ssh_authorized_key
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
 
 data "template_file" "etcds" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
   vars = {
-    index        = "${count.index}"
-    cluster_name = "${var.cluster_name}"
-    dns_zone     = "${var.dns_zone}"
+    index        = count.index
+    cluster_name = var.cluster_name
+    dns_zone     = var.dns_zone
   }
 }
+

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -48,8 +48,8 @@ resource "aws_instance" "controllers" {
 
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
-  count = var.controller_count
-  content = data.template_file.controller-configs[count.index].rendered
+  count        = var.controller_count
+  content      = data.template_file.controller-configs[count.index].rendered
   pretty_print = false
   snippets     = var.controller_clc_snippets
 }

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -10,7 +10,7 @@ resource "aws_route53_record" "etcds" {
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = [element(aws_instance.controllers.*.private_ip, count.index)]
+  records = [aws_instance.controllers[count.index].private_ip]
 }
 
 # Controller instances
@@ -24,7 +24,7 @@ resource "aws_instance" "controllers" {
   instance_type = var.controller_type
 
   ami       = local.ami_id
-  user_data = element(data.ct_config.controller-ignitions.*.rendered, count.index)
+  user_data = data.ct_config.controller-ignitions[count.index].rendered
 
   # storage
   root_block_device {
@@ -35,7 +35,7 @@ resource "aws_instance" "controllers" {
 
   # network
   associate_public_ip_address = true
-  subnet_id                   = element(aws_subnet.public.*.id, count.index)
+  subnet_id                   = aws_subnet.public[count.index].id
   vpc_security_group_ids      = [aws_security_group.controller.id]
 
   lifecycle {
@@ -49,10 +49,7 @@ resource "aws_instance" "controllers" {
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
   count = var.controller_count
-  content = element(
-    data.template_file.controller-configs.*.rendered,
-    count.index,
-  )
+  content = data.template_file.controller-configs[count.index].rendered
   pretty_print = false
   snippets     = var.controller_clc_snippets
 }

--- a/aws/flatcar-linux/kubernetes/dns.tf
+++ b/aws/flatcar-linux/kubernetes/dns.tf
@@ -1,10 +1,11 @@
 # Wildcard DNS Record for ingress
 resource "aws_route53_record" "ingress-wildcard" {
-  zone_id = "${var.dns_zone_id}"
-  name    = "${format("*.%s.%s.", var.cluster_name, var.dns_zone)}"
+  zone_id = var.dns_zone_id
+  name    = format("*.%s.%s.", var.cluster_name, var.dns_zone)
   type    = "CNAME"
   ttl     = 60
   records = [
-    "${format("%s.%s.", var.cluster_name, var.dns_zone)}",
+    format("%s.%s.", var.cluster_name, var.dns_zone),
   ]
 }
+

--- a/aws/flatcar-linux/kubernetes/network.tf
+++ b/aws/flatcar-linux/kubernetes/network.tf
@@ -1,57 +1,67 @@
-data "aws_availability_zones" "all" {}
+data "aws_availability_zones" "all" {
+}
 
 # Network VPC, gateway, and routes
 
 resource "aws_vpc" "network" {
-  cidr_block                       = "${var.host_cidr}"
+  cidr_block                       = var.host_cidr
   assign_generated_ipv6_cidr_block = true
   enable_dns_support               = true
   enable_dns_hostnames             = true
 
-  tags = "${map("Name", "${var.cluster_name}")}"
+  tags = {
+    "Name" = var.cluster_name
+  }
 }
 
 resource "aws_internet_gateway" "gateway" {
-  vpc_id = "${aws_vpc.network.id}"
+  vpc_id = aws_vpc.network.id
 
-  tags = "${map("Name", "${var.cluster_name}")}"
+  tags = {
+    "Name" = var.cluster_name
+  }
 }
 
 resource "aws_route_table" "default" {
-  vpc_id = "${aws_vpc.network.id}"
+  vpc_id = aws_vpc.network.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.gateway.id}"
+    gateway_id = aws_internet_gateway.gateway.id
   }
 
   route {
     ipv6_cidr_block = "::/0"
-    gateway_id      = "${aws_internet_gateway.gateway.id}"
+    gateway_id      = aws_internet_gateway.gateway.id
   }
 
-  tags = "${map("Name", "${var.cluster_name}")}"
+  tags = {
+    "Name" = var.cluster_name
+  }
 }
 
 # Subnets (one per availability zone)
 
 resource "aws_subnet" "public" {
-  count = "${length(data.aws_availability_zones.all.names)}"
+  count = length(data.aws_availability_zones.all.names)
 
-  vpc_id            = "${aws_vpc.network.id}"
-  availability_zone = "${data.aws_availability_zones.all.names[count.index]}"
+  vpc_id            = aws_vpc.network.id
+  availability_zone = data.aws_availability_zones.all.names[count.index]
 
-  cidr_block                      = "${cidrsubnet(var.host_cidr, 4, count.index)}"
-  ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.network.ipv6_cidr_block, 8, count.index)}"
+  cidr_block                      = cidrsubnet(var.host_cidr, 4, count.index)
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.network.ipv6_cidr_block, 8, count.index)
   map_public_ip_on_launch         = true
   assign_ipv6_address_on_creation = true
 
-  tags = "${map("Name", "${var.cluster_name}-public-${count.index}")}"
+  tags = {
+    "Name" = "${var.cluster_name}-public-${count.index}"
+  }
 }
 
 resource "aws_route_table_association" "public" {
-  count = "${length(data.aws_availability_zones.all.names)}"
+  count = length(data.aws_availability_zones.all.names)
 
-  route_table_id = "${aws_route_table.default.id}"
-  subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
+  route_table_id = aws_route_table.default.id
+  subnet_id      = element(aws_subnet.public.*.id, count.index)
 }
+

--- a/aws/flatcar-linux/kubernetes/network.tf
+++ b/aws/flatcar-linux/kubernetes/network.tf
@@ -62,6 +62,6 @@ resource "aws_route_table_association" "public" {
   count = length(data.aws_availability_zones.all.names)
 
   route_table_id = aws_route_table.default.id
-  subnet_id      = element(aws_subnet.public.*.id, count.index)
+  subnet_id      = aws_subnet.public[count.index].id
 }
 

--- a/aws/flatcar-linux/kubernetes/nlb.tf
+++ b/aws/flatcar-linux/kubernetes/nlb.tf
@@ -1,14 +1,14 @@
 # Network Load Balancer DNS Record
 resource "aws_route53_record" "apiserver" {
-  zone_id = "${var.dns_zone_id}"
+  zone_id = var.dns_zone_id
 
-  name = "${format("%s.%s.", var.cluster_name, var.dns_zone)}"
+  name = format("%s.%s.", var.cluster_name, var.dns_zone)
   type = "A"
 
   # AWS recommends their special "alias" records for NLBs
   alias {
-    name                   = "${aws_lb.nlb.dns_name}"
-    zone_id                = "${aws_lb.nlb.zone_id}"
+    name                   = aws_lb.nlb.dns_name
+    zone_id                = aws_lb.nlb.zone_id
     evaluate_target_health = true
   }
 }
@@ -19,51 +19,51 @@ resource "aws_lb" "nlb" {
   load_balancer_type = "network"
   internal           = false
 
-  subnets = ["${aws_subnet.public.*.id}"]
+  subnets = aws_subnet.public.*.id
 
   enable_cross_zone_load_balancing = true
 }
 
 # Forward TCP apiserver traffic to controllers
 resource "aws_lb_listener" "apiserver-https" {
-  load_balancer_arn = "${aws_lb.nlb.arn}"
+  load_balancer_arn = aws_lb.nlb.arn
   protocol          = "TCP"
   port              = "6443"
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.controllers.arn}"
+    target_group_arn = aws_lb_target_group.controllers.arn
   }
 }
 
 # Forward HTTP ingress traffic to workers
 resource "aws_lb_listener" "ingress-http" {
-  load_balancer_arn = "${aws_lb.nlb.arn}"
+  load_balancer_arn = aws_lb.nlb.arn
   protocol          = "TCP"
   port              = 80
 
   default_action {
     type             = "forward"
-    target_group_arn = "${module.workers.target_group_http}"
+    target_group_arn = module.workers.target_group_http
   }
 }
 
 # Forward HTTPS ingress traffic to workers
 resource "aws_lb_listener" "ingress-https" {
-  load_balancer_arn = "${aws_lb.nlb.arn}"
+  load_balancer_arn = aws_lb.nlb.arn
   protocol          = "TCP"
   port              = 443
 
   default_action {
     type             = "forward"
-    target_group_arn = "${module.workers.target_group_https}"
+    target_group_arn = module.workers.target_group_https
   }
 }
 
 # Target group of controllers
 resource "aws_lb_target_group" "controllers" {
   name        = "${var.cluster_name}-controllers"
-  vpc_id      = "${aws_vpc.network.id}"
+  vpc_id      = aws_vpc.network.id
   target_type = "instance"
 
   protocol = "TCP"
@@ -85,9 +85,10 @@ resource "aws_lb_target_group" "controllers" {
 
 # Attach controller instances to apiserver NLB
 resource "aws_lb_target_group_attachment" "controllers" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
-  target_group_arn = "${aws_lb_target_group.controllers.arn}"
-  target_id        = "${element(aws_instance.controllers.*.id, count.index)}"
+  target_group_arn = aws_lb_target_group.controllers.arn
+  target_id        = element(aws_instance.controllers.*.id, count.index)
   port             = 6443
 }
+

--- a/aws/flatcar-linux/kubernetes/nlb.tf
+++ b/aws/flatcar-linux/kubernetes/nlb.tf
@@ -88,7 +88,7 @@ resource "aws_lb_target_group_attachment" "controllers" {
   count = var.controller_count
 
   target_group_arn = aws_lb_target_group.controllers.arn
-  target_id        = element(aws_instance.controllers.*.id, count.index)
+  target_id        = aws_instance.controllers[count.index].id
   port             = 6443
 }
 

--- a/aws/flatcar-linux/kubernetes/outputs.tf
+++ b/aws/flatcar-linux/kubernetes/outputs.tf
@@ -1,53 +1,54 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin}"
+  value = module.bootkube.kubeconfig-admin
 }
 
 # Outputs for Kubernetes Ingress
 
 output "ingress_dns_name" {
-  value       = "${aws_lb.nlb.dns_name}"
+  value       = aws_lb.nlb.dns_name
   description = "DNS name of the network load balancer for distributing traffic to Ingress controllers"
 }
 
 output "ingress_zone_id" {
-  value       = "${aws_lb.nlb.zone_id}"
+  value       = aws_lb.nlb.zone_id
   description = "Route53 zone id of the network load balancer DNS name that can be used in Route53 alias records"
 }
 
 # Outputs for worker pools
 
 output "vpc_id" {
-  value       = "${aws_vpc.network.id}"
+  value       = aws_vpc.network.id
   description = "ID of the VPC for creating worker instances"
 }
 
 output "subnet_ids" {
-  value       = ["${aws_subnet.public.*.id}"]
+  value       = [aws_subnet.public.*.id]
   description = "List of subnet IDs for creating worker instances"
 }
 
 output "worker_security_groups" {
-  value       = ["${aws_security_group.worker.id}"]
+  value       = [aws_security_group.worker.id]
   description = "List of worker security group IDs"
 }
 
 output "kubeconfig" {
-  value = "${module.bootkube.kubeconfig-kubelet}"
+  value = module.bootkube.kubeconfig-kubelet
 }
 
 # Outputs for custom load balancing
 
 output "nlb_id" {
   description = "ARN of the Network Load Balancer"
-  value       = "${aws_lb.nlb.id}"
+  value       = aws_lb.nlb.id
 }
 
 output "worker_target_group_http" {
   description = "ARN of a target group of workers for HTTP traffic"
-  value       = "${module.workers.target_group_http}"
+  value       = module.workers.target_group_http
 }
 
 output "worker_target_group_https" {
   description = "ARN of a target group of workers for HTTPS traffic"
-  value       = "${module.workers.target_group_https}"
+  value       = module.workers.target_group_https
 }
+

--- a/aws/flatcar-linux/kubernetes/require.tf
+++ b/aws/flatcar-linux/kubernetes/require.tf
@@ -23,3 +23,4 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0.1"
 }
+

--- a/aws/flatcar-linux/kubernetes/require.tf
+++ b/aws/flatcar-linux/kubernetes/require.tf
@@ -17,7 +17,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {

--- a/aws/flatcar-linux/kubernetes/require.tf
+++ b/aws/flatcar-linux/kubernetes/require.tf
@@ -21,5 +21,5 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
 }

--- a/aws/flatcar-linux/kubernetes/require.tf
+++ b/aws/flatcar-linux/kubernetes/require.tf
@@ -13,7 +13,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "template" {

--- a/aws/flatcar-linux/kubernetes/security.tf
+++ b/aws/flatcar-linux/kubernetes/security.tf
@@ -6,13 +6,15 @@ resource "aws_security_group" "controller" {
   name        = "${var.cluster_name}-controller"
   description = "${var.cluster_name} controller security group"
 
-  vpc_id = "${aws_vpc.network.id}"
+  vpc_id = aws_vpc.network.id
 
-  tags = "${map("Name", "${var.cluster_name}-controller")}"
+  tags = {
+    "Name" = "${var.cluster_name}-controller"
+  }
 }
 
 resource "aws_security_group_rule" "controller-ssh" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -22,7 +24,7 @@ resource "aws_security_group_rule" "controller-ssh" {
 }
 
 resource "aws_security_group_rule" "controller-etcd" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -33,17 +35,17 @@ resource "aws_security_group_rule" "controller-etcd" {
 
 # Allow Prometheus to scrape etcd metrics
 resource "aws_security_group_rule" "controller-etcd-metrics" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 2381
   to_port                  = 2381
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-apiserver" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -53,17 +55,17 @@ resource "aws_security_group_rule" "controller-apiserver" {
 }
 
 resource "aws_security_group_rule" "controller-flannel" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = "udp"
   from_port                = 8472
   to_port                  = 8472
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-flannel-self" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = "udp"
@@ -74,28 +76,28 @@ resource "aws_security_group_rule" "controller-flannel-self" {
 
 # Allow Prometheus to scrape node-exporter daemonset
 resource "aws_security_group_rule" "controller-node-exporter" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 9100
   to_port                  = 9100
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 # Allow apiserver to access kubelets for exec, log, port-forward
 resource "aws_security_group_rule" "controller-kubelet" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 10250
   to_port                  = 10250
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-kubelet-self" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -105,17 +107,17 @@ resource "aws_security_group_rule" "controller-kubelet-self" {
 }
 
 resource "aws_security_group_rule" "controller-bgp" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 179
   to_port                  = 179
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-bgp-self" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -125,17 +127,17 @@ resource "aws_security_group_rule" "controller-bgp-self" {
 }
 
 resource "aws_security_group_rule" "controller-ipip" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = 4
   from_port                = 0
   to_port                  = 0
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-ipip-self" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = 4
@@ -145,17 +147,17 @@ resource "aws_security_group_rule" "controller-ipip-self" {
 }
 
 resource "aws_security_group_rule" "controller-ipip-legacy" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = 94
   from_port                = 0
   to_port                  = 0
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-ipip-legacy-self" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = 94
@@ -165,7 +167,7 @@ resource "aws_security_group_rule" "controller-ipip-legacy-self" {
 }
 
 resource "aws_security_group_rule" "controller-egress" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type             = "egress"
   protocol         = "-1"
@@ -181,13 +183,15 @@ resource "aws_security_group" "worker" {
   name        = "${var.cluster_name}-worker"
   description = "${var.cluster_name} worker security group"
 
-  vpc_id = "${aws_vpc.network.id}"
+  vpc_id = aws_vpc.network.id
 
-  tags = "${map("Name", "${var.cluster_name}-worker")}"
+  tags = {
+    "Name" = "${var.cluster_name}-worker"
+  }
 }
 
 resource "aws_security_group_rule" "worker-ssh" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -197,7 +201,7 @@ resource "aws_security_group_rule" "worker-ssh" {
 }
 
 resource "aws_security_group_rule" "worker-http" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -207,7 +211,7 @@ resource "aws_security_group_rule" "worker-http" {
 }
 
 resource "aws_security_group_rule" "worker-https" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -217,17 +221,17 @@ resource "aws_security_group_rule" "worker-https" {
 }
 
 resource "aws_security_group_rule" "worker-flannel" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type                     = "ingress"
   protocol                 = "udp"
   from_port                = 8472
   to_port                  = 8472
-  source_security_group_id = "${aws_security_group.controller.id}"
+  source_security_group_id = aws_security_group.controller.id
 }
 
 resource "aws_security_group_rule" "worker-flannel-self" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = "udp"
@@ -238,7 +242,7 @@ resource "aws_security_group_rule" "worker-flannel-self" {
 
 # Allow Prometheus to scrape node-exporter daemonset
 resource "aws_security_group_rule" "worker-node-exporter" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -248,7 +252,7 @@ resource "aws_security_group_rule" "worker-node-exporter" {
 }
 
 resource "aws_security_group_rule" "ingress-health" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -259,18 +263,18 @@ resource "aws_security_group_rule" "ingress-health" {
 
 # Allow apiserver to access kubelets for exec, log, port-forward
 resource "aws_security_group_rule" "worker-kubelet" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 10250
   to_port                  = 10250
-  source_security_group_id = "${aws_security_group.controller.id}"
+  source_security_group_id = aws_security_group.controller.id
 }
 
 # Allow Prometheus to scrape kubelet metrics
 resource "aws_security_group_rule" "worker-kubelet-self" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -280,17 +284,17 @@ resource "aws_security_group_rule" "worker-kubelet-self" {
 }
 
 resource "aws_security_group_rule" "worker-bgp" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 179
   to_port                  = 179
-  source_security_group_id = "${aws_security_group.controller.id}"
+  source_security_group_id = aws_security_group.controller.id
 }
 
 resource "aws_security_group_rule" "worker-bgp-self" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -300,17 +304,17 @@ resource "aws_security_group_rule" "worker-bgp-self" {
 }
 
 resource "aws_security_group_rule" "worker-ipip" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type                     = "ingress"
   protocol                 = 4
   from_port                = 0
   to_port                  = 0
-  source_security_group_id = "${aws_security_group.controller.id}"
+  source_security_group_id = aws_security_group.controller.id
 }
 
 resource "aws_security_group_rule" "worker-ipip-self" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = 4
@@ -320,17 +324,17 @@ resource "aws_security_group_rule" "worker-ipip-self" {
 }
 
 resource "aws_security_group_rule" "worker-ipip-legacy" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type                     = "ingress"
   protocol                 = 94
   from_port                = 0
   to_port                  = 0
-  source_security_group_id = "${aws_security_group.controller.id}"
+  source_security_group_id = aws_security_group.controller.id
 }
 
 resource "aws_security_group_rule" "worker-ipip-legacy-self" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = 94
@@ -340,7 +344,7 @@ resource "aws_security_group_rule" "worker-ipip-legacy-self" {
 }
 
 resource "aws_security_group_rule" "worker-egress" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type             = "egress"
   protocol         = "-1"
@@ -349,3 +353,4 @@ resource "aws_security_group_rule" "worker-egress" {
   cidr_blocks      = ["0.0.0.0/0"]
   ipv6_cidr_blocks = ["::/0"]
 }
+

--- a/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/aws/flatcar-linux/kubernetes/ssh.tf
@@ -1,46 +1,46 @@
 # Secure copy etcd TLS assets to controllers.
 resource "null_resource" "copy-controller-secrets" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   connection {
     type    = "ssh"
-    host    = "${element(aws_instance.controllers.*.public_ip, count.index)}"
+    host    = element(aws_instance.controllers.*.public_ip, count.index)
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_ca_cert}"
+    content     = module.bootkube.etcd_ca_cert
     destination = "$HOME/etcd-client-ca.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_cert}"
+    content     = module.bootkube.etcd_client_cert
     destination = "$HOME/etcd-client.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_key}"
+    content     = module.bootkube.etcd_client_key
     destination = "$HOME/etcd-client.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_cert}"
+    content     = module.bootkube.etcd_server_cert
     destination = "$HOME/etcd-server.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_key}"
+    content     = module.bootkube.etcd_server_key
     destination = "$HOME/etcd-server.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_cert}"
+    content     = module.bootkube.etcd_peer_cert
     destination = "$HOME/etcd-peer.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_key}"
+    content     = module.bootkube.etcd_peer_key
     destination = "$HOME/etcd-peer.key"
   }
 
@@ -68,21 +68,21 @@ resource "null_resource" "copy-controller-secrets" {
 # one-time self-hosted cluster bootstrapping.
 resource "null_resource" "bootkube-start" {
   depends_on = [
-    "module.bootkube",
-    "module.workers",
-    "aws_route53_record.apiserver",
-    "null_resource.copy-controller-secrets",
+    module.bootkube,
+    module.workers,
+    aws_route53_record.apiserver,
+    null_resource.copy-controller-secrets,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${aws_instance.controllers.0.public_ip}"
+    host    = aws_instance.controllers[0].public_ip
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    source      = "${var.asset_dir}"
+    source      = var.asset_dir
     destination = "$HOME/assets"
   }
 
@@ -93,3 +93,4 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
+

--- a/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/aws/flatcar-linux/kubernetes/ssh.tf
@@ -4,7 +4,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(aws_instance.controllers.*.public_ip, count.index)
+    host    = aws_instance.controllers[count.index].public_ip
     user    = "core"
     timeout = "15m"
   }

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -1,90 +1,90 @@
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
 # AWS
 
 variable "dns_zone" {
-  type        = "string"
+  type        = string
   description = "AWS Route53 DNS Zone (e.g. aws.example.com)"
 }
 
 variable "dns_zone_id" {
-  type        = "string"
+  type        = string
   description = "AWS Route53 DNS Zone ID (e.g. Z3PAABBCFAKEC0)"
 }
 
 # instances
 
 variable "controller_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of workers"
 }
 
 variable "controller_type" {
-  type        = "string"
+  type        = string
   default     = "t3.small"
   description = "EC2 instance type for controllers"
 }
 
 variable "worker_type" {
-  type        = "string"
+  type        = string
   default     = "t3.small"
   description = "EC2 instance type for workers"
 }
 
 variable "os_image" {
-  type        = "string"
+  type        = string
   default     = "flatcar-stable"
   description = "AMI channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
 }
 
 variable "disk_size" {
-  type        = "string"
+  type        = string
   default     = "40"
   description = "Size of the EBS volume in GB"
 }
 
 variable "disk_type" {
-  type        = "string"
+  type        = string
   default     = "gp2"
   description = "Type of the EBS volume (e.g. standard, gp2, io1)"
 }
 
 variable "disk_iops" {
-  type        = "string"
+  type        = string
   default     = "0"
   description = "IOPS of the EBS volume (e.g. 100)"
 }
 
 variable "worker_price" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Spot price in USD for autoscaling group spot instances. Leave as default empty string for autoscaling group to use on-demand instances. Note, switching in-place from spot to on-demand is not possible: https://github.com/terraform-providers/terraform-provider-aws/issues/4320"
 }
 
 variable "worker_target_groups" {
-  type        = "list"
+  type        = list(string)
   description = "Additional target group ARNs to which worker instances should be added"
   default     = []
 }
 
 variable "controller_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
 
 variable "worker_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Worker Container Linux Config snippets"
   default     = []
 }
@@ -92,36 +92,36 @@ variable "worker_clc_snippets" {
 # configuration
 
 variable "ssh_authorized_key" {
-  type        = "string"
+  type        = string
   description = "SSH public key for user 'core'"
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "networking" {
   description = "Choice of networking provider (calico or flannel)"
-  type        = "string"
+  type        = string
   default     = "calico"
 }
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only). Use 8981 if using instances types with Jumbo frames."
-  type        = "string"
+  type        = string
   default     = "1480"
 }
 
 variable "host_cidr" {
   description = "CIDR IPv4 range to assign to EC2 nodes"
-  type        = "string"
+  type        = string
   default     = "10.0.0.0/16"
 }
 
 variable "pod_cidr" {
   description = "CIDR IPv4 range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.2.0.0/16"
 }
 
@@ -131,24 +131,26 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
-  default     = "cluster.local"
+  type = string
+  default = "cluster.local"
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type = string
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = "false"
+  default = "false"
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = "string"
-  default     = "false"
+  type = string
+  default = "false"
 }
+

--- a/aws/flatcar-linux/kubernetes/versions.tf
+++ b/aws/flatcar-linux/kubernetes/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -1,22 +1,23 @@
 module "workers" {
   source = "./workers"
-  name   = "${var.cluster_name}"
+  name   = var.cluster_name
 
   # AWS
-  vpc_id          = "${aws_vpc.network.id}"
-  subnet_ids      = ["${aws_subnet.public.*.id}"]
-  security_groups = ["${aws_security_group.worker.id}"]
-  worker_count           = "${var.worker_count}"
-  instance_type   = "${var.worker_type}"
-  os_image        = "${var.os_image}"
-  disk_size       = "${var.disk_size}"
-  spot_price      = "${var.worker_price}"
-  target_groups   = ["${var.worker_target_groups}"]
+  vpc_id          = aws_vpc.network.id
+  subnet_ids      = [aws_subnet.public.*.id]
+  security_groups = [aws_security_group.worker.id]
+  worker_count    = var.worker_count
+  instance_type   = var.worker_type
+  os_image        = var.os_image
+  disk_size       = var.disk_size
+  spot_price      = var.worker_price
+  target_groups   = [var.worker_target_groups]
 
   # configuration
-  kubeconfig            = "${module.bootkube.kubeconfig-kubelet}"
-  ssh_authorized_key    = "${var.ssh_authorized_key}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  clc_snippets          = "${var.worker_clc_snippets}"
+  kubeconfig            = module.bootkube.kubeconfig-kubelet
+  ssh_authorized_key    = var.ssh_authorized_key
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  clc_snippets          = var.worker_clc_snippets
 }
+

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -6,7 +6,7 @@ module "workers" {
   vpc_id          = "${aws_vpc.network.id}"
   subnet_ids      = ["${aws_subnet.public.*.id}"]
   security_groups = ["${aws_security_group.worker.id}"]
-  count           = "${var.worker_count}"
+  worker_count           = "${var.worker_count}"
   instance_type   = "${var.worker_type}"
   os_image        = "${var.os_image}"
   disk_size       = "${var.disk_size}"

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -4,14 +4,14 @@ module "workers" {
 
   # AWS
   vpc_id          = aws_vpc.network.id
-  subnet_ids      = [aws_subnet.public.*.id]
+  subnet_ids      = aws_subnet.public.*.id
   security_groups = [aws_security_group.worker.id]
   worker_count    = var.worker_count
   instance_type   = var.worker_type
   os_image        = var.os_image
   disk_size       = var.disk_size
   spot_price      = var.worker_price
-  target_groups   = [var.worker_target_groups]
+  target_groups   = var.worker_target_groups
 
   # configuration
   kubeconfig            = module.bootkube.kubeconfig-kubelet

--- a/aws/flatcar-linux/kubernetes/workers/ami.tf
+++ b/aws/flatcar-linux/kubernetes/workers/ami.tf
@@ -4,8 +4,8 @@ locals {
   # flatcar-stable -> Flatcar Linux AMI
   ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
 
-  flavor  = element(split("-", var.os_image), 0)
-  channel = element(split("-", var.os_image), 1)
+  flavor  = split("-", var.os_image)[0]
+  channel = split("-", var.os_image)[1]
 }
 
 data "aws_ami" "coreos" {

--- a/aws/flatcar-linux/kubernetes/workers/ami.tf
+++ b/aws/flatcar-linux/kubernetes/workers/ami.tf
@@ -2,10 +2,10 @@ locals {
   # Pick a CoreOS Container Linux derivative
   # coreos-stable -> Container Linux AMI
   # flatcar-stable -> Flatcar Linux AMI
-  ami_id = "${local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id}"
+  ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
 
-  flavor  = "${element(split("-", var.os_image), 0)}"
-  channel = "${element(split("-", var.os_image), 1)}"
+  flavor  = element(split("-", var.os_image), 0)
+  channel = element(split("-", var.os_image), 1)
 }
 
 data "aws_ami" "coreos" {
@@ -47,3 +47,4 @@ data "aws_ami" "flatcar" {
     values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-*"]
   }
 }
+

--- a/aws/flatcar-linux/kubernetes/workers/ingress.tf
+++ b/aws/flatcar-linux/kubernetes/workers/ingress.tf
@@ -2,7 +2,7 @@
 
 resource "aws_lb_target_group" "workers-http" {
   name        = "${var.name}-workers-http"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
   target_type = "instance"
 
   protocol = "TCP"
@@ -25,7 +25,7 @@ resource "aws_lb_target_group" "workers-http" {
 
 resource "aws_lb_target_group" "workers-https" {
   name        = "${var.name}-workers-https"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
   target_type = "instance"
 
   protocol = "TCP"
@@ -45,3 +45,4 @@ resource "aws_lb_target_group" "workers-https" {
     interval = 10
   }
 }
+

--- a/aws/flatcar-linux/kubernetes/workers/outputs.tf
+++ b/aws/flatcar-linux/kubernetes/workers/outputs.tf
@@ -1,9 +1,10 @@
 output "target_group_http" {
   description = "ARN of a target group of workers for HTTP traffic"
-  value       = "${aws_lb_target_group.workers-http.arn}"
+  value       = aws_lb_target_group.workers-http.arn
 }
 
 output "target_group_https" {
   description = "ARN of a target group of workers for HTTPS traffic"
-  value       = "${aws_lb_target_group.workers-https.arn}"
+  value       = aws_lb_target_group.workers-https.arn
 }
+

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -1,77 +1,77 @@
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Unique name for the worker pool"
 }
 
 # AWS
 
 variable "vpc_id" {
-  type        = "string"
+  type        = string
   description = "Must be set to `vpc_id` output by cluster"
 }
 
 variable "subnet_ids" {
-  type        = "list"
+  type        = list(string)
   description = "Must be set to `subnet_ids` output by cluster"
 }
 
 variable "security_groups" {
-  type        = "list"
+  type        = list(string)
   description = "Must be set to `worker_security_groups` output by cluster"
 }
 
 # instances
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of instances"
 }
 
 variable "instance_type" {
-  type        = "string"
+  type        = string
   default     = "t3.small"
   description = "EC2 instance type"
 }
 
 variable "os_image" {
-  type        = "string"
+  type        = string
   default     = "flatcar-stable"
   description = "AMI channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
 }
 
 variable "disk_size" {
-  type        = "string"
+  type        = string
   default     = "40"
   description = "Size of the EBS volume in GB"
 }
 
 variable "disk_type" {
-  type        = "string"
+  type        = string
   default     = "gp2"
   description = "Type of the EBS volume (e.g. standard, gp2, io1)"
 }
 
 variable "disk_iops" {
-  type        = "string"
+  type        = string
   default     = "0"
   description = "IOPS of the EBS volume (required for io1)"
 }
 
 variable "spot_price" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Spot price in USD for autoscaling group spot instances. Leave as default empty string for autoscaling group to use on-demand instances. Note, switching in-place from spot to on-demand is not possible: https://github.com/terraform-providers/terraform-provider-aws/issues/4320"
 }
 
 variable "target_groups" {
-  type        = "list"
+  type        = list(string)
   description = "Additional target group ARNs to which instances should be added"
   default     = []
 }
 
 variable "clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Container Linux Config snippets"
   default     = []
 }
@@ -79,12 +79,12 @@ variable "clc_snippets" {
 # configuration
 
 variable "kubeconfig" {
-  type        = "string"
+  type        = string
   description = "Must be set to `kubeconfig` output by cluster"
 }
 
 variable "ssh_authorized_key" {
-  type        = "string"
+  type        = string
   description = "SSH public key for user 'core'"
 }
 
@@ -94,12 +94,14 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
-  default     = "cluster.local"
+  type = string
+  default = "cluster.local"
 }
+

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -22,7 +22,7 @@ variable "security_groups" {
 
 # instances
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of instances"

--- a/aws/flatcar-linux/kubernetes/workers/versions.tf
+++ b/aws/flatcar-linux/kubernetes/workers/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -3,9 +3,9 @@ resource "aws_autoscaling_group" "workers" {
   name = "${var.name}-worker ${aws_launch_configuration.worker.name}"
 
   # count
-  desired_capacity          = "${var.count}"
-  min_size                  = "${var.count}"
-  max_size                  = "${var.count + 2}"
+  desired_capacity          = "${var.worker_count}"
+  min_size                  = "${var.worker_count}"
+  max_size                  = "${var.worker_count + 2}"
   default_cooldown          = 30
   health_check_grace_period = 30
 

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -16,11 +16,11 @@ resource "aws_autoscaling_group" "workers" {
   launch_configuration = aws_launch_configuration.worker.name
 
   # target groups to which instances should be added
-  target_group_arns = [
+  target_group_arns = flatten([
     aws_lb_target_group.workers-http.id,
     aws_lb_target_group.workers-https.id,
     var.target_groups,
-  ]
+  ])
 
   lifecycle {
     # override the default destroy and replace update behavior

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -3,23 +3,23 @@ resource "aws_autoscaling_group" "workers" {
   name = "${var.name}-worker ${aws_launch_configuration.worker.name}"
 
   # count
-  desired_capacity          = "${var.worker_count}"
-  min_size                  = "${var.worker_count}"
-  max_size                  = "${var.worker_count + 2}"
+  desired_capacity          = var.worker_count
+  min_size                  = var.worker_count
+  max_size                  = var.worker_count + 2
   default_cooldown          = 30
   health_check_grace_period = 30
 
   # network
-  vpc_zone_identifier = ["${var.subnet_ids}"]
+  vpc_zone_identifier = var.subnet_ids
 
   # template
-  launch_configuration = "${aws_launch_configuration.worker.name}"
+  launch_configuration = aws_launch_configuration.worker.name
 
   # target groups to which instances should be added
   target_group_arns = [
-    "${aws_lb_target_group.workers-http.id}",
-    "${aws_lb_target_group.workers-https.id}",
-    "${var.target_groups}",
+    aws_lb_target_group.workers-http.id,
+    aws_lb_target_group.workers-https.id,
+    var.target_groups,
   ]
 
   lifecycle {
@@ -33,54 +33,57 @@ resource "aws_autoscaling_group" "workers" {
   # used. Disable wait to avoid issues and align with other clouds.
   wait_for_capacity_timeout = "0"
 
-  tags = [{
-    key                 = "Name"
-    value               = "${var.name}-worker"
-    propagate_at_launch = true
-  }]
+  tags = [
+    {
+      key                 = "Name"
+      value               = "${var.name}-worker"
+      propagate_at_launch = true
+    },
+  ]
 }
 
 # Worker template
 resource "aws_launch_configuration" "worker" {
-  image_id          = "${local.ami_id}"
-  instance_type     = "${var.instance_type}"
-  spot_price        = "${var.spot_price}"
+  image_id          = local.ami_id
+  instance_type     = var.instance_type
+  spot_price        = var.spot_price
   enable_monitoring = false
 
-  user_data = "${data.ct_config.worker-ignition.rendered}"
+  user_data = data.ct_config.worker-ignition.rendered
 
   # storage
   root_block_device {
-    volume_type = "${var.disk_type}"
-    volume_size = "${var.disk_size}"
-    iops        = "${var.disk_iops}"
+    volume_type = var.disk_type
+    volume_size = var.disk_size
+    iops        = var.disk_iops
   }
 
   # network
-  security_groups = ["${var.security_groups}"]
+  security_groups = var.security_groups
 
   lifecycle {
     // Override the default destroy and replace update behavior
     create_before_destroy = true
-    ignore_changes        = ["image_id"]
+    ignore_changes        = [image_id]
   }
 }
 
 # Worker Ignition config
 data "ct_config" "worker-ignition" {
-  content      = "${data.template_file.worker-config.rendered}"
+  content      = data.template_file.worker-config.rendered
   pretty_print = false
-  snippets     = ["${var.clc_snippets}"]
+  snippets     = var.clc_snippets
 }
 
 # Worker Container Linux config
 data "template_file" "worker-config" {
-  template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
+  template = file("${path.module}/cl/worker.yaml.tmpl")
 
   vars = {
-    kubeconfig             = "${indent(10, var.kubeconfig)}"
-    ssh_authorized_key     = "${var.ssh_authorized_key}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    kubeconfig             = indent(10, var.kubeconfig)
+    ssh_authorized_key     = var.ssh_authorized_key
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
+

--- a/azure/flatcar-linux/kubernetes/bootkube.tf
+++ b/azure/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/kinvolk/terraform-render-bootkube.git?ref=d07243a9e7f6084cfe08b708731a79c26146badb"
+  source = "git::https://github.com/kinvolk/terraform-render-bootkube.git?ref=9c1ff5a9e8b3e98922980a097c49c8b3a903437a"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/azure/flatcar-linux/kubernetes/bootkube.tf
+++ b/azure/flatcar-linux/kubernetes/bootkube.tf
@@ -2,14 +2,15 @@
 module "bootkube" {
   source = "git::https://github.com/kinvolk/terraform-render-bootkube.git?ref=9c1ff5a9e8b3e98922980a097c49c8b3a903437a"
 
-  cluster_name          = "${var.cluster_name}"
-  api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers          = ["${formatlist("%s.%s", azurerm_dns_a_record.etcds.*.name, var.dns_zone)}"]
-  asset_dir             = "${var.asset_dir}"
+  cluster_name          = var.cluster_name
+  api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  etcd_servers          = formatlist("%s.%s", azurerm_dns_a_record.etcds.*.name, var.dns_zone)
+  asset_dir             = var.asset_dir
   networking            = "flannel"
-  pod_cidr              = "${var.pod_cidr}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  enable_reporting      = "${var.enable_reporting}"
-  enable_aggregation    = "${var.enable_aggregation}"
+  pod_cidr              = var.pod_cidr
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  enable_reporting      = var.enable_reporting
+  enable_aggregation    = var.enable_aggregation
 }
+

--- a/azure/flatcar-linux/kubernetes/controllers.tf
+++ b/azure/flatcar-linux/kubernetes/controllers.tf
@@ -11,16 +11,13 @@ resource "azurerm_dns_a_record" "etcds" {
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = [element(
-    azurerm_network_interface.controllers.*.private_ip_address,
-    count.index,
-  )]
+  records = [azurerm_network_interface.controllers[count.index].private_ip_address]
 }
 
 locals {
   # Channel for a Container Linux derivative
   # coreos-stable -> Container Linux Stable
-  channel = element(split("-", var.os_image), 1)
+  channel = split("-", var.os_image)[1]
 }
 
 # Controller availability set to spread controllers
@@ -65,12 +62,12 @@ resource "azurerm_virtual_machine" "controllers" {
   }
 
   # network
-  network_interface_ids = [element(azurerm_network_interface.controllers.*.id, count.index)]
+  network_interface_ids = [azurerm_network_interface.controllers[count.index].id]
 
   os_profile {
     computer_name  = "${var.cluster_name}-controller-${count.index}"
     admin_username = "core"
-    custom_data    = element(data.ct_config.controller-ignitions.*.rendered, count.index)
+    custom_data    = data.ct_config.controller-ignitions[count.index].rendered
   }
 
   # Azure mandates setting an ssh_key, even though Ignition custom_data handles it too
@@ -110,7 +107,7 @@ resource "azurerm_network_interface" "controllers" {
     private_ip_address_allocation = "dynamic"
 
     # public IPv4
-    public_ip_address_id = element(azurerm_public_ip.controllers.*.id, count.index)
+    public_ip_address_id = azurerm_public_ip.controllers[count.index].id
   }
 }
 
@@ -135,10 +132,7 @@ resource "azurerm_public_ip" "controllers" {
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
   count = var.controller_count
-  content = element(
-    data.template_file.controller-configs.*.rendered,
-    count.index,
-  )
+  content = data.template_file.controller-configs[count.index].rendered
   pretty_print = false
   snippets     = var.controller_clc_snippets
 }

--- a/azure/flatcar-linux/kubernetes/controllers.tf
+++ b/azure/flatcar-linux/kubernetes/controllers.tf
@@ -1,54 +1,57 @@
 # Discrete DNS records for each controller's private IPv4 for etcd usage
 resource "azurerm_dns_a_record" "etcds" {
-  count               = "${var.controller_count}"
-  resource_group_name = "${var.dns_zone_group}"
+  count               = var.controller_count
+  resource_group_name = var.dns_zone_group
 
   # DNS Zone name where record should be created
-  zone_name = "${var.dns_zone}"
+  zone_name = var.dns_zone
 
   # DNS record
-  name = "${format("%s-etcd%d", var.cluster_name, count.index)}"
+  name = format("%s-etcd%d", var.cluster_name, count.index)
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = ["${element(azurerm_network_interface.controllers.*.private_ip_address, count.index)}"]
+  records = [element(
+    azurerm_network_interface.controllers.*.private_ip_address,
+    count.index,
+  )]
 }
 
 locals {
   # Channel for a Container Linux derivative
   # coreos-stable -> Container Linux Stable
-  channel = "${element(split("-", var.os_image), 1)}"
+  channel = element(split("-", var.os_image), 1)
 }
 
 # Controller availability set to spread controllers
 resource "azurerm_availability_set" "controllers" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                         = "${var.cluster_name}-controllers"
-  location                     = "${var.region}"
+  location                     = var.region
   platform_fault_domain_count  = 2
   platform_update_domain_count = 4
   managed                      = true
 }
 
 data "azurerm_image" "custom" {
-  name                = "${var.custom_image_name}"
-  resource_group_name = "${var.custom_image_resource_group_name}"
+  name                = var.custom_image_name
+  resource_group_name = var.custom_image_resource_group_name
 }
 
 # Controller instances
 resource "azurerm_virtual_machine" "controllers" {
-  count               = "${var.controller_count}"
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  count               = var.controller_count
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                = "${var.cluster_name}-controller-${count.index}"
-  location            = "${var.region}"
-  availability_set_id = "${azurerm_availability_set.controllers.id}"
-  vm_size             = "${var.controller_type}"
+  location            = var.region
+  availability_set_id = azurerm_availability_set.controllers.id
+  vm_size             = var.controller_type
 
   # boot
   storage_image_reference {
-    id = "${data.azurerm_image.custom.id}"
+    id = data.azurerm_image.custom.id
   }
 
   # storage
@@ -56,18 +59,18 @@ resource "azurerm_virtual_machine" "controllers" {
     name              = "${var.cluster_name}-controller-${count.index}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
-    disk_size_gb      = "${var.disk_size}"
+    disk_size_gb      = var.disk_size
     os_type           = "Linux"
     managed_disk_type = "Premium_LRS"
   }
 
   # network
-  network_interface_ids = ["${element(azurerm_network_interface.controllers.*.id, count.index)}"]
+  network_interface_ids = [element(azurerm_network_interface.controllers.*.id, count.index)]
 
   os_profile {
     computer_name  = "${var.cluster_name}-controller-${count.index}"
     admin_username = "core"
-    custom_data    = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+    custom_data    = element(data.ct_config.controller-ignitions.*.rendered, count.index)
   }
 
   # Azure mandates setting an ssh_key, even though Ignition custom_data handles it too
@@ -76,7 +79,7 @@ resource "azurerm_virtual_machine" "controllers" {
 
     ssh_keys {
       path     = "/home/core/.ssh/authorized_keys"
-      key_data = "${var.ssh_authorized_key}"
+      key_data = var.ssh_authorized_key
     }
   }
 
@@ -86,85 +89,87 @@ resource "azurerm_virtual_machine" "controllers" {
 
   lifecycle {
     ignore_changes = [
-      "storage_os_disk",
-      "os_profile",
+      storage_os_disk,
+      os_profile,
     ]
   }
 }
 
 # Controller NICs with public and private IPv4
 resource "azurerm_network_interface" "controllers" {
-  count               = "${var.controller_count}"
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  count               = var.controller_count
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                      = "${var.cluster_name}-controller-${count.index}"
-  location                  = "${azurerm_resource_group.cluster.location}"
-  network_security_group_id = "${azurerm_network_security_group.controller.id}"
+  location                  = azurerm_resource_group.cluster.location
+  network_security_group_id = azurerm_network_security_group.controller.id
 
   ip_configuration {
     name                          = "ip0"
-    subnet_id                     = "${azurerm_subnet.controller.id}"
+    subnet_id                     = azurerm_subnet.controller.id
     private_ip_address_allocation = "dynamic"
 
     # public IPv4
-    public_ip_address_id = "${element(azurerm_public_ip.controllers.*.id, count.index)}"
+    public_ip_address_id = element(azurerm_public_ip.controllers.*.id, count.index)
   }
 }
 
 # Add controller NICs to the controller backend address pool
 resource "azurerm_network_interface_backend_address_pool_association" "controllers" {
-  network_interface_id    = "${azurerm_network_interface.controllers.id}"
+  network_interface_id    = azurerm_network_interface.controllers[0].id
   ip_configuration_name   = "ip0"
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.controller.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.controller.id
 }
 
 # Controller public IPv4 addresses
 resource "azurerm_public_ip" "controllers" {
-  count               = "${var.controller_count}"
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  count               = var.controller_count
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name              = "${var.cluster_name}-controller-${count.index}"
-  location          = "${azurerm_resource_group.cluster.location}"
+  location          = azurerm_resource_group.cluster.location
   sku               = "Standard"
   allocation_method = "Static"
 }
 
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
-  count        = "${var.controller_count}"
-  content      = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  count = var.controller_count
+  content = element(
+    data.template_file.controller-configs.*.rendered,
+    count.index,
+  )
   pretty_print = false
-  snippets     = ["${var.controller_clc_snippets}"]
+  snippets     = var.controller_clc_snippets
 }
 
 # Controller Container Linux configs
 data "template_file" "controller-configs" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
-  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+  template = file("${path.module}/cl/controller.yaml.tmpl")
 
   vars = {
     # Cannot use cyclic dependencies on controllers or their DNS records
     etcd_name   = "etcd${count.index}"
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
-
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
-
-    kubeconfig             = "${indent(10, module.bootkube.kubeconfig-kubelet)}"
-    ssh_authorized_key     = "${var.ssh_authorized_key}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    etcd_initial_cluster   = join(",", data.template_file.etcds.*.rendered)
+    kubeconfig             = indent(10, module.bootkube.kubeconfig-kubelet)
+    ssh_authorized_key     = var.ssh_authorized_key
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
 
 data "template_file" "etcds" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
   vars = {
-    index        = "${count.index}"
-    cluster_name = "${var.cluster_name}"
-    dns_zone     = "${var.dns_zone}"
+    index        = count.index
+    cluster_name = var.cluster_name
+    dns_zone     = var.dns_zone
   }
 }
+

--- a/azure/flatcar-linux/kubernetes/controllers.tf
+++ b/azure/flatcar-linux/kubernetes/controllers.tf
@@ -131,8 +131,8 @@ resource "azurerm_public_ip" "controllers" {
 
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
-  count = var.controller_count
-  content = data.template_file.controller-configs[count.index].rendered
+  count        = var.controller_count
+  content      = data.template_file.controller-configs[count.index].rendered
   pretty_print = false
   snippets     = var.controller_clc_snippets
 }

--- a/azure/flatcar-linux/kubernetes/lb.tf
+++ b/azure/flatcar-linux/kubernetes/lb.tf
@@ -1,123 +1,123 @@
 # DNS record for the apiserver load balancer
 resource "azurerm_dns_a_record" "apiserver" {
-  resource_group_name = "${var.dns_zone_group}"
+  resource_group_name = var.dns_zone_group
 
   # DNS Zone name where record should be created
-  zone_name = "${var.dns_zone}"
+  zone_name = var.dns_zone
 
   # DNS record
-  name = "${var.cluster_name}"
+  name = var.cluster_name
   ttl  = 300
 
   # IPv4 address of apiserver load balancer
-  records = ["${azurerm_public_ip.apiserver-ipv4.ip_address}"]
+  records = [azurerm_public_ip.apiserver-ipv4.ip_address]
 }
 
 # Static IPv4 address for the apiserver frontend
 resource "azurerm_public_ip" "apiserver-ipv4" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name              = "${var.cluster_name}-apiserver-ipv4"
-  location          = "${var.region}"
+  location          = var.region
   sku               = "Standard"
   allocation_method = "Static"
 }
 
 # Static IPv4 address for the ingress frontend
 resource "azurerm_public_ip" "ingress-ipv4" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name              = "${var.cluster_name}-ingress-ipv4"
-  location          = "${var.region}"
+  location          = var.region
   sku               = "Standard"
   allocation_method = "Static"
 }
 
 # Network Load Balancer for apiservers and ingress
 resource "azurerm_lb" "cluster" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
-  name     = "${var.cluster_name}"
-  location = "${var.region}"
+  name     = var.cluster_name
+  location = var.region
   sku      = "Standard"
 
   frontend_ip_configuration {
     name                 = "apiserver"
-    public_ip_address_id = "${azurerm_public_ip.apiserver-ipv4.id}"
+    public_ip_address_id = azurerm_public_ip.apiserver-ipv4.id
   }
 
   frontend_ip_configuration {
     name                 = "ingress"
-    public_ip_address_id = "${azurerm_public_ip.ingress-ipv4.id}"
+    public_ip_address_id = azurerm_public_ip.ingress-ipv4.id
   }
 }
 
 resource "azurerm_lb_rule" "apiserver" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                           = "apiserver"
-  loadbalancer_id                = "${azurerm_lb.cluster.id}"
+  loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "apiserver"
 
   protocol                = "Tcp"
   frontend_port           = 6443
   backend_port            = 6443
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.controller.id}"
-  probe_id                = "${azurerm_lb_probe.apiserver.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.controller.id
+  probe_id                = azurerm_lb_probe.apiserver.id
 }
 
 resource "azurerm_lb_rule" "ingress-http" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                           = "ingress-http"
-  loadbalancer_id                = "${azurerm_lb.cluster.id}"
+  loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "ingress"
 
   protocol                = "Tcp"
   frontend_port           = 80
   backend_port            = 80
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.worker.id}"
-  probe_id                = "${azurerm_lb_probe.ingress.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.worker.id
+  probe_id                = azurerm_lb_probe.ingress.id
 }
 
 resource "azurerm_lb_rule" "ingress-https" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                           = "ingress-https"
-  loadbalancer_id                = "${azurerm_lb.cluster.id}"
+  loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "ingress"
 
   protocol                = "Tcp"
   frontend_port           = 443
   backend_port            = 443
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.worker.id}"
-  probe_id                = "${azurerm_lb_probe.ingress.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.worker.id
+  probe_id                = azurerm_lb_probe.ingress.id
 }
 
 # Address pool of controllers
 resource "azurerm_lb_backend_address_pool" "controller" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name            = "controller"
-  loadbalancer_id = "${azurerm_lb.cluster.id}"
+  loadbalancer_id = azurerm_lb.cluster.id
 }
 
 # Address pool of workers
 resource "azurerm_lb_backend_address_pool" "worker" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name            = "worker"
-  loadbalancer_id = "${azurerm_lb.cluster.id}"
+  loadbalancer_id = azurerm_lb.cluster.id
 }
 
 # Health checks / probes
 
 # TCP health check for apiserver
 resource "azurerm_lb_probe" "apiserver" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name            = "apiserver"
-  loadbalancer_id = "${azurerm_lb.cluster.id}"
+  loadbalancer_id = azurerm_lb.cluster.id
   protocol        = "Tcp"
   port            = 6443
 
@@ -129,10 +129,10 @@ resource "azurerm_lb_probe" "apiserver" {
 
 # HTTP health check for ingress
 resource "azurerm_lb_probe" "ingress" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name            = "ingress"
-  loadbalancer_id = "${azurerm_lb.cluster.id}"
+  loadbalancer_id = azurerm_lb.cluster.id
   protocol        = "Http"
   port            = 10254
   request_path    = "/healthz"
@@ -142,3 +142,4 @@ resource "azurerm_lb_probe" "ingress" {
 
   interval_in_seconds = 5
 }
+

--- a/azure/flatcar-linux/kubernetes/network.tf
+++ b/azure/flatcar-linux/kubernetes/network.tf
@@ -1,15 +1,15 @@
 # Organize cluster into a resource group
 resource "azurerm_resource_group" "cluster" {
-  name     = "${var.cluster_name}"
-  location = "${var.region}"
+  name     = var.cluster_name
+  location = var.region
 }
 
 resource "azurerm_virtual_network" "network" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
-  name          = "${var.cluster_name}"
-  location      = "${azurerm_resource_group.cluster.location}"
-  address_space = ["${var.host_cidr}"]
+  name          = var.cluster_name
+  location      = azurerm_resource_group.cluster.location
+  address_space = [var.host_cidr]
 }
 
 # Subnets - separate subnets for controller and workers because Azure
@@ -17,17 +17,18 @@ resource "azurerm_virtual_network" "network" {
 # tags like GCP or security group membership like AWS
 
 resource "azurerm_subnet" "controller" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                 = "controller"
-  virtual_network_name = "${azurerm_virtual_network.network.name}"
-  address_prefix       = "${cidrsubnet(var.host_cidr, 1, 0)}"
+  virtual_network_name = azurerm_virtual_network.network.name
+  address_prefix       = cidrsubnet(var.host_cidr, 1, 0)
 }
 
 resource "azurerm_subnet" "worker" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                 = "worker"
-  virtual_network_name = "${azurerm_virtual_network.network.name}"
-  address_prefix       = "${cidrsubnet(var.host_cidr, 1, 1)}"
+  virtual_network_name = azurerm_virtual_network.network.name
+  address_prefix       = cidrsubnet(var.host_cidr, 1, 1)
 }
+

--- a/azure/flatcar-linux/kubernetes/outputs.tf
+++ b/azure/flatcar-linux/kubernetes/outputs.tf
@@ -1,55 +1,56 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin}"
+  value = module.bootkube.kubeconfig-admin
 }
 
 # Outputs for Kubernetes Ingress
 
 output "ingress_static_ipv4" {
-  value       = "${azurerm_public_ip.ingress-ipv4.ip_address}"
+  value       = azurerm_public_ip.ingress-ipv4.ip_address
   description = "IPv4 address of the load balancer for distributing traffic to Ingress controllers"
 }
 
 # Outputs for worker pools
 
 output "region" {
-  value = "${azurerm_resource_group.cluster.location}"
+  value = azurerm_resource_group.cluster.location
 }
 
 output "resource_group_name" {
-  value = "${azurerm_resource_group.cluster.name}"
+  value = azurerm_resource_group.cluster.name
 }
 
 output "subnet_id" {
-  value = "${azurerm_subnet.worker.id}"
+  value = azurerm_subnet.worker.id
 }
 
 output "security_group_id" {
-  value = "${azurerm_network_security_group.worker.id}"
+  value = azurerm_network_security_group.worker.id
 }
 
 output "kubeconfig" {
-  value = "${module.bootkube.kubeconfig-kubelet}"
+  value = module.bootkube.kubeconfig-kubelet
 }
 
 # Outputs for custom firewalling
 
 output "worker_security_group_name" {
-  value = "${azurerm_network_security_group.worker.name}"
+  value = azurerm_network_security_group.worker.name
 }
 
 output "worker_address_prefix" {
   description = "Worker network subnet CIDR address (for source/destination)"
-  value       = "${azurerm_subnet.worker.address_prefix}"
+  value       = azurerm_subnet.worker.address_prefix
 }
 
 # Outputs for custom load balancing
 
 output "loadbalancer_id" {
   description = "ID of the cluster load balancer"
-  value       = "${azurerm_lb.cluster.id}"
+  value       = azurerm_lb.cluster.id
 }
 
 output "backend_address_pool_id" {
   description = "ID of the worker backend address pool"
-  value       = "${azurerm_lb_backend_address_pool.worker.id}"
+  value       = azurerm_lb_backend_address_pool.worker.id
 }
+

--- a/azure/flatcar-linux/kubernetes/require.tf
+++ b/azure/flatcar-linux/kubernetes/require.tf
@@ -23,3 +23,4 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0.1"
 }
+

--- a/azure/flatcar-linux/kubernetes/require.tf
+++ b/azure/flatcar-linux/kubernetes/require.tf
@@ -17,7 +17,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {

--- a/azure/flatcar-linux/kubernetes/require.tf
+++ b/azure/flatcar-linux/kubernetes/require.tf
@@ -21,5 +21,5 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
 }

--- a/azure/flatcar-linux/kubernetes/require.tf
+++ b/azure/flatcar-linux/kubernetes/require.tf
@@ -13,7 +13,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "template" {

--- a/azure/flatcar-linux/kubernetes/security.tf
+++ b/azure/flatcar-linux/kubernetes/security.tf
@@ -1,17 +1,17 @@
 # Controller security group
 
 resource "azurerm_network_security_group" "controller" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name     = "${var.cluster_name}-controller"
-  location = "${azurerm_resource_group.cluster.location}"
+  location = azurerm_resource_group.cluster.location
 }
 
 resource "azurerm_network_security_rule" "controller-ssh" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-ssh"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2000"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -19,45 +19,45 @@ resource "azurerm_network_security_rule" "controller-ssh" {
   source_port_range           = "*"
   destination_port_range      = "22"
   source_address_prefix       = "*"
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 resource "azurerm_network_security_rule" "controller-etcd" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-etcd"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2005"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "2379-2380"
-  source_address_prefix       = "${azurerm_subnet.controller.address_prefix}"
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  source_address_prefix       = azurerm_subnet.controller.address_prefix
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 # Allow Prometheus to scrape etcd metrics
 resource "azurerm_network_security_rule" "controller-etcd-metrics" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-etcd-metrics"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2010"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "2381"
-  source_address_prefix       = "${azurerm_subnet.worker.address_prefix}"
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  source_address_prefix       = azurerm_subnet.worker.address_prefix
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 resource "azurerm_network_security_rule" "controller-apiserver" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-apiserver"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2015"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -65,46 +65,46 @@ resource "azurerm_network_security_rule" "controller-apiserver" {
   source_port_range           = "*"
   destination_port_range      = "6443"
   source_address_prefix       = "*"
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 resource "azurerm_network_security_rule" "controller-flannel" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-flannel"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2020"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Udp"
   source_port_range           = "*"
   destination_port_range      = "8472"
-  source_address_prefixes     = ["${azurerm_subnet.controller.address_prefix}", "${azurerm_subnet.worker.address_prefix}"]
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  source_address_prefixes     = [azurerm_subnet.controller.address_prefix, azurerm_subnet.worker.address_prefix]
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 # Allow Prometheus to scrape node-exporter daemonset
 resource "azurerm_network_security_rule" "controller-node-exporter" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-node-exporter"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2025"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "9100"
-  source_address_prefix       = "${azurerm_subnet.worker.address_prefix}"
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  source_address_prefix       = azurerm_subnet.worker.address_prefix
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 # Allow apiserver to access kubelet's for exec, log, port-forward
 resource "azurerm_network_security_rule" "controller-kubelet" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-kubelet"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2030"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -113,18 +113,18 @@ resource "azurerm_network_security_rule" "controller-kubelet" {
   destination_port_range      = "10250"
 
   # allow Prometheus to scrape kubelet metrics too
-  source_address_prefixes    = ["${azurerm_subnet.controller.address_prefix}", "${azurerm_subnet.worker.address_prefix}"]
-  destination_address_prefix = "${azurerm_subnet.controller.address_prefix}"
+  source_address_prefixes    = [azurerm_subnet.controller.address_prefix, azurerm_subnet.worker.address_prefix]
+  destination_address_prefix = azurerm_subnet.controller.address_prefix
 }
 
 # Override Azure AllowVNetInBound and AllowAzureLoadBalancerInBound
 # https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#default-security-rules
 
 resource "azurerm_network_security_rule" "controller-allow-loadblancer" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-loadbalancer"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "3000"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -136,10 +136,10 @@ resource "azurerm_network_security_rule" "controller-allow-loadblancer" {
 }
 
 resource "azurerm_network_security_rule" "controller-deny-all" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "deny-all"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "3005"
   access                      = "Deny"
   direction                   = "Inbound"
@@ -153,32 +153,32 @@ resource "azurerm_network_security_rule" "controller-deny-all" {
 # Worker security group
 
 resource "azurerm_network_security_group" "worker" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name     = "${var.cluster_name}-worker"
-  location = "${azurerm_resource_group.cluster.location}"
+  location = azurerm_resource_group.cluster.location
 }
 
 resource "azurerm_network_security_rule" "worker-ssh" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-ssh"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2000"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefix       = "${azurerm_subnet.controller.address_prefix}"
-  destination_address_prefix  = "${azurerm_subnet.worker.address_prefix}"
+  source_address_prefix       = azurerm_subnet.controller.address_prefix
+  destination_address_prefix  = azurerm_subnet.worker.address_prefix
 }
 
 resource "azurerm_network_security_rule" "worker-http" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-http"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2005"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -186,14 +186,14 @@ resource "azurerm_network_security_rule" "worker-http" {
   source_port_range           = "*"
   destination_port_range      = "80"
   source_address_prefix       = "*"
-  destination_address_prefix  = "${azurerm_subnet.worker.address_prefix}"
+  destination_address_prefix  = azurerm_subnet.worker.address_prefix
 }
 
 resource "azurerm_network_security_rule" "worker-https" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-https"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2010"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -201,46 +201,46 @@ resource "azurerm_network_security_rule" "worker-https" {
   source_port_range           = "*"
   destination_port_range      = "443"
   source_address_prefix       = "*"
-  destination_address_prefix  = "${azurerm_subnet.worker.address_prefix}"
+  destination_address_prefix  = azurerm_subnet.worker.address_prefix
 }
 
 resource "azurerm_network_security_rule" "worker-flannel" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-flannel"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2015"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Udp"
   source_port_range           = "*"
   destination_port_range      = "8472"
-  source_address_prefixes     = ["${azurerm_subnet.controller.address_prefix}", "${azurerm_subnet.worker.address_prefix}"]
-  destination_address_prefix  = "${azurerm_subnet.worker.address_prefix}"
+  source_address_prefixes     = [azurerm_subnet.controller.address_prefix, azurerm_subnet.worker.address_prefix]
+  destination_address_prefix  = azurerm_subnet.worker.address_prefix
 }
 
 # Allow Prometheus to scrape node-exporter daemonset
 resource "azurerm_network_security_rule" "worker-node-exporter" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-node-exporter"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2020"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "9100"
-  source_address_prefix       = "${azurerm_subnet.worker.address_prefix}"
-  destination_address_prefix  = "${azurerm_subnet.worker.address_prefix}"
+  source_address_prefix       = azurerm_subnet.worker.address_prefix
+  destination_address_prefix  = azurerm_subnet.worker.address_prefix
 }
 
 # Allow apiserver to access kubelet's for exec, log, port-forward
 resource "azurerm_network_security_rule" "worker-kubelet" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-kubelet"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2025"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -249,18 +249,18 @@ resource "azurerm_network_security_rule" "worker-kubelet" {
   destination_port_range      = "10250"
 
   # allow Prometheus to scrape kubelet metrics too
-  source_address_prefixes    = ["${azurerm_subnet.controller.address_prefix}", "${azurerm_subnet.worker.address_prefix}"]
-  destination_address_prefix = "${azurerm_subnet.worker.address_prefix}"
+  source_address_prefixes    = [azurerm_subnet.controller.address_prefix, azurerm_subnet.worker.address_prefix]
+  destination_address_prefix = azurerm_subnet.worker.address_prefix
 }
 
 # Override Azure AllowVNetInBound and AllowAzureLoadBalancerInBound
 # https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#default-security-rules
 
 resource "azurerm_network_security_rule" "worker-allow-loadblancer" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-loadbalancer"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "3000"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -272,10 +272,10 @@ resource "azurerm_network_security_rule" "worker-allow-loadblancer" {
 }
 
 resource "azurerm_network_security_rule" "worker-deny-all" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "deny-all"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "3005"
   access                      = "Deny"
   direction                   = "Inbound"
@@ -285,3 +285,4 @@ resource "azurerm_network_security_rule" "worker-deny-all" {
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
 }
+

--- a/azure/flatcar-linux/kubernetes/ssh.tf
+++ b/azure/flatcar-linux/kubernetes/ssh.tf
@@ -6,7 +6,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(azurerm_public_ip.controllers.*.ip_address, count.index)
+    host    = azurerm_public_ip.controllers[count.index].ip_address
     user    = "core"
     timeout = "15m"
   }
@@ -74,7 +74,7 @@ resource "null_resource" "bootkube-start" {
 
   connection {
     type    = "ssh"
-    host    = element(azurerm_public_ip.controllers.*.ip_address, 0)
+    host    = azurerm_public_ip.controllers[0].ip_address
     user    = "core"
     timeout = "15m"
   }

--- a/azure/flatcar-linux/kubernetes/ssh.tf
+++ b/azure/flatcar-linux/kubernetes/ssh.tf
@@ -1,50 +1,48 @@
 # Secure copy etcd TLS assets to controllers.
 resource "null_resource" "copy-controller-secrets" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
-  depends_on = [
-    "azurerm_virtual_machine.controllers",
-  ]
+  depends_on = [azurerm_virtual_machine.controllers]
 
   connection {
     type    = "ssh"
-    host    = "${element(azurerm_public_ip.controllers.*.ip_address, count.index)}"
+    host    = element(azurerm_public_ip.controllers.*.ip_address, count.index)
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_ca_cert}"
+    content     = module.bootkube.etcd_ca_cert
     destination = "$HOME/etcd-client-ca.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_cert}"
+    content     = module.bootkube.etcd_client_cert
     destination = "$HOME/etcd-client.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_key}"
+    content     = module.bootkube.etcd_client_key
     destination = "$HOME/etcd-client.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_cert}"
+    content     = module.bootkube.etcd_server_cert
     destination = "$HOME/etcd-server.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_key}"
+    content     = module.bootkube.etcd_server_key
     destination = "$HOME/etcd-server.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_cert}"
+    content     = module.bootkube.etcd_peer_cert
     destination = "$HOME/etcd-peer.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_key}"
+    content     = module.bootkube.etcd_peer_key
     destination = "$HOME/etcd-peer.key"
   }
 
@@ -68,21 +66,21 @@ resource "null_resource" "copy-controller-secrets" {
 # one-time self-hosted cluster bootstrapping.
 resource "null_resource" "bootkube-start" {
   depends_on = [
-    "module.bootkube",
-    "module.workers",
-    "azurerm_dns_a_record.apiserver",
-    "null_resource.copy-controller-secrets",
+    module.bootkube,
+    module.workers,
+    azurerm_dns_a_record.apiserver,
+    null_resource.copy-controller-secrets,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${element(azurerm_public_ip.controllers.*.ip_address, 0)}"
+    host    = element(azurerm_public_ip.controllers.*.ip_address, 0)
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    source      = "${var.asset_dir}"
+    source      = var.asset_dir
     destination = "$HOME/assets"
   }
 
@@ -93,3 +91,4 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
+

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -1,87 +1,87 @@
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
 # Azure
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "Azure Region (e.g. centralus , see `az account list-locations --output table`)"
 }
 
 variable "dns_zone" {
-  type        = "string"
+  type        = string
   description = "Azure DNS Zone (e.g. azure.example.com)"
 }
 
 variable "dns_zone_group" {
-  type        = "string"
+  type        = string
   description = "Resource group where the Azure DNS Zone resides (e.g. global)"
 }
 
 variable "custom_image_resource_group_name" {
-  type        = "string"
+  type        = string
   description = "The name of the Resource Group in which the Custom Image exists."
 }
 
 variable "custom_image_name" {
-  type        = "string"
+  type        = string
   description = "The name of the Custom Image to provision this Virtual Machine from."
 }
 
 # instances
 
 variable "controller_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of workers"
 }
 
 variable "controller_type" {
-  type        = "string"
+  type        = string
   default     = "Standard_DS1_v2"
   description = "Machine type for controllers (see `az vm list-skus --location centralus`)"
 }
 
 variable "worker_type" {
-  type        = "string"
+  type        = string
   default     = "Standard_F1"
   description = "Machine type for workers (see `az vm list-skus --location centralus`)"
 }
 
 variable "os_image" {
-  type        = "string"
+  type        = string
   default     = "coreos-stable"
   description = "Channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha)"
 }
 
 variable "disk_size" {
-  type        = "string"
+  type        = string
   default     = "40"
   description = "Size of the disk in GB"
 }
 
 variable "worker_priority" {
-  type        = "string"
+  type        = string
   default     = "Regular"
   description = "Set worker priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time."
 }
 
 variable "controller_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
 
 variable "worker_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Worker Container Linux Config snippets"
   default     = []
 }
@@ -89,24 +89,24 @@ variable "worker_clc_snippets" {
 # configuration
 
 variable "ssh_authorized_key" {
-  type        = "string"
+  type        = string
   description = "SSH public key for user 'core'"
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "host_cidr" {
   description = "CIDR IPv4 range to assign to instances"
-  type        = "string"
+  type        = string
   default     = "10.0.0.0/16"
 }
 
 variable "pod_cidr" {
   description = "CIDR IPv4 range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.2.0.0/16"
 }
 
@@ -116,24 +116,26 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
-  default     = "cluster.local"
+  type = string
+  default = "cluster.local"
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type = string
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = "false"
+  default = "false"
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = "string"
-  default     = "false"
+  type = string
+  default = "false"
 }
+

--- a/azure/flatcar-linux/kubernetes/versions.tf
+++ b/azure/flatcar-linux/kubernetes/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/azure/flatcar-linux/kubernetes/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers.tf
@@ -9,7 +9,7 @@ module "workers" {
   security_group_id       = "${azurerm_network_security_group.worker.id}"
   backend_address_pool_id = "${azurerm_lb_backend_address_pool.worker.id}"
 
-  count    = "${var.worker_count}"
+  worker_count    = "${var.worker_count}"
   vm_type  = "${var.worker_type}"
   os_image = "${var.os_image}"
   priority = "${var.worker_priority}"

--- a/azure/flatcar-linux/kubernetes/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers.tf
@@ -1,26 +1,27 @@
 module "workers" {
   source = "./workers"
-  name   = "${var.cluster_name}"
+  name   = var.cluster_name
 
   # Azure
-  resource_group_name     = "${azurerm_resource_group.cluster.name}"
-  region                  = "${azurerm_resource_group.cluster.location}"
-  subnet_id               = "${azurerm_subnet.worker.id}"
-  security_group_id       = "${azurerm_network_security_group.worker.id}"
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.worker.id}"
+  resource_group_name     = azurerm_resource_group.cluster.name
+  region                  = azurerm_resource_group.cluster.location
+  subnet_id               = azurerm_subnet.worker.id
+  security_group_id       = azurerm_network_security_group.worker.id
+  backend_address_pool_id = azurerm_lb_backend_address_pool.worker.id
 
-  worker_count    = "${var.worker_count}"
-  vm_type  = "${var.worker_type}"
-  os_image = "${var.os_image}"
-  priority = "${var.worker_priority}"
+  worker_count = var.worker_count
+  vm_type      = var.worker_type
+  os_image     = var.os_image
+  priority     = var.worker_priority
 
-  custom_image_resource_group_name = "${var.custom_image_resource_group_name}"
-  custom_image_name = "${var.custom_image_name}"
+  custom_image_resource_group_name = var.custom_image_resource_group_name
+  custom_image_name                = var.custom_image_name
 
   # configuration
-  kubeconfig            = "${module.bootkube.kubeconfig-kubelet}"
-  ssh_authorized_key    = "${var.ssh_authorized_key}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  clc_snippets          = "${var.worker_clc_snippets}"
+  kubeconfig            = module.bootkube.kubeconfig-kubelet
+  ssh_authorized_key    = var.ssh_authorized_key
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  clc_snippets          = var.worker_clc_snippets
 }
+

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -1,73 +1,73 @@
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Unique name for the worker pool"
 }
 
 # Azure
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "Must be set to the Azure Region of cluster"
 }
 
 variable "resource_group_name" {
-  type        = "string"
+  type        = string
   description = "Must be set to the resource group name of cluster"
 }
 
 variable "subnet_id" {
-  type        = "string"
+  type        = string
   description = "Must be set to the `worker_subnet_id` output by cluster"
 }
 
 variable "security_group_id" {
-  type        = "string"
+  type        = string
   description = "Must be set to the `worker_security_group_id` output by cluster"
 }
 
 variable "backend_address_pool_id" {
-  type        = "string"
+  type        = string
   description = "Must be set to the `worker_backend_address_pool_id` output by cluster"
 }
 
 variable "custom_image_resource_group_name" {
-  type        = "string"
+  type        = string
   description = "The name of the Resource Group in which the Custom Image exists."
 }
 
 variable "custom_image_name" {
-  type        = "string"
+  type        = string
   description = "The name of the Custom Image to provision this Virtual Machine from."
 }
 
 # instances
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of instances"
 }
 
 variable "vm_type" {
-  type        = "string"
+  type        = string
   default     = "Standard_F1"
   description = "Machine type for instances (see `az vm list-skus --location centralus`)"
 }
 
 variable "os_image" {
-  type        = "string"
+  type        = string
   default     = "coreos-stable"
   description = "Channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha)"
 }
 
 variable "priority" {
-  type        = "string"
+  type        = string
   default     = "Regular"
   description = "Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be evicted at any time."
 }
 
 variable "clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Container Linux Config snippets"
   default     = []
 }
@@ -75,12 +75,12 @@ variable "clc_snippets" {
 # configuration
 
 variable "kubeconfig" {
-  type        = "string"
+  type        = string
   description = "Must be set to `kubeconfig` output by cluster"
 }
 
 variable "ssh_authorized_key" {
-  type        = "string"
+  type        = string
   description = "SSH public key for user 'core'"
 }
 
@@ -90,12 +90,14 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
-  default     = "cluster.local"
+  type = string
+  default = "cluster.local"
 }
+

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -42,7 +42,7 @@ variable "custom_image_name" {
 
 # instances
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of instances"

--- a/azure/flatcar-linux/kubernetes/workers/versions.tf
+++ b/azure/flatcar-linux/kubernetes/workers/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,31 +1,31 @@
 locals {
   # Channel for a Container Linux derivative
   # coreos-stable -> Container Linux Stable
-  channel = "${element(split("-", var.os_image), 1)}"
+  channel = element(split("-", var.os_image), 1)
 }
 
 data "azurerm_image" "custom_workers" {
-  name                = "${var.custom_image_name}"
-  resource_group_name = "${var.custom_image_resource_group_name}"
+  name                = var.custom_image_name
+  resource_group_name = var.custom_image_resource_group_name
 }
 
 # Workers scale set
 resource "azurerm_virtual_machine_scale_set" "workers" {
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = var.resource_group_name
 
   name                   = "${var.name}-workers"
-  location               = "${var.region}"
+  location               = var.region
   single_placement_group = false
 
   sku {
-    name     = "${var.vm_type}"
+    name     = var.vm_type
     tier     = "standard"
-    capacity = "${var.worker_count}"
+    capacity = var.worker_count
   }
 
   # boot
   storage_profile_image_reference {
-    id = "${data.azurerm_image.custom_workers.id}"
+    id = data.azurerm_image.custom_workers.id
   }
 
   # storage
@@ -39,7 +39,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
   os_profile {
     computer_name_prefix = "${var.name}-worker-"
     admin_username       = "core"
-    custom_data          = "${data.ct_config.worker-ignition.rendered}"
+    custom_data          = data.ct_config.worker-ignition.rendered
   }
 
   # Azure mandates setting an ssh_key, even though Ignition custom_data handles it too
@@ -48,7 +48,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
 
     ssh_keys {
       path     = "/home/core/.ssh/authorized_keys"
-      key_data = "${var.ssh_authorized_key}"
+      key_data = var.ssh_authorized_key
     }
   }
 
@@ -56,61 +56,62 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
   network_profile {
     name                      = "nic0"
     primary                   = true
-    network_security_group_id = "${var.security_group_id}"
+    network_security_group_id = var.security_group_id
 
     ip_configuration {
       name      = "ip0"
       primary   = true
-      subnet_id = "${var.subnet_id}"
+      subnet_id = var.subnet_id
 
       # backend address pool to which the NIC should be added
-      load_balancer_backend_address_pool_ids = ["${var.backend_address_pool_id}"]
+      load_balancer_backend_address_pool_ids = [var.backend_address_pool_id]
     }
   }
 
   # lifecycle
   upgrade_policy_mode = "Manual"
-  priority            = "${var.priority}"
+  priority            = var.priority
   eviction_policy     = "Delete"
 }
 
 # Scale up or down to maintain desired number, tolerating deallocations.
 resource "azurerm_monitor_autoscale_setting" "workers" {
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = var.resource_group_name
 
   name     = "${var.name}-maintain-desired"
-  location = "${var.region}"
+  location = var.region
 
   # autoscale
   enabled            = true
-  target_resource_id = "${azurerm_virtual_machine_scale_set.workers.id}"
+  target_resource_id = azurerm_virtual_machine_scale_set.workers.id
 
   profile {
     name = "default"
 
     capacity {
-      minimum = "${var.worker_count}"
-      default = "${var.worker_count}"
-      maximum = "${var.worker_count}"
+      minimum = var.worker_count
+      default = var.worker_count
+      maximum = var.worker_count
     }
   }
 }
 
 # Worker Ignition configs
 data "ct_config" "worker-ignition" {
-  content      = "${data.template_file.worker-config.rendered}"
+  content      = data.template_file.worker-config.rendered
   pretty_print = false
-  snippets     = ["${var.clc_snippets}"]
+  snippets     = var.clc_snippets
 }
 
 # Worker Container Linux configs
 data "template_file" "worker-config" {
-  template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
+  template = file("${path.module}/cl/worker.yaml.tmpl")
 
   vars = {
-    kubeconfig             = "${indent(10, var.kubeconfig)}"
-    ssh_authorized_key     = "${var.ssh_authorized_key}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    kubeconfig             = indent(10, var.kubeconfig)
+    ssh_authorized_key     = var.ssh_authorized_key
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
+

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,7 +1,7 @@
 locals {
   # Channel for a Container Linux derivative
   # coreos-stable -> Container Linux Stable
-  channel = element(split("-", var.os_image), 1)
+  channel = split("-", var.os_image)[1]
 }
 
 data "azurerm_image" "custom_workers" {

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -20,7 +20,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
   sku {
     name     = "${var.vm_type}"
     tier     = "standard"
-    capacity = "${var.count}"
+    capacity = "${var.worker_count}"
   }
 
   # boot
@@ -89,9 +89,9 @@ resource "azurerm_monitor_autoscale_setting" "workers" {
     name = "default"
 
     capacity {
-      minimum = "${var.count}"
-      default = "${var.count}"
-      maximum = "${var.count}"
+      minimum = "${var.worker_count}"
+      default = "${var.worker_count}"
+      maximum = "${var.worker_count}"
     }
   }
 }

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -4,7 +4,7 @@ module "bootkube" {
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]
-  etcd_servers                    = [var.controller_domains]
+  etcd_servers                    = var.controller_domains
   asset_dir                       = var.asset_dir
   networking                      = var.networking
   network_mtu                     = var.network_mtu
@@ -15,4 +15,3 @@ module "bootkube" {
   enable_reporting                = var.enable_reporting
   enable_aggregation              = var.enable_aggregation
 }
-

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -2,16 +2,17 @@
 module "bootkube" {
   source = "github.com/kinvolk/terraform-render-bootkube?ref=9c1ff5a9e8b3e98922980a097c49c8b3a903437a"
 
-  cluster_name                    = "${var.cluster_name}"
-  api_servers                     = ["${var.k8s_domain_name}"]
-  etcd_servers                    = ["${var.controller_domains}"]
-  asset_dir                       = "${var.asset_dir}"
-  networking                      = "${var.networking}"
-  network_mtu                     = "${var.network_mtu}"
-  network_ip_autodetection_method = "${var.network_ip_autodetection_method}"
-  pod_cidr                        = "${var.pod_cidr}"
-  service_cidr                    = "${var.service_cidr}"
-  cluster_domain_suffix           = "${var.cluster_domain_suffix}"
-  enable_reporting                = "${var.enable_reporting}"
-  enable_aggregation              = "${var.enable_aggregation}"
+  cluster_name                    = var.cluster_name
+  api_servers                     = [var.k8s_domain_name]
+  etcd_servers                    = [var.controller_domains]
+  asset_dir                       = var.asset_dir
+  networking                      = var.networking
+  network_mtu                     = var.network_mtu
+  network_ip_autodetection_method = var.network_ip_autodetection_method
+  pod_cidr                        = var.pod_cidr
+  service_cidr                    = var.service_cidr
+  cluster_domain_suffix           = var.cluster_domain_suffix
+  enable_reporting                = var.enable_reporting
+  enable_aggregation              = var.enable_aggregation
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=d07243a9e7f6084cfe08b708731a79c26146badb"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=9c1ff5a9e8b3e98922980a097c49c8b3a903437a"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]

--- a/bare-metal/flatcar-linux/kubernetes/groups.tf
+++ b/bare-metal/flatcar-linux/kubernetes/groups.tf
@@ -1,33 +1,51 @@
 resource "matchbox_group" "install" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
+  count = length(var.controller_names) + length(var.worker_names)
 
-  name = "${format("install-%s", element(concat(var.controller_names, var.worker_names), count.index))}"
+  name = format(
+    "install-%s",
+    element(concat(var.controller_names, var.worker_names), count.index),
+  )
 
-  profile = "${local.flavor == "flatcar" ? var.cached_install == "true" ? element(matchbox_profile.cached-flatcar-linux-install.*.name, count.index) : element(matchbox_profile.flatcar-install.*.name, count.index) : var.cached_install == "true" ? element(matchbox_profile.cached-container-linux-install.*.name, count.index) : element(matchbox_profile.container-linux-install.*.name, count.index)}"
+  profile = local.flavor == "flatcar" ? var.cached_install == "true" ? element(
+    matchbox_profile.cached-flatcar-linux-install.*.name,
+    count.index,
+    ) : element(matchbox_profile.flatcar-install.*.name, count.index) : var.cached_install == "true" ? element(
+    matchbox_profile.cached-container-linux-install.*.name,
+    count.index,
+  ) : element(matchbox_profile.container-linux-install.*.name, count.index)
 
   selector = {
-    mac = "${element(concat(var.controller_macs, var.worker_macs), count.index)}"
+    mac = element(concat(var.controller_macs, var.worker_macs), count.index)
   }
 }
 
 resource "matchbox_group" "controller" {
-  count   = "${length(var.controller_names)}"
-  name    = "${format("%s-%s", var.cluster_name, element(var.controller_names, count.index))}"
-  profile = "${element(matchbox_profile.controllers.*.name, count.index)}"
+  count = length(var.controller_names)
+  name = format(
+    "%s-%s",
+    var.cluster_name,
+    element(var.controller_names, count.index),
+  )
+  profile = element(matchbox_profile.controllers.*.name, count.index)
 
   selector = {
-    mac = "${element(var.controller_macs, count.index)}"
+    mac = element(var.controller_macs, count.index)
     os  = "installed"
   }
 }
 
 resource "matchbox_group" "worker" {
-  count   = "${length(var.worker_names)}"
-  name    = "${format("%s-%s", var.cluster_name, element(var.worker_names, count.index))}"
-  profile = "${element(matchbox_profile.workers.*.name, count.index)}"
+  count = length(var.worker_names)
+  name = format(
+    "%s-%s",
+    var.cluster_name,
+    element(var.worker_names, count.index),
+  )
+  profile = element(matchbox_profile.workers.*.name, count.index)
 
   selector = {
-    mac = "${element(var.worker_macs, count.index)}"
+    mac = element(var.worker_macs, count.index)
     os  = "installed"
   }
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/groups.tf
+++ b/bare-metal/flatcar-linux/kubernetes/groups.tf
@@ -3,19 +3,13 @@ resource "matchbox_group" "install" {
 
   name = format(
     "install-%s",
-    element(concat(var.controller_names, var.worker_names), count.index),
+    concat(var.controller_names, var.worker_names)[count.index]
   )
 
-  profile = local.flavor == "flatcar" ? var.cached_install == "true" ? element(
-    matchbox_profile.cached-flatcar-linux-install.*.name,
-    count.index,
-    ) : element(matchbox_profile.flatcar-install.*.name, count.index) : var.cached_install == "true" ? element(
-    matchbox_profile.cached-container-linux-install.*.name,
-    count.index,
-  ) : element(matchbox_profile.container-linux-install.*.name, count.index)
+  profile = local.flavor == "flatcar" ? var.cached_install == "true" ? matchbox_profile.cached-flatcar-linux-install[count.index].name : matchbox_profile.flatcar-install[count.index].name : var.cached_install == "true" ? matchbox_profile.cached-container-linux-install[count.index].name : matchbox_profile.container-linux-install[count.index].name
 
   selector = {
-    mac = element(concat(var.controller_macs, var.worker_macs), count.index)
+    mac = concat(var.controller_macs, var.worker_macs)[count.index]
   }
 }
 
@@ -24,12 +18,12 @@ resource "matchbox_group" "controller" {
   name = format(
     "%s-%s",
     var.cluster_name,
-    element(var.controller_names, count.index),
+    var.controller_names[count.index]
   )
-  profile = element(matchbox_profile.controllers.*.name, count.index)
+  profile = matchbox_profile.controllers[count.index].name
 
   selector = {
-    mac = element(var.controller_macs, count.index)
+    mac = var.controller_macs[count.index]
     os  = "installed"
   }
 }
@@ -39,12 +33,12 @@ resource "matchbox_group" "worker" {
   name = format(
     "%s-%s",
     var.cluster_name,
-    element(var.worker_names, count.index),
+    var.worker_names[count.index]
   )
-  profile = element(matchbox_profile.workers.*.name, count.index)
+  profile = matchbox_profile.workers[count.index].name
 
   selector = {
-    mac = element(var.worker_macs, count.index)
+    mac = var.worker_macs[count.index]
     os  = "installed"
   }
 }

--- a/bare-metal/flatcar-linux/kubernetes/outputs.tf
+++ b/bare-metal/flatcar-linux/kubernetes/outputs.tf
@@ -1,3 +1,4 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin}"
+  value = module.bootkube.kubeconfig-admin
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -1,15 +1,19 @@
 locals {
   # coreos-stable -> coreos flavor, stable channel
   # flatcar-stable -> flatcar flavor, stable channel
-  flavor = "${element(split("-", var.os_channel), 0)}"
+  flavor = element(split("-", var.os_channel), 0)
 
-  channel = "${element(split("-", var.os_channel), 1)}"
+  channel = element(split("-", var.os_channel), 1)
 }
 
 // Container Linux Install profile (from release.core-os.net)
 resource "matchbox_profile" "container-linux-install" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
-  name  = "${format("%s-container-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))}"
+  count = length(var.controller_names) + length(var.worker_names)
+  name = format(
+    "%s-container-linux-install-%s",
+    var.cluster_name,
+    element(concat(var.controller_names, var.worker_names), count.index),
+  )
 
   kernel = "${var.download_protocol}://${local.channel}.release.core-os.net/amd64-usr/${var.os_version}/coreos_production_pxe.vmlinuz"
 
@@ -23,26 +27,28 @@ resource "matchbox_profile" "container-linux-install" {
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
-    "${var.kernel_args}",
+    var.kernel_args,
   ]
 
-  container_linux_config = "${element(data.template_file.container-linux-install-configs.*.rendered, count.index)}"
+  container_linux_config = element(
+    data.template_file.container-linux-install-configs.*.rendered,
+    count.index,
+  )
 }
 
 data "template_file" "container-linux-install-configs" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
+  count = length(var.controller_names) + length(var.worker_names)
 
-  template = "${file("${path.module}/cl/install.yaml.tmpl")}"
+  template = file("${path.module}/cl/install.yaml.tmpl")
 
   vars = {
-    os_flavor           = "${local.flavor}"
-    os_channel          = "${local.channel}"
-    os_version          = "${var.os_version}"
-    ignition_endpoint   = "${format("%s/ignition", var.matchbox_http_endpoint)}"
-    install_disk        = "${var.install_disk}"
-    container_linux_oem = "${var.container_linux_oem}"
-    ssh_authorized_key  = "${var.ssh_authorized_key}"
-
+    os_flavor           = local.flavor
+    os_channel          = local.channel
+    os_version          = var.os_version
+    ignition_endpoint   = format("%s/ignition", var.matchbox_http_endpoint)
+    install_disk        = var.install_disk
+    container_linux_oem = var.container_linux_oem
+    ssh_authorized_key  = var.ssh_authorized_key
     # only cached-container-linux profile adds -b baseurl
     baseurl_flag = ""
   }
@@ -51,8 +57,12 @@ data "template_file" "container-linux-install-configs" {
 // Container Linux Install profile (from matchbox /assets cache)
 // Note: Admin must have downloaded os_version into matchbox assets/coreos.
 resource "matchbox_profile" "cached-container-linux-install" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
-  name  = "${format("%s-cached-container-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))}"
+  count = length(var.controller_names) + length(var.worker_names)
+  name = format(
+    "%s-cached-container-linux-install-%s",
+    var.cluster_name,
+    element(concat(var.controller_names, var.worker_names), count.index),
+  )
 
   kernel = "/assets/coreos/${var.os_version}/coreos_production_pxe.vmlinuz"
 
@@ -66,26 +76,28 @@ resource "matchbox_profile" "cached-container-linux-install" {
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
-    "${var.kernel_args}",
+    var.kernel_args,
   ]
 
-  container_linux_config = "${element(data.template_file.cached-container-linux-install-configs.*.rendered, count.index)}"
+  container_linux_config = element(
+    data.template_file.cached-container-linux-install-configs.*.rendered,
+    count.index,
+  )
 }
 
 data "template_file" "cached-container-linux-install-configs" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
+  count = length(var.controller_names) + length(var.worker_names)
 
-  template = "${file("${path.module}/cl/install.yaml.tmpl")}"
+  template = file("${path.module}/cl/install.yaml.tmpl")
 
   vars = {
-    os_flavor           = "${local.flavor}"
-    os_channel          = "${local.channel}"
-    os_version          = "${var.os_version}"
-    ignition_endpoint   = "${format("%s/ignition", var.matchbox_http_endpoint)}"
-    install_disk        = "${var.install_disk}"
-    container_linux_oem = "${var.container_linux_oem}"
-    ssh_authorized_key  = "${var.ssh_authorized_key}"
-
+    os_flavor           = local.flavor
+    os_channel          = local.channel
+    os_version          = var.os_version
+    ignition_endpoint   = format("%s/ignition", var.matchbox_http_endpoint)
+    install_disk        = var.install_disk
+    container_linux_oem = var.container_linux_oem
+    ssh_authorized_key  = var.ssh_authorized_key
     # profile uses -b baseurl to install from matchbox cache
     baseurl_flag = "-b ${var.matchbox_http_endpoint}/assets/${local.flavor}"
   }
@@ -93,8 +105,12 @@ data "template_file" "cached-container-linux-install-configs" {
 
 // Flatcar Linux install profile (from release.flatcar-linux.net)
 resource "matchbox_profile" "flatcar-install" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
-  name  = "${format("%s-flatcar-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))}"
+  count = length(var.controller_names) + length(var.worker_names)
+  name = format(
+    "%s-flatcar-install-%s",
+    var.cluster_name,
+    element(concat(var.controller_names, var.worker_names), count.index),
+  )
 
   kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
 
@@ -108,17 +124,24 @@ resource "matchbox_profile" "flatcar-install" {
     "flatcar.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
-    "${var.kernel_args}",
+    var.kernel_args,
   ]
 
-  container_linux_config = "${element(data.template_file.container-linux-install-configs.*.rendered, count.index)}"
+  container_linux_config = element(
+    data.template_file.container-linux-install-configs.*.rendered,
+    count.index,
+  )
 }
 
 // Flatcar Linux Install profile (from matchbox /assets cache)
 // Note: Admin must have downloaded os_version into matchbox assets/flatcar.
 resource "matchbox_profile" "cached-flatcar-linux-install" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
-  name  = "${format("%s-cached-flatcar-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))}"
+  count = length(var.controller_names) + length(var.worker_names)
+  name = format(
+    "%s-cached-flatcar-linux-install-%s",
+    var.cluster_name,
+    element(concat(var.controller_names, var.worker_names), count.index),
+  )
 
   kernel = "/assets/flatcar/${var.os_version}/flatcar_production_pxe.vmlinuz"
 
@@ -132,69 +155,106 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     "flatcar.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
-    "${var.kernel_args}",
+    var.kernel_args,
   ]
 
-  container_linux_config = "${element(data.template_file.cached-container-linux-install-configs.*.rendered, count.index)}"
+  container_linux_config = element(
+    data.template_file.cached-container-linux-install-configs.*.rendered,
+    count.index,
+  )
 }
 
 // Kubernetes Controller profiles
 resource "matchbox_profile" "controllers" {
-  count        = "${length(var.controller_names)}"
-  name         = "${format("%s-controller-%s", var.cluster_name, element(var.controller_names, count.index))}"
-  raw_ignition = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+  count = length(var.controller_names)
+  name = format(
+    "%s-controller-%s",
+    var.cluster_name,
+    element(var.controller_names, count.index),
+  )
+  raw_ignition = element(data.ct_config.controller-ignitions.*.rendered, count.index)
 }
 
 data "ct_config" "controller-ignitions" {
-  count        = "${length(var.controller_names)}"
-  content      = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  count = length(var.controller_names)
+  content = element(
+    data.template_file.controller-configs.*.rendered,
+    count.index,
+  )
   pretty_print = false
 
   # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps
-  snippets = ["${local.clc_map[element(var.controller_names, count.index)]}"]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibilty in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  snippets = [local.clc_map[element(var.controller_names, count.index)]]
 }
 
 data "template_file" "controller-configs" {
-  count = "${length(var.controller_names)}"
+  count = length(var.controller_names)
 
-  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+  template = file("${path.module}/cl/controller.yaml.tmpl")
 
   vars = {
-    domain_name            = "${element(var.controller_domains, count.index)}"
-    etcd_name              = "${element(var.controller_names, count.index)}"
-    etcd_initial_cluster   = "${join(",", formatlist("%s=https://%s:2380", var.controller_names, var.controller_domains))}"
-    cluster_dns_service_ip = "${module.bootkube.cluster_dns_service_ip}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
-    ssh_authorized_key     = "${var.ssh_authorized_key}"
+    domain_name = element(var.controller_domains, count.index)
+    etcd_name   = element(var.controller_names, count.index)
+    etcd_initial_cluster = join(
+      ",",
+      formatlist(
+        "%s=https://%s:2380",
+        var.controller_names,
+        var.controller_domains,
+      ),
+    )
+    cluster_dns_service_ip = module.bootkube.cluster_dns_service_ip
+    cluster_domain_suffix  = var.cluster_domain_suffix
+    ssh_authorized_key     = var.ssh_authorized_key
   }
 }
 
 // Kubernetes Worker profiles
 resource "matchbox_profile" "workers" {
-  count        = "${length(var.worker_names)}"
-  name         = "${format("%s-worker-%s", var.cluster_name, element(var.worker_names, count.index))}"
-  raw_ignition = "${element(data.ct_config.worker-ignitions.*.rendered, count.index)}"
+  count = length(var.worker_names)
+  name = format(
+    "%s-worker-%s",
+    var.cluster_name,
+    element(var.worker_names, count.index),
+  )
+  raw_ignition = element(data.ct_config.worker-ignitions.*.rendered, count.index)
 }
 
 data "ct_config" "worker-ignitions" {
-  count        = "${length(var.worker_names)}"
-  content      = "${element(data.template_file.worker-configs.*.rendered, count.index)}"
+  count        = length(var.worker_names)
+  content      = element(data.template_file.worker-configs.*.rendered, count.index)
   pretty_print = false
 
   # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps
-  snippets = ["${local.clc_map[element(var.worker_names, count.index)]}"]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibilty in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  snippets = [local.clc_map[element(var.worker_names, count.index)]]
 }
 
 data "template_file" "worker-configs" {
-  count = "${length(var.worker_names)}"
+  count = length(var.worker_names)
 
-  template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
+  template = file("${path.module}/cl/worker.yaml.tmpl")
 
   vars = {
-    domain_name            = "${element(var.worker_domains, count.index)}"
-    cluster_dns_service_ip = "${module.bootkube.cluster_dns_service_ip}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
-    ssh_authorized_key     = "${var.ssh_authorized_key}"
+    domain_name            = element(var.worker_domains, count.index)
+    cluster_dns_service_ip = module.bootkube.cluster_dns_service_ip
+    cluster_domain_suffix  = var.cluster_domain_suffix
+    ssh_authorized_key     = var.ssh_authorized_key
   }
 }
 
@@ -202,14 +262,18 @@ locals {
   # Hack to workaround https://github.com/hashicorp/terraform/issues/17251
   # Default Container Linux config snippets map every node names to list("\n") so
   # all lookups succeed
-  clc_defaults = "${zipmap(concat(var.controller_names, var.worker_names), chunklist(data.template_file.clc-default-snippets.*.rendered, 1))}"
+  clc_defaults = zipmap(
+    concat(var.controller_names, var.worker_names),
+    chunklist(data.template_file.clc-default-snippets.*.rendered, 1),
+  )
 
   # Union of the default and user specific snippets, later overrides prior.
-  clc_map = "${merge(local.clc_defaults, var.clc_snippets)}"
+  clc_map = merge(local.clc_defaults, var.clc_snippets)
 }
 
 // Horrible hack to generate a Terraform list of node count length
 data "template_file" "clc-default-snippets" {
-  count    = "${length(var.controller_names) + length(var.worker_names)}"
+  count    = length(var.controller_names) + length(var.worker_names)
   template = "\n"
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -164,8 +164,8 @@ resource "matchbox_profile" "controllers" {
 }
 
 data "ct_config" "controller-ignitions" {
-  count = length(var.controller_names)
-  content = data.template_file.controller-configs[count.index].rendered
+  count        = length(var.controller_names)
+  content      = data.template_file.controller-configs[count.index].rendered
   pretty_print = false
 
   # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -1,9 +1,9 @@
 locals {
   # coreos-stable -> coreos flavor, stable channel
   # flatcar-stable -> flatcar flavor, stable channel
-  flavor = element(split("-", var.os_channel), 0)
+  flavor = split("-", var.os_channel)[0]
 
-  channel = element(split("-", var.os_channel), 1)
+  channel = split("-", var.os_channel)[1]
 }
 
 // Container Linux Install profile (from release.core-os.net)
@@ -12,7 +12,7 @@ resource "matchbox_profile" "container-linux-install" {
   name = format(
     "%s-container-linux-install-%s",
     var.cluster_name,
-    element(concat(var.controller_names, var.worker_names), count.index),
+    concat(var.controller_names, var.worker_names)[count.index]
   )
 
   kernel = "${var.download_protocol}://${local.channel}.release.core-os.net/amd64-usr/${var.os_version}/coreos_production_pxe.vmlinuz"
@@ -30,10 +30,7 @@ resource "matchbox_profile" "container-linux-install" {
     var.kernel_args,
   ])
 
-  container_linux_config = element(
-    data.template_file.container-linux-install-configs.*.rendered,
-    count.index,
-  )
+  container_linux_config = data.template_file.container-linux-install-configs[count.index].rendered
 }
 
 data "template_file" "container-linux-install-configs" {
@@ -61,7 +58,7 @@ resource "matchbox_profile" "cached-container-linux-install" {
   name = format(
     "%s-cached-container-linux-install-%s",
     var.cluster_name,
-    element(concat(var.controller_names, var.worker_names), count.index),
+    concat(var.controller_names, var.worker_names)[count.index]
   )
 
   kernel = "/assets/coreos/${var.os_version}/coreos_production_pxe.vmlinuz"
@@ -79,10 +76,7 @@ resource "matchbox_profile" "cached-container-linux-install" {
     var.kernel_args,
   ])
 
-  container_linux_config = element(
-    data.template_file.cached-container-linux-install-configs.*.rendered,
-    count.index,
-  )
+  container_linux_config = data.template_file.cached-container-linux-install-configs[count.index].rendered
 }
 
 data "template_file" "cached-container-linux-install-configs" {
@@ -109,7 +103,7 @@ resource "matchbox_profile" "flatcar-install" {
   name = format(
     "%s-flatcar-install-%s",
     var.cluster_name,
-    element(concat(var.controller_names, var.worker_names), count.index),
+    concat(var.controller_names, var.worker_names)[count.index]
   )
 
   kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
@@ -127,10 +121,7 @@ resource "matchbox_profile" "flatcar-install" {
     var.kernel_args,
   ])
 
-  container_linux_config = element(
-    data.template_file.container-linux-install-configs.*.rendered,
-    count.index,
-  )
+  container_linux_config = data.template_file.container-linux-install-configs[count.index].rendered
 }
 
 // Flatcar Linux Install profile (from matchbox /assets cache)
@@ -140,7 +131,7 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
   name = format(
     "%s-cached-flatcar-linux-install-%s",
     var.cluster_name,
-    element(concat(var.controller_names, var.worker_names), count.index),
+    concat(var.controller_names, var.worker_names)[count.index]
   )
 
   kernel = "/assets/flatcar/${var.os_version}/flatcar_production_pxe.vmlinuz"
@@ -158,10 +149,7 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     var.kernel_args,
   ])
 
-  container_linux_config = element(
-    data.template_file.cached-container-linux-install-configs.*.rendered,
-    count.index,
-  )
+  container_linux_config = data.template_file.cached-container-linux-install-configs[count.index].rendered
 }
 
 // Kubernetes Controller profiles
@@ -170,17 +158,14 @@ resource "matchbox_profile" "controllers" {
   name = format(
     "%s-controller-%s",
     var.cluster_name,
-    element(var.controller_names, count.index),
+    var.controller_names[count.index]
   )
-  raw_ignition = element(data.ct_config.controller-ignitions.*.rendered, count.index)
+  raw_ignition = data.ct_config.controller-ignitions[count.index].rendered
 }
 
 data "ct_config" "controller-ignitions" {
   count = length(var.controller_names)
-  content = element(
-    data.template_file.controller-configs.*.rendered,
-    count.index,
-  )
+  content = data.template_file.controller-configs[count.index].rendered
   pretty_print = false
 
   # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps
@@ -192,7 +177,7 @@ data "ct_config" "controller-ignitions" {
   # If the expression in the following list itself returns a list, remove the
   # brackets to avoid interpretation as a list of lists. If the expression
   # returns a single list item then leave it as-is and remove this TODO comment.
-  snippets = local.clc_map[element(var.controller_names, count.index)]
+  snippets = local.clc_map[var.controller_names[count.index]]
 }
 
 data "template_file" "controller-configs" {
@@ -201,8 +186,8 @@ data "template_file" "controller-configs" {
   template = file("${path.module}/cl/controller.yaml.tmpl")
 
   vars = {
-    domain_name = element(var.controller_domains, count.index)
-    etcd_name   = element(var.controller_names, count.index)
+    domain_name = var.controller_domains[count.index]
+    etcd_name   = var.controller_names[count.index]
     etcd_initial_cluster = join(
       ",",
       formatlist(
@@ -223,14 +208,14 @@ resource "matchbox_profile" "workers" {
   name = format(
     "%s-worker-%s",
     var.cluster_name,
-    element(var.worker_names, count.index),
+    var.worker_names[count.index]
   )
-  raw_ignition = element(data.ct_config.worker-ignitions.*.rendered, count.index)
+  raw_ignition = data.ct_config.worker-ignitions[count.index].rendered
 }
 
 data "ct_config" "worker-ignitions" {
   count        = length(var.worker_names)
-  content      = element(data.template_file.worker-configs.*.rendered, count.index)
+  content      = data.template_file.worker-configs[count.index].rendered
   pretty_print = false
 
   # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps
@@ -242,7 +227,7 @@ data "ct_config" "worker-ignitions" {
   # If the expression in the following list itself returns a list, remove the
   # brackets to avoid interpretation as a list of lists. If the expression
   # returns a single list item then leave it as-is and remove this TODO comment.
-  snippets = local.clc_map[element(var.worker_names, count.index)]
+  snippets = local.clc_map[var.worker_names[count.index]]
 }
 
 data "template_file" "worker-configs" {
@@ -251,7 +236,7 @@ data "template_file" "worker-configs" {
   template = file("${path.module}/cl/worker.yaml.tmpl")
 
   vars = {
-    domain_name            = element(var.worker_domains, count.index)
+    domain_name            = var.worker_domains[count.index]
     cluster_dns_service_ip = module.bootkube.cluster_dns_service_ip
     cluster_domain_suffix  = var.cluster_domain_suffix
     ssh_authorized_key     = var.ssh_authorized_key

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -21,14 +21,14 @@ resource "matchbox_profile" "container-linux-install" {
     "${var.download_protocol}://${local.channel}.release.core-os.net/amd64-usr/${var.os_version}/coreos_production_pxe_image.cpio.gz",
   ]
 
-  args = [
+  args = flatten([
     "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
     var.kernel_args,
-  ]
+  ])
 
   container_linux_config = element(
     data.template_file.container-linux-install-configs.*.rendered,
@@ -70,14 +70,14 @@ resource "matchbox_profile" "cached-container-linux-install" {
     "/assets/coreos/${var.os_version}/coreos_production_pxe_image.cpio.gz",
   ]
 
-  args = [
+  args = flatten([
     "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
     var.kernel_args,
-  ]
+  ])
 
   container_linux_config = element(
     data.template_file.cached-container-linux-install-configs.*.rendered,
@@ -118,14 +118,14 @@ resource "matchbox_profile" "flatcar-install" {
     "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
   ]
 
-  args = [
+  args = flatten([
     "initrd=flatcar_production_pxe_image.cpio.gz",
     "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "flatcar.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
     var.kernel_args,
-  ]
+  ])
 
   container_linux_config = element(
     data.template_file.container-linux-install-configs.*.rendered,
@@ -149,14 +149,14 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     "/assets/flatcar/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
   ]
 
-  args = [
+  args = flatten([
     "initrd=flatcar_production_pxe_image.cpio.gz",
     "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "flatcar.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
     var.kernel_args,
-  ]
+  ])
 
   container_linux_config = element(
     data.template_file.cached-container-linux-install-configs.*.rendered,
@@ -192,7 +192,7 @@ data "ct_config" "controller-ignitions" {
   # If the expression in the following list itself returns a list, remove the
   # brackets to avoid interpretation as a list of lists. If the expression
   # returns a single list item then leave it as-is and remove this TODO comment.
-  snippets = [local.clc_map[element(var.controller_names, count.index)]]
+  snippets = local.clc_map[element(var.controller_names, count.index)]
 }
 
 data "template_file" "controller-configs" {
@@ -242,7 +242,7 @@ data "ct_config" "worker-ignitions" {
   # If the expression in the following list itself returns a list, remove the
   # brackets to avoid interpretation as a list of lists. If the expression
   # returns a single list item then leave it as-is and remove this TODO comment.
-  snippets = [local.clc_map[element(var.worker_names, count.index)]]
+  snippets = local.clc_map[element(var.worker_names, count.index)]
 }
 
 data "template_file" "worker-configs" {

--- a/bare-metal/flatcar-linux/kubernetes/require.tf
+++ b/bare-metal/flatcar-linux/kubernetes/require.tf
@@ -13,7 +13,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {

--- a/bare-metal/flatcar-linux/kubernetes/require.tf
+++ b/bare-metal/flatcar-linux/kubernetes/require.tf
@@ -19,3 +19,4 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0.1"
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/require.tf
+++ b/bare-metal/flatcar-linux/kubernetes/require.tf
@@ -17,5 +17,5 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
 }

--- a/bare-metal/flatcar-linux/kubernetes/require.tf
+++ b/bare-metal/flatcar-linux/kubernetes/require.tf
@@ -9,7 +9,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "template" {

--- a/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -1,59 +1,59 @@
 # Secure copy etcd TLS assets and kubeconfig to controllers. Activates kubelet.service
 resource "null_resource" "copy-controller-secrets" {
-  count = "${length(var.controller_names)}"
+  count = length(var.controller_names)
 
   # Without depends_on, remote-exec could start and wait for machines before
   # matchbox groups are written, causing a deadlock.
   depends_on = [
-    "matchbox_group.install",
-    "matchbox_group.controller",
-    "matchbox_group.worker",
+    matchbox_group.install,
+    matchbox_group.controller,
+    matchbox_group.worker,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${element(var.controller_domains, count.index)}"
+    host    = element(var.controller_domains, count.index)
     user    = "core"
     timeout = "60m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.kubeconfig-kubelet}"
+    content     = module.bootkube.kubeconfig-kubelet
     destination = "$HOME/kubeconfig"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_ca_cert}"
+    content     = module.bootkube.etcd_ca_cert
     destination = "$HOME/etcd-client-ca.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_cert}"
+    content     = module.bootkube.etcd_client_cert
     destination = "$HOME/etcd-client.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_key}"
+    content     = module.bootkube.etcd_client_key
     destination = "$HOME/etcd-client.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_cert}"
+    content     = module.bootkube.etcd_server_cert
     destination = "$HOME/etcd-server.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_key}"
+    content     = module.bootkube.etcd_server_key
     destination = "$HOME/etcd-server.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_cert}"
+    content     = module.bootkube.etcd_peer_cert
     destination = "$HOME/etcd-peer.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_key}"
+    content     = module.bootkube.etcd_peer_key
     destination = "$HOME/etcd-peer.key"
   }
 
@@ -76,25 +76,25 @@ resource "null_resource" "copy-controller-secrets" {
 
 # Secure copy kubeconfig to all workers. Activates kubelet.service
 resource "null_resource" "copy-worker-secrets" {
-  count = "${length(var.worker_names)}"
+  count = length(var.worker_names)
 
   # Without depends_on, remote-exec could start and wait for machines before
   # matchbox groups are written, causing a deadlock.
   depends_on = [
-    "matchbox_group.install",
-    "matchbox_group.controller",
-    "matchbox_group.worker",
+    matchbox_group.install,
+    matchbox_group.controller,
+    matchbox_group.worker,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${element(var.worker_domains, count.index)}"
+    host    = element(var.worker_domains, count.index)
     user    = "core"
     timeout = "60m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.kubeconfig-kubelet}"
+    content     = module.bootkube.kubeconfig-kubelet
     destination = "$HOME/kubeconfig"
   }
 
@@ -112,19 +112,19 @@ resource "null_resource" "bootkube-start" {
   # Terraform only does one task at a time, so it would try to bootstrap
   # while no Kubelets are running.
   depends_on = [
-    "null_resource.copy-controller-secrets",
-    "null_resource.copy-worker-secrets",
+    null_resource.copy-controller-secrets,
+    null_resource.copy-worker-secrets,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${element(var.controller_domains, 0)}"
+    host    = element(var.controller_domains, 0)
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    source      = "${var.asset_dir}"
+    source      = var.asset_dir
     destination = "$HOME/assets"
   }
 
@@ -135,3 +135,4 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -12,7 +12,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(var.controller_domains, count.index)
+    host    = var.controller_domains[count.index]
     user    = "core"
     timeout = "60m"
   }
@@ -88,7 +88,7 @@ resource "null_resource" "copy-worker-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(var.worker_domains, count.index)
+    host    = var.worker_domains[count.index]
     user    = "core"
     timeout = "60m"
   }
@@ -118,7 +118,7 @@ resource "null_resource" "bootkube-start" {
 
   connection {
     type    = "ssh"
-    host    = element(var.controller_domains, 0)
+    host    = var.controller_domains[0]
     user    = "core"
     timeout = "15m"
   }

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -1,22 +1,22 @@
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name"
 }
 
 # bare-metal
 
 variable "matchbox_http_endpoint" {
-  type        = "string"
+  type        = string
   description = "Matchbox HTTP read-only endpoint (e.g. http://matchbox.example.com:8080)"
 }
 
 variable "os_channel" {
-  type        = "string"
+  type        = string
   description = "Channel for a Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
 }
 
 variable "os_version" {
-  type        = "string"
+  type        = string
   description = "Version for a Container Linux derivative to PXE and install (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
 }
 
@@ -24,37 +24,37 @@ variable "os_version" {
 # Terraform's crude "type system" does not properly support lists of maps so we do this.
 
 variable "controller_names" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of controller names (e.g. [node1])"
 }
 
 variable "controller_macs" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of controller identifying MAC addresses (e.g. [52:54:00:a1:9c:ae])"
 }
 
 variable "controller_domains" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of controller FQDNs (e.g. [node1.example.com])"
 }
 
 variable "worker_names" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of worker names (e.g. [node2, node3])"
 }
 
 variable "worker_macs" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of worker identifying MAC addresses (e.g. [52:54:00:b2:2f:86, 52:54:00:c3:61:77])"
 }
 
 variable "worker_domains" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of worker FQDNs (e.g. [node2.example.com, node3.example.com])"
 }
 
 variable "clc_snippets" {
-  type        = "map"
+  type        = map(string)
   description = "Map from machine names to lists of Container Linux Config snippets"
   default     = {}
 }
@@ -63,40 +63,40 @@ variable "clc_snippets" {
 
 variable "k8s_domain_name" {
   description = "Controller DNS name which resolves to a controller instance. Workers and kubeconfig's will communicate with this endpoint (e.g. cluster.example.com)"
-  type        = "string"
+  type        = string
 }
 
 variable "ssh_authorized_key" {
-  type        = "string"
+  type        = string
   description = "SSH public key for user 'core'"
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "networking" {
   description = "Choice of networking provider (flannel or calico)"
-  type        = "string"
+  type        = string
   default     = "calico"
 }
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only)"
-  type        = "string"
+  type        = string
   default     = "1480"
 }
 
 variable "network_ip_autodetection_method" {
   description = "Method to autodetect the host IPv4 address (applies to calico only)"
-  type        = "string"
+  type        = string
   default     = "first-found"
 }
 
 variable "pod_cidr" {
   description = "CIDR IPv4 range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.2.0.0/16"
 }
 
@@ -106,7 +106,8 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type = string
   default = "10.3.0.0/16"
 }
 
@@ -114,48 +115,49 @@ EOD
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
-  default     = "cluster.local"
+  type = string
+  default = "cluster.local"
 }
 
 variable "download_protocol" {
-  type        = "string"
-  default     = "https"
+  type = string
+  default = "https"
   description = "Protocol iPXE should use to download the kernel and initrd. Defaults to https, which requires iPXE compiled with crypto support. Unused if cached_install is true."
 }
 
 variable "cached_install" {
-  type        = "string"
-  default     = "false"
+  type = string
+  default = "false"
   description = "Whether Container Linux should PXE boot and install from matchbox /assets cache. Note that the admin must have downloaded the os_version into matchbox assets."
 }
 
 variable "install_disk" {
-  type        = "string"
-  default     = "/dev/sda"
+  type = string
+  default = "/dev/sda"
   description = "Disk device to which the install profiles should install Container Linux (e.g. /dev/sda)"
 }
 
 variable "container_linux_oem" {
-  type        = "string"
-  default     = ""
+  type = string
+  default = ""
   description = "DEPRECATED: Specify an OEM image id to use as base for the installation (e.g. ami, vmware_raw, xen) or leave blank for the default image"
 }
 
 variable "kernel_args" {
   description = "Additional kernel arguments to provide at PXE boot."
-  type        = "list"
-  default     = []
+  type = list(string)
+  default = []
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type = string
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = "false"
+  default = "false"
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = "string"
-  default     = "false"
+  type = string
+  default = "false"
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/versions.tf
+++ b/bare-metal/flatcar-linux/kubernetes/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/digital-ocean/container-linux/kubernetes/require.tf
+++ b/digital-ocean/container-linux/kubernetes/require.tf
@@ -17,7 +17,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {

--- a/digital-ocean/container-linux/kubernetes/require.tf
+++ b/digital-ocean/container-linux/kubernetes/require.tf
@@ -21,5 +21,5 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
 }

--- a/digital-ocean/container-linux/kubernetes/require.tf
+++ b/digital-ocean/container-linux/kubernetes/require.tf
@@ -13,7 +13,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "template" {

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -76,7 +76,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
   alias = "default"
 }
 ```

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -95,11 +95,11 @@ module "aws-tempest" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//aws/flatcar-linux/kubernetes?ref=<hash>"
 
   providers = {
-    aws = "aws.default"
-    local = "local.default"
-    null = "null.default"
-    template = "template.default"
-    tls = "tls.default"
+    aws = aws.default
+    local = local.default
+    null = null.default
+    template = template.default
+    tls = tls.default
   }
 
   # AWS

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -24,9 +24,9 @@ Terraform v0.11.13
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Read [concepts](/docs/architecture/concepts.md) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -57,7 +57,7 @@ provider "aws" {
 }
 
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -71,7 +71,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias = "default"
 }
 

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -66,7 +66,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias = "default"
 }
 

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -74,7 +74,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
   alias   = "default"
 }
 ```

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -69,7 +69,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias   = "default"
 }
 

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -64,7 +64,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias   = "default"
 }
 

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -27,9 +27,9 @@ Terraform v0.11.12
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Read [concepts](/architecture/concepts/) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -55,7 +55,7 @@ provider "azurerm" {
 }
 
 provider "ct" {
-  version = "~> 0.3"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -90,11 +90,11 @@ module "azure-ramius" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//azure/flatcar-linux/kubernetes"
 
   providers = {
-    azurerm  = "azurerm.default"
-    local    = "local.default"
-    null     = "null.default"
-    template = "template.default"
-    tls      = "tls.default"
+    azurerm  = azurerm.default
+    local    = local.default
+    null     = null.default
+    template = template.default
+    tls      = tls.default
   }
 
   # Azure

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -164,7 +164,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias = "default"
 }
 

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -169,7 +169,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
   alias = "default"
 }
 ```

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -159,7 +159,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias = "default"
 }
 

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -144,9 +144,9 @@ Configure the Matchbox provider to use your Matchbox API endpoint and client cer
 provider "matchbox" {
   version     = "0.3.0"
   endpoint    = "matchbox.example.com:8081"
-  client_cert = "${file("~/.config/matchbox/client.crt")}"
-  client_key  = "${file("~/.config/matchbox/client.key")}"
-  ca          = "${file("~/.config/matchbox/ca.crt")}"
+  client_cert = file("~/.config/matchbox/client.crt")
+  client_key  = file("~/.config/matchbox/client.key")
+  ca          = file("~/.config/matchbox/ca.crt")
 }
 
 provider "ct" {
@@ -183,10 +183,10 @@ module "bare-metal-mercury" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//bare-metal/flatcar-linux/kubernetes?ref=<hash>"
   
   providers = {
-    local = "local.default"
-    null = "null.default"
-    template = "template.default"
-    tls = "tls.default"
+    local = local.default
+    null = null.default
+    template = template.default
+    tls = tls.default
   }
   
   # bare-metal

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -117,9 +117,9 @@ Terraform v0.11.13
 Add the [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-matchbox/releases/download/v0.2.3/terraform-provider-matchbox-v0.2.3-linux-amd64.tar.gz
-tar xzf terraform-provider-matchbox-v0.2.3-linux-amd64.tar.gz
-mv terraform-provider-matchbox-v0.2.3-linux-amd64/terraform-provider-matchbox ~/.terraform.d/plugins/terraform-provider-matchbox_v0.2.3
+wget https://github.com/poseidon/terraform-provider-matchbox/releases/download/v0.3.0/terraform-provider-matchbox-v0.3.0-linux-amd64.tar.gz
+tar xzf terraform-provider-matchbox-v0.3.0-linux-amd64.tar.gz
+mv terraform-provider-matchbox-v0.3.0-linux-amd64/terraform-provider-matchbox ~/.terraform.d/plugins/terraform-provider-matchbox_v0.3.0
 ```
 
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
@@ -142,7 +142,7 @@ Configure the Matchbox provider to use your Matchbox API endpoint and client cer
 
 ```tf
 provider "matchbox" {
-  version     = "0.2.3"
+  version     = "0.3.0"
   endpoint    = "matchbox.example.com:8081"
   client_cert = "${file("~/.config/matchbox/client.crt")}"
   client_key  = "${file("~/.config/matchbox/client.key")}"

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -125,9 +125,9 @@ mv terraform-provider-matchbox-v0.2.3-linux-amd64/terraform-provider-matchbox ~/
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Read [concepts](/architecture/concepts/) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -150,7 +150,7 @@ provider "matchbox" {
 }
 
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -72,7 +72,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias = "default"
 }
 

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -67,7 +67,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias = "default"
 }
 

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -24,9 +24,9 @@ Terraform v0.11.12
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Read [concepts](/architecture/concepts/) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -58,7 +58,7 @@ provider "google" {
 }
 
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -77,7 +77,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
   alias = "default"
 }
 ```

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -78,12 +78,12 @@ Terraform v0.11.13
 ```
 
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system
-to `~/.terraform.d/plugins/`, noting the `_v0.3.1` suffix.
+to `~/.terraform.d/plugins/`, noting the `_v0.4.0` suffix.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Add the [terraform-provider-libvirt](https://github.com/dmacvicar/terraform-provider-libvirt) plugin binary for your system
@@ -119,7 +119,7 @@ Create a file named `provider.tf` with the following contents:
 
 ```tf
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -128,7 +128,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias   = "default"
 }
 

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -133,7 +133,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias   = "default"
 }
 

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -138,7 +138,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
   alias   = "default"
 }
 

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -87,7 +87,7 @@ provider "tls" {
 }
 
 provider "packet" {
-  version = "~> 1.2"
+  version = "~> 2.2.1"
   alias   = "default"
 }
 ```

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -82,7 +82,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
   alias   = "default"
 }
 

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -72,7 +72,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias   = "default"
 }
 

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -176,7 +176,7 @@ module "worker-pool-helium" {
   facility     = "ams1"
   pool_name    = "helium"
 
-  count = 2
+  worker_count = 2
   type  = "t1.small.x86"
 
   ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/no-https/packet.ipxe"
@@ -317,7 +317,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 
 | Name | Description | Default | Example |
 |:-----|:------------|:--------|:--------|
-| count | Number of worker nodes | 1 | 3 |
+| worker_count | Number of worker nodes | 1 | 3 |
 | type | Type of nodes to provision | "baremetal_0" | "t1.small.x86". See https://www.packet.com/developers/api/#plans for more |
 | labels | Comma separated labels to be added to the worker nodes | "" | "node.supernova.io/role=backend" |
 | ipxe_script_url | URL that contains iPXE script to boot Flatcar on the node over PXE | https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/no-https/packet.ipxe | https://scripts.foobar.com/ipxe-flatcar.ipxe |

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -77,7 +77,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
   alias   = "default"
 }
 

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -113,12 +113,12 @@ module "controller" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes?ref=<hash>"
 
   providers = {
-    aws      = "aws.default"
-    local    = "local.default"
-    null     = "null.default"
-    template = "template.default"
-    tls      = "tls.default"
-    packet   = "packet.default"
+    aws      = aws.default
+    local    = local.default
+    null     = null.default
+    template = template.default
+    tls      = tls.default
+    packet   = packet.default
   }
 
   # Route53

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -25,9 +25,9 @@ Terraform v0.11.13
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Read [concepts](/lokomotive/architecture/concepts.md) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -63,7 +63,7 @@ provider "aws" {
 }
 
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/google-cloud/flatcar-linux/kubernetes/require.tf
+++ b/google-cloud/flatcar-linux/kubernetes/require.tf
@@ -17,7 +17,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {

--- a/google-cloud/flatcar-linux/kubernetes/require.tf
+++ b/google-cloud/flatcar-linux/kubernetes/require.tf
@@ -21,5 +21,5 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
 }

--- a/google-cloud/flatcar-linux/kubernetes/require.tf
+++ b/google-cloud/flatcar-linux/kubernetes/require.tf
@@ -13,7 +13,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "template" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -17,7 +17,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "ct" {
-  version = "~> 0.3"
+  version = "~> 0.4.0"
 }
 
 provider "local" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -13,7 +13,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "template" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -21,7 +21,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
 }
 
 provider "libvirt" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
@@ -13,7 +13,7 @@ provider "local" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
@@ -17,7 +17,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
 }
 
 provider "libvirt" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "ct" {
-  version = "~> 0.3"
+  version = "~> 0.4.0"
 }
 
 provider "local" {

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=0913331140747fd464946981c1d43a895d7a630b"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=9c1ff5a9e8b3e98922980a097c49c8b3a903437a"
 
   cluster_name = "${var.cluster_name}"
 

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -1,23 +1,24 @@
 module "bootkube" {
   source = "github.com/kinvolk/terraform-render-bootkube?ref=9c1ff5a9e8b3e98922980a097c49c8b3a903437a"
 
-  cluster_name = "${var.cluster_name}"
+  cluster_name = var.cluster_name
 
   # Cannot use cyclic dependencies on controllers or their DNS records
-  api_servers          = ["${format("%s-private.%s", var.cluster_name, var.dns_zone)}"]
-  api_servers_external = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers         = "${aws_route53_record.etcds.*.name}"
-  asset_dir            = "${var.asset_dir}"
-  networking           = "${var.networking}"
-  network_mtu          = "${var.network_mtu}"
+  api_servers          = [format("%s-private.%s", var.cluster_name, var.dns_zone)]
+  api_servers_external = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  etcd_servers         = aws_route53_record.etcds.*.name
+  asset_dir            = var.asset_dir
+  networking           = var.networking
+  network_mtu          = var.network_mtu
 
   # Select private Packet NIC by using the can-reach Calico autodetection option with the first
   # host in our private CIDR.
   network_ip_autodetection_method = "can-reach=${cidrhost(var.node_private_cidr, 1)}"
 
-  pod_cidr              = "${var.pod_cidr}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  enable_reporting      = "${var.enable_reporting}"
-  enable_aggregation    = "${var.enable_aggregation}"
+  pod_cidr              = var.pod_cidr
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  enable_reporting      = var.enable_reporting
+  enable_aggregation    = var.enable_aggregation
 }
+

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -46,11 +46,11 @@ resource "packet_device" "controllers" {
   project_id       = var.project_id
   ipxe_script_url  = var.ipxe_script_url
   always_pxe       = "false"
-  user_data = data.ct_config.controller-install-ignitions[count.index].rendered
+  user_data        = data.ct_config.controller-install-ignitions[count.index].rendered
 }
 
 data "ct_config" "controller-install-ignitions" {
-  count = var.controller_count
+  count   = var.controller_count
   content = data.template_file.controller-install[count.index].rendered
 }
 
@@ -70,7 +70,7 @@ data "template_file" "controller-install" {
 data "ct_config" "controller-ignitions" {
   count    = var.controller_count
   platform = "packet"
-  content = data.template_file.controller-configs[count.index].rendered
+  content  = data.template_file.controller-configs[count.index].rendered
 }
 
 data "template_file" "controller-configs" {

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -10,7 +10,7 @@ resource "aws_route53_record" "etcds" {
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = [element(packet_device.controllers.*.access_private_ipv4, count.index)]
+  records = [packet_device.controllers[count.index].access_private_ipv4]
 }
 
 # DNS record for the API servers
@@ -46,18 +46,12 @@ resource "packet_device" "controllers" {
   project_id       = var.project_id
   ipxe_script_url  = var.ipxe_script_url
   always_pxe       = "false"
-  user_data = element(
-    data.ct_config.controller-install-ignitions.*.rendered,
-    count.index,
-  )
+  user_data = data.ct_config.controller-install-ignitions[count.index].rendered
 }
 
 data "ct_config" "controller-install-ignitions" {
   count = var.controller_count
-  content = element(
-    data.template_file.controller-install.*.rendered,
-    count.index,
-  )
+  content = data.template_file.controller-install[count.index].rendered
 }
 
 data "template_file" "controller-install" {
@@ -69,17 +63,14 @@ data "template_file" "controller-install" {
     os_version           = var.os_version
     flatcar_linux_oem    = "packet"
     ssh_keys             = jsonencode(var.ssh_keys)
-    postinstall_ignition = element(data.ct_config.controller-ignitions.*.rendered, count.index)
+    postinstall_ignition = data.ct_config.controller-ignitions[count.index].rendered
   }
 }
 
 data "ct_config" "controller-ignitions" {
   count    = var.controller_count
   platform = "packet"
-  content = element(
-    data.template_file.controller-configs.*.rendered,
-    count.index,
-  )
+  content = data.template_file.controller-configs[count.index].rendered
 }
 
 data "template_file" "controller-configs" {

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -1,105 +1,112 @@
 # Discrete DNS records for each controller's private IPv4 for etcd usage
 resource "aws_route53_record" "etcds" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   # DNS Zone where record should be created
-  zone_id = "${var.dns_zone_id}"
+  zone_id = var.dns_zone_id
 
-  name = "${format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)}"
+  name = format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)
   type = "A"
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = ["${element(packet_device.controllers.*.access_private_ipv4, count.index)}"]
+  records = [element(packet_device.controllers.*.access_private_ipv4, count.index)]
 }
 
 # DNS record for the API servers
 resource "aws_route53_record" "apiservers" {
-  zone_id = "${var.dns_zone_id}"
+  zone_id = var.dns_zone_id
 
-  name = "${format("%s.%s.", var.cluster_name, var.dns_zone)}"
+  name = format("%s.%s.", var.cluster_name, var.dns_zone)
   type = "A"
   ttl  = "300"
 
   # TODO - verify that a multi-controller setup actually works
-  records = ["${packet_device.controllers.*.access_public_ipv4}"]
+  records = packet_device.controllers.*.access_public_ipv4
 }
 
 resource "aws_route53_record" "apiservers_private" {
-  zone_id = "${var.dns_zone_id}"
+  zone_id = var.dns_zone_id
 
-  name = "${format("%s-private.%s.", var.cluster_name, var.dns_zone)}"
+  name = format("%s-private.%s.", var.cluster_name, var.dns_zone)
   type = "A"
   ttl  = "300"
 
   # TODO - verify that a multi-controller setup actually works
-  records = ["${packet_device.controllers.*.access_private_ipv4}"]
+  records = packet_device.controllers.*.access_private_ipv4
 }
 
-
 resource "packet_device" "controllers" {
-  count            = "${var.controller_count}"
+  count            = var.controller_count
   hostname         = "${var.cluster_name}-controller-${count.index}"
-  plan             = "${var.controller_type}"
-  facilities       = ["${var.facility}"]
+  plan             = var.controller_type
+  facilities       = [var.facility]
   operating_system = "custom_ipxe"
   billing_cycle    = "hourly"
-  project_id       = "${var.project_id}"
-  ipxe_script_url  = "${var.ipxe_script_url}"
+  project_id       = var.project_id
+  ipxe_script_url  = var.ipxe_script_url
   always_pxe       = "false"
-  user_data        = "${element(data.ct_config.controller-install-ignitions.*.rendered, count.index)}"
+  user_data = element(
+    data.ct_config.controller-install-ignitions.*.rendered,
+    count.index,
+  )
 }
 
 data "ct_config" "controller-install-ignitions" {
-  count   = "${var.controller_count}"
-  content = "${element(data.template_file.controller-install.*.rendered, count.index)}"
+  count = var.controller_count
+  content = element(
+    data.template_file.controller-install.*.rendered,
+    count.index,
+  )
 }
 
 data "template_file" "controller-install" {
-  count    = "${var.controller_count}"
-  template = "${file("${path.module}/cl/controller-install.yaml.tmpl")}"
+  count    = var.controller_count
+  template = file("${path.module}/cl/controller-install.yaml.tmpl")
 
-  vars {
-    os_channel           = "${var.os_channel}"
-    os_version           = "${var.os_version}"
+  vars = {
+    os_channel           = var.os_channel
+    os_version           = var.os_version
     flatcar_linux_oem    = "packet"
-    ssh_keys             = "${jsonencode("${var.ssh_keys}")}"
-    postinstall_ignition = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+    ssh_keys             = jsonencode(var.ssh_keys)
+    postinstall_ignition = element(data.ct_config.controller-ignitions.*.rendered, count.index)
   }
 }
 
 data "ct_config" "controller-ignitions" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   platform = "packet"
-  content  = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  content = element(
+    data.template_file.controller-configs.*.rendered,
+    count.index,
+  )
 }
 
 data "template_file" "controller-configs" {
-  count    = "${var.controller_count}"
-  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+  count    = var.controller_count
+  template = file("${path.module}/cl/controller.yaml.tmpl")
 
-  vars {
+  vars = {
     # Cannot use cyclic dependencies on controllers or their DNS records
     etcd_name   = "etcd${count.index}"
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
-
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
-
-    kubeconfig            = "${indent(10, module.bootkube.kubeconfig-kubelet)}"
-    ssh_keys              = "${jsonencode("${var.ssh_keys}")}"
-    k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix = "${var.cluster_domain_suffix}"
+    etcd_initial_cluster  = join(",", data.template_file.etcds.*.rendered)
+    kubeconfig            = indent(10, module.bootkube.kubeconfig-kubelet)
+    ssh_keys              = jsonencode(var.ssh_keys)
+    k8s_dns_service_ip    = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix = var.cluster_domain_suffix
   }
 }
 
 data "template_file" "etcds" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  vars {
-    index        = "${count.index}"
-    cluster_name = "${var.cluster_name}"
-    dns_zone     = "${var.dns_zone}"
+  vars = {
+    index        = count.index
+    cluster_name = var.cluster_name
+    dns_zone     = var.dns_zone
   }
 }
+

--- a/packet/flatcar-linux/kubernetes/outputs.tf
+++ b/packet/flatcar-linux/kubernetes/outputs.tf
@@ -1,7 +1,8 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin}"
+  value = module.bootkube.kubeconfig-admin
 }
 
 output "kubeconfig" {
-  value = "${module.bootkube.kubeconfig-kubelet}"
+  value = module.bootkube.kubeconfig-kubelet
 }
+

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -21,7 +21,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
 }
 
 provider "packet" {

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -31,3 +31,4 @@ provider "packet" {
 provider "aws" {
   version = ">= 1.13, < 3.0"
 }
+

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -17,7 +17,7 @@ provider "null" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "ct" {
-  version = "~> 0.3"
+  version = "~> 0.4.0"
 }
 
 provider "local" {

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -25,7 +25,7 @@ provider "tls" {
 }
 
 provider "packet" {
-  version = "~> 1.4"
+  version = "~> 2.2.1"
 }
 
 provider "aws" {

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -13,7 +13,7 @@ provider "local" {
 }
 
 provider "null" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "template" {

--- a/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/packet/flatcar-linux/kubernetes/ssh.tf
@@ -1,46 +1,46 @@
 # Secure copy etcd TLS assets to controllers.
 resource "null_resource" "copy-controller-secrets" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   connection {
     type    = "ssh"
-    host    = "${element(packet_device.controllers.*.access_public_ipv4, count.index)}"
+    host    = element(packet_device.controllers.*.access_public_ipv4, count.index)
     user    = "core"
     timeout = "60m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_ca_cert}"
+    content     = module.bootkube.etcd_ca_cert
     destination = "$HOME/etcd-client-ca.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_cert}"
+    content     = module.bootkube.etcd_client_cert
     destination = "$HOME/etcd-client.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_key}"
+    content     = module.bootkube.etcd_client_key
     destination = "$HOME/etcd-client.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_cert}"
+    content     = module.bootkube.etcd_server_cert
     destination = "$HOME/etcd-server.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_key}"
+    content     = module.bootkube.etcd_server_key
     destination = "$HOME/etcd-server.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_cert}"
+    content     = module.bootkube.etcd_peer_cert
     destination = "$HOME/etcd-peer.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_key}"
+    content     = module.bootkube.etcd_peer_key
     destination = "$HOME/etcd-peer.key"
   }
 
@@ -68,25 +68,25 @@ resource "null_resource" "copy-controller-secrets" {
 # one-time self-hosted cluster bootstrapping.
 resource "null_resource" "bootkube-start" {
   depends_on = [
-    "module.bootkube",
-    "aws_route53_record.apiservers",
-    "null_resource.copy-controller-secrets",
+    module.bootkube,
+    aws_route53_record.apiservers,
+    null_resource.copy-controller-secrets,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${packet_device.controllers.0.access_public_ipv4}"
+    host    = packet_device.controllers[0].access_public_ipv4
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    source      = "${var.asset_dir}"
+    source      = var.asset_dir
     destination = "$HOME/assets"
   }
 
   provisioner "file" {
-    content     = "${data.template_file.host_protection_policy.rendered}"
+    content     = data.template_file.host_protection_policy.rendered
     destination = "$HOME/assets/manifests-networking/calico-policy.yaml"
   }
 
@@ -99,31 +99,35 @@ resource "null_resource" "bootkube-start" {
 }
 
 data "template_file" "controller_host_endpoints" {
-  count    = "${var.controller_count}"
-  template = "${file("${path.module}/calico/controller-host-endpoint.yaml.tmpl")}"
+  count    = var.controller_count
+  template = file("${path.module}/calico/controller-host-endpoint.yaml.tmpl")
 
-  vars {
-    node_name = "${element(packet_device.controllers.*.hostname, count.index)}"
+  vars = {
+    node_name = element(packet_device.controllers.*.hostname, count.index)
   }
 }
 
 data "template_file" "worker_host_endpoints" {
-  count    = "${var.worker_count}"
-  template = "${file("${path.module}/calico/worker-host-endpoint.yaml.tmpl")}"
+  count    = var.worker_count
+  template = file("${path.module}/calico/worker-host-endpoint.yaml.tmpl")
 
-  vars {
-    node_name = "${element("${var.worker_nodes_hostnames}", count.index)}"
+  vars = {
+    node_name = element(var.worker_nodes_hostnames, count.index)
   }
 }
 
 data "template_file" "host_protection_policy" {
-  template = "${file("${path.module}/calico/host-protection.yaml.tmpl")}"
+  template = file("${path.module}/calico/host-protection.yaml.tmpl")
 
   vars = {
-    controller_host_endpoints = "${join("\n", data.template_file.controller_host_endpoints.*.rendered)}"
-    worker_host_endpoints     = "${join("\n", data.template_file.worker_host_endpoints.*.rendered)}"
-    management_cidrs          = "${jsonencode("${var.management_cidrs}")}"
-    cluster_internal_cidrs    = "${jsonencode(list("${var.node_private_cidr}", "${var.pod_cidr}", "${var.service_cidr}"))}"
-    etcd_server_cidrs         = "${jsonencode("${packet_device.controllers.*.access_private_ipv4}")}"
+    controller_host_endpoints = join(
+      "\n",
+      data.template_file.controller_host_endpoints.*.rendered,
+    )
+    worker_host_endpoints  = join("\n", data.template_file.worker_host_endpoints.*.rendered)
+    management_cidrs       = jsonencode(var.management_cidrs)
+    cluster_internal_cidrs = jsonencode([var.node_private_cidr, var.pod_cidr, var.service_cidr])
+    etcd_server_cidrs      = jsonencode(packet_device.controllers.*.access_private_ipv4)
   }
 }
+

--- a/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/packet/flatcar-linux/kubernetes/ssh.tf
@@ -4,7 +4,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(packet_device.controllers.*.access_public_ipv4, count.index)
+    host    = packet_device.controllers[count.index].access_public_ipv4
     user    = "core"
     timeout = "60m"
   }
@@ -103,7 +103,7 @@ data "template_file" "controller_host_endpoints" {
   template = file("${path.module}/calico/controller-host-endpoint.yaml.tmpl")
 
   vars = {
-    node_name = element(packet_device.controllers.*.hostname, count.index)
+    node_name = packet_device.controllers[count.index].hostname
   }
 }
 
@@ -112,7 +112,7 @@ data "template_file" "worker_host_endpoints" {
   template = file("${path.module}/calico/worker-host-endpoint.yaml.tmpl")
 
   vars = {
-    node_name = element(var.worker_nodes_hostnames, count.index)
+    node_name = var.worker_nodes_hostnames[count.index]
   }
 }
 

--- a/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/packet/flatcar-linux/kubernetes/ssh.tf
@@ -120,14 +120,11 @@ data "template_file" "host_protection_policy" {
   template = file("${path.module}/calico/host-protection.yaml.tmpl")
 
   vars = {
-    controller_host_endpoints = join(
-      "\n",
-      data.template_file.controller_host_endpoints.*.rendered,
-    )
-    worker_host_endpoints  = join("\n", data.template_file.worker_host_endpoints.*.rendered)
-    management_cidrs       = jsonencode(var.management_cidrs)
-    cluster_internal_cidrs = jsonencode([var.node_private_cidr, var.pod_cidr, var.service_cidr])
-    etcd_server_cidrs      = jsonencode(packet_device.controllers.*.access_private_ipv4)
+    controller_host_endpoints = join("\n", data.template_file.controller_host_endpoints.*.rendered)
+    worker_host_endpoints     = join("\n", data.template_file.worker_host_endpoints.*.rendered)
+    management_cidrs          = jsonencode(var.management_cidrs)
+    cluster_internal_cidrs    = jsonencode([var.node_private_cidr, var.pod_cidr, var.service_cidr])
+    etcd_server_cidrs         = jsonencode(packet_device.controllers.*.access_private_ipv4)
   }
 }
 

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -1,17 +1,17 @@
 # DNS records
 
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
 variable "dns_zone" {
-  type        = "string"
+  type        = string
   description = "AWS Route53 DNS Zone (e.g. aws.example.com)"
 }
 
 variable "dns_zone_id" {
-  type        = "string"
+  type        = string
   description = "AWS Route53 DNS Zone ID (e.g. Z3PAABBCFAKEC0)"
 }
 
@@ -22,41 +22,41 @@ variable "project_id" {
 # Nodes
 
 variable "os_channel" {
-  type        = "string"
+  type        = string
   default     = "stable"
   description = "Flatcar Linux channel to install from (stable, beta, alpha)"
 }
 
 variable "os_version" {
-  type        = "string"
+  type        = string
   default     = "current"
   description = "Flatcar Linux version to install (for example '2079.3.1' - see https://www.flatcar-linux.org/releases/)"
 }
 
 variable "controller_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   description = "Number of workers"
 }
 
 variable "worker_nodes_hostnames" {
-  type        = "list"
+  type        = list(string)
   description = "List of hostname of packet_device resources"
 }
 
 variable "controller_type" {
-  type        = "string"
+  type        = string
   default     = "baremetal_0"
   description = "Packet instance type for controllers"
 }
 
 variable "ipxe_script_url" {
-  type = "string"
+  type = string
 
   # Workaround. iPXE-booting Flatcar on Packet over HTTPS is failing due to a bug in iPXE.
   # This patch is supposed to fix this: http://git.ipxe.org/ipxe.git/commitdiff/b6ffe28a2
@@ -69,43 +69,43 @@ variable "ipxe_script_url" {
 }
 
 variable "facility" {
-  type        = "string"
+  type        = string
   description = "Packet facility to deploy the cluster in"
 }
 
 # Configuration
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "networking" {
   description = "Choice of networking provider (flannel or calico)"
-  type        = "string"
+  type        = string
   default     = "calico"
 }
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only)"
-  type        = "string"
+  type        = string
   default     = "1480"
 }
 
 variable "network_ip_autodetection_method" {
   description = "Method to autodetect the host IPv4 address (applies to calico only)"
-  type        = "string"
+  type        = string
   default     = "first-found"
 }
 
 variable "pod_cidr" {
   description = "CIDR IPv4 range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.2.0.0/16"
 }
 
@@ -115,34 +115,36 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
-  default     = "cluster.local"
+  type = string
+  default = "cluster.local"
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type = string
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = "false"
+  default = "false"
 }
 
 variable "management_cidrs" {
   description = "List of IPv4 CIDRs authorized to access or manage the cluster"
-  type        = "list"
+  type = list(string)
 }
 
 variable "node_private_cidr" {
   description = "Private IPv4 CIDR of the nodes used to allow inter-node traffic"
-  type        = "string"
+  type = string
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = "string"
-  default     = "false"
+  type = string
+  default = "false"
 }
+

--- a/packet/flatcar-linux/kubernetes/versions.tf
+++ b/packet/flatcar-linux/kubernetes/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/packet/flatcar-linux/kubernetes/workers/outputs.tf
+++ b/packet/flatcar-linux/kubernetes/workers/outputs.tf
@@ -1,7 +1,8 @@
 output "worker_nodes_hostname" {
-  value = "${packet_device.nodes.*.hostname}"
+  value = packet_device.nodes.*.hostname
 }
 
 output "worker_nodes_public_ipv4" {
-  value = "${packet_device.nodes.*.access_public_ipv4}"
+  value = packet_device.nodes.*.access_public_ipv4
 }
+

--- a/packet/flatcar-linux/kubernetes/workers/require.tf
+++ b/packet/flatcar-linux/kubernetes/workers/require.tf
@@ -17,7 +17,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "~> 1.0"
+  version = "~> 2.0.1"
 }
 
 provider "packet" {

--- a/packet/flatcar-linux/kubernetes/workers/require.tf
+++ b/packet/flatcar-linux/kubernetes/workers/require.tf
@@ -13,7 +13,7 @@ provider "local" {
 }
 
 provider "template" {
-  version = "~> 1.0"
+  version = "~> 2.1.2"
 }
 
 provider "tls" {

--- a/packet/flatcar-linux/kubernetes/workers/require.tf
+++ b/packet/flatcar-linux/kubernetes/workers/require.tf
@@ -23,3 +23,4 @@ provider "tls" {
 provider "packet" {
   version = "~> 2.2.1"
 }
+

--- a/packet/flatcar-linux/kubernetes/workers/require.tf
+++ b/packet/flatcar-linux/kubernetes/workers/require.tf
@@ -21,5 +21,5 @@ provider "tls" {
 }
 
 provider "packet" {
-  version = "~> 1.4"
+  version = "~> 2.2.1"
 }

--- a/packet/flatcar-linux/kubernetes/workers/require.tf
+++ b/packet/flatcar-linux/kubernetes/workers/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "ct" {
-  version = "~> 0.3"
+  version = "~> 0.4.0"
 }
 
 provider "local" {

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -16,7 +16,7 @@ variable "pool_name" {
   description = "Unique worker pool name (prepended to hostname)"
 }
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of workers"

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -1,7 +1,7 @@
 # Cluster
 
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
@@ -12,18 +12,18 @@ variable "project_id" {
 # Nodes
 
 variable "pool_name" {
-  type        = "string"
+  type        = string
   description = "Unique worker pool name (prepended to hostname)"
 }
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of workers"
 }
 
 variable "type" {
-  type        = "string"
+  type        = string
   default     = "baremetal_0"
   description = "Packet instance type for workers"
 }
@@ -31,19 +31,19 @@ variable "type" {
 # TODO: migrate to `templatefile` when Terraform `0.12` is out and use `{% for ~}`
 # to avoid specifying `--node-labels` again when the var is empty.
 variable "labels" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Custom labels to assign to worker nodes. Provide comma separated key=value pairs as labels. e.g. 'foo=oof,bar=,baz=zab'"
 }
 
 variable "taints" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Comma separated list of taints. eg. 'clusterType=staging:NoSchedule,nodeType=storage:NoSchedule'"
 }
 
 variable "ipxe_script_url" {
-  type = "string"
+  type = string
 
   # Workaround. iPXE-booting Flatcar on Packet over HTTPS is failing due to a bug in iPXE.
   # This patch is supposed to fix this: http://git.ipxe.org/ipxe.git/commitdiff/b6ffe28a2
@@ -56,35 +56,35 @@ variable "ipxe_script_url" {
 }
 
 variable "facility" {
-  type        = "string"
+  type        = string
   description = "Packet facility to deploy the cluster in"
 }
 
 variable "os_channel" {
-  type        = "string"
+  type        = string
   default     = "stable"
   description = "Flatcar Linux channel to install from (stable, beta, alpha)"
 }
 
 variable "os_version" {
-  type        = "string"
+  type        = string
   default     = "current"
   description = "Flatcar Linux version to install (for example '2079.3.1' - see https://www.flatcar-linux.org/releases/)"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
 
 variable "kubeconfig" {
   description = "Kubeconfig file"
-  type        = "string"
+  type        = string
 }
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
@@ -94,38 +94,39 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type = string
   default = "10.3.0.0/16"
 }
 
 variable "setup_raid" {
-  description = "Attempt to create a RAID 0 from extra disks to be used for persistent container storage. Valid values: \"true\", \"false\""
-  type        = "string"
-  default     = "false"
+  description = "Attempt to create a RAID 0 from extra disks to be used for persistent container storage. Valid values: 'true', 'false'"
+  type = string
+  default = "false"
 }
 
 variable "setup_raid_hdd" {
   description = "Attempt to create a RAID 0 from extra Hard Disk drives only, to be used for persistent container storage. Valid values: \"true\", \"false\""
-  type        = "string"
-  default     = "false"
+  type = string
+  default = "false"
 }
 
 variable "setup_raid_ssd" {
   description = "Attempt to create a RAID 0 from extra Solid State Drives only, to be used for persistent container storage. Valid values: \"true\", \"false\""
-  type        = "string"
-  default     = "false"
+  type = string
+  default = "false"
 }
 
 variable "setup_raid_ssd_fs" {
   description = "When set to \"true\" file system will be created on SSD RAID device and will be mounted on /mnt/node-local-ssd-storage. To use the raw device set it to \"false\". Valid values: \"true\", \"false\""
-  type        = "string"
-  default     = "true"
+  type = string
+  default = "true"
 }
 
 variable "reservation_ids" {
-  description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'worker-${index}' and the value is the reservation ID. Nodes not present in the map will use the value of `reservation_ids_default` variable. Example: reservation_ids = { worker-0 = \"<reservation_id>\" }"
-  type        = "map"
-  default     = {}
+  description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'worker-n' and the value is the reservation ID. Nodes not present in the map will use the value of `reservation_ids_default` variable. Example: reservation_ids = { worker-0 = \"<reservation_id>\" }"
+  type = map
+  default = {}
 }
 
 variable "reservation_ids_default" {
@@ -137,6 +138,7 @@ map. An empty string means "use no hardware reservation". `next-available` will
 choose any reservation that matches the worker pool's device type and facility.
 EOD
 
-  type    = "string"
+  type    = string
   default = ""
 }
+

--- a/packet/flatcar-linux/kubernetes/workers/versions.tf
+++ b/packet/flatcar-linux/kubernetes/workers/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,5 +1,5 @@
 resource "packet_device" "nodes" {
-  count            = "${var.count}"
+  count            = "${var.worker_count}"
   hostname         = "${var.cluster_name}-${var.pool_name}-worker-${count.index}"
   plan             = "${var.type}"
   facilities       = ["${var.facility}"]
@@ -36,7 +36,7 @@ data "template_file" "install" {
 }
 
 resource "packet_bgp_session" "bgp" {
-  count          = "${var.count}"
+  count          = "${var.worker_count}"
   device_id      = "${element(packet_device.nodes.*.id, count.index)}"
   address_family = "ipv4"
 }

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -37,7 +37,7 @@ data "template_file" "install" {
 
 resource "packet_bgp_session" "bgp" {
   count          = var.worker_count
-  device_id      = element(packet_device.nodes.*.id, count.index)
+  device_id      = packet_device.nodes[count.index].id
   address_family = "ipv4"
 }
 


### PR DESCRIPTION
## General

This is a huge PR. It is not ready to be merged yet but I'm opening it in draft mode so that people can start reviewing.

## Testing

To test the PR, install Terraform 0.12 on your machine and create a cluster using the [docs](https://github.com/kinvolk/lokomotive-kubernetes#modules).

The following platforms have been already migrated to Terraform 0.12 and can be tested:

- [ ] AWS
- [ ] Azure
- [ ] Bare metal
- [ ] Packet

## TODO

The following tasks must be completed before merging this PR:

- [ ] Migrate DO, GCP and KVM platforms to Terraform 0.12.
- [ ] Fix whitespace and indentation issues created by `terraform 0.12upgrade`.
- [ ] Finish updating docs.
- [ ] Clean up version requirements.
- [ ] Update CI process to support Terraform 0.12.
- [ ] Merge https://github.com/kinvolk/terraform-render-bootkube/tree/tf12.
- [ ] Pin terraform-render-bootkube module reference to the correct commit.
- [ ] Rebase and squash commits nicely.

The following follow up tasks should be opened after merging:

- [ ] Update lokoctl to support Terraform 0.12.