### PR TITLE
Functionality to setup disk specific RAIDs

### DIFF
--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -88,14 +88,59 @@ storage:
             mkfs.ext4 /dev/md/node-local-storage
           }
 
+          function create_disk_specific_data_raid() {
+            # Ignore the disk on which Linux is installed when selecting disks for RAID.
+            local osdisk="$1"
+            local major_numbers="$2"
+            # for hdd value is 1 and for ssd value is 0
+            local disk_type="$3"
+            # RAID device path on disk
+            local device_path="$4"
+
+            # Select disks for RAID.
+            local disks=$(lsblk -lnpd -o name,rota -I "$${major_numbers}" \
+              | grep "$${disk_type}" \
+              | sort -h -k 4,4 \
+              | grep -vE "^$${osdisk} " \
+              | awk '{x=$1 " " x;} END{print x}'
+            )
+            local count=$(echo "$$disks" | wc -w)
+
+            # Exit if we don't have any disks to create an array
+            [ $$count -lt 1 ] && return 0
+
+            # Create, format and mount array.
+            local extra_opts=""
+            if [ $$count -lt 2 ]; then
+              # Force array creation even with one disk
+              extra_opts="--force"
+            fi
+
+            # if the device_path is "/dev/md/node-local-hdd-storage" then array
+            # name would be "node-local-hdd-storage"
+            array_name=$(echo "$${device_path}" | cut -d"/" -f 4)
+            mdadm --create "$${device_path}" --homehost=any $$extra_opts --verbose --name="$${array_name}" --level=0 --raid-devices="$${count}" $${disks}
+            cat /proc/mdstat
+            mkfs.ext4 "$${device_path}"
+          }
+
           os_disk="$(select_install_disk $${major_numbers})"
 
           # Create a RAID 0 from extra disks to be used for persistent container storage.
           # This will only be run if setup_raid variable is set to true.
           setup_raid=${setup_raid}
+          setup_raid_hdd=${setup_raid_hdd}
+          setup_raid_ssd=${setup_raid_ssd}
 
           if [ "$${setup_raid}" = true ]; then
             create_data_raid "$${os_disk}" "$${major_numbers}"
+          else
+            if [ "$${setup_raid_hdd}" = true ]; then
+              create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 1 /dev/md/node-local-hdd-storage
+            fi
+            if [ "$${setup_raid_ssd}" = true ]; then
+              create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 0 /dev/md/node-local-ssd-storage
+            fi
           fi
 
           flatcar-install \

--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -96,6 +96,7 @@ storage:
             local disk_type="$3"
             # RAID device path on disk
             local device_path="$4"
+            local setup_fs_on_raid="$5"
 
             # Select disks for RAID.
             local disks=$(lsblk -lnpd -o name,rota -I "$${major_numbers}" \
@@ -121,7 +122,9 @@ storage:
             array_name=$(echo "$${device_path}" | cut -d"/" -f 4)
             mdadm --create "$${device_path}" --homehost=any $$extra_opts --verbose --name="$${array_name}" --level=0 --raid-devices="$${count}" $${disks}
             cat /proc/mdstat
-            mkfs.ext4 "$${device_path}"
+            if [ "$${setup_fs_on_raid}" = true ]; then
+              mkfs.ext4 "$${device_path}"
+            fi
           }
 
           os_disk="$(select_install_disk $${major_numbers})"
@@ -131,15 +134,16 @@ storage:
           setup_raid=${setup_raid}
           setup_raid_hdd=${setup_raid_hdd}
           setup_raid_ssd=${setup_raid_ssd}
+          setup_raid_ssd_fs=${setup_raid_ssd_fs}
 
           if [ "$${setup_raid}" = true ]; then
             create_data_raid "$${os_disk}" "$${major_numbers}"
           else
             if [ "$${setup_raid_hdd}" = true ]; then
-              create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 1 /dev/md/node-local-hdd-storage
+              create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 1 /dev/md/node-local-hdd-storage true
             fi
             if [ "$${setup_raid_ssd}" = true ]; then
-              create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 0 /dev/md/node-local-ssd-storage
+              create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 0 /dev/md/node-local-ssd-storage "$${setup_raid_ssd_fs}"
             fi
           fi
 

--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -119,7 +119,7 @@ storage:
 
             # if the device_path is "/dev/md/node-local-hdd-storage" then array
             # name would be "node-local-hdd-storage"
-            array_name=$(echo "$${device_path}" | cut -d"/" -f 4)
+            array_name=$(basename "$${device_path}")
             mdadm --create "$${device_path}" --homehost=any $$extra_opts --verbose --name="$${array_name}" --level=0 --raid-devices="$${count}" $${disks}
             cat /proc/mdstat
             if [ "$${setup_fs_on_raid}" = true ]; then

--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -130,20 +130,14 @@ storage:
           os_disk="$(select_install_disk $${major_numbers})"
 
           # Create a RAID 0 from extra disks to be used for persistent container storage.
-          # This will only be run if setup_raid variable is set to true.
-          setup_raid=${setup_raid}
-          setup_raid_hdd=${setup_raid_hdd}
-          setup_raid_ssd=${setup_raid_ssd}
-          setup_raid_ssd_fs=${setup_raid_ssd_fs}
-
-          if [ "$${setup_raid}" = true ]; then
+          if [ ${setup_raid} = true ]; then
             create_data_raid "$${os_disk}" "$${major_numbers}"
           else
-            if [ "$${setup_raid_hdd}" = true ]; then
+            if [ ${setup_raid_hdd} = true ]; then
               create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 1 /dev/md/node-local-hdd-storage true
             fi
-            if [ "$${setup_raid_ssd}" = true ]; then
-              create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 0 /dev/md/node-local-ssd-storage "$${setup_raid_ssd_fs}"
+            if [ ${setup_raid_ssd} = true ]; then
+              create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 0 /dev/md/node-local-ssd-storage ${setup_raid_ssd_fs}
             fi
           fi
 

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -138,10 +138,16 @@ storage:
             # Don't mount if no RAID is configured.
             [ -z "$${raid_config}" ] && return 0
 
-            # Make mount persistent across reboots.
-            local devname=$(awk '{print $2}' /etc/mdadm.conf)
-            mount "$${devname}" /mnt/
-            echo "$${devname} /mnt ext4 defaults,nofail,discard 0 0" | tee -a /etc/fstab
+            cat /etc/mdadm.conf | while read line; do
+              # Make mount persistent across reboots.
+              local devname=$(echo "$${line}" | awk '{print $2}')
+              local mount_point=$(echo "$${devname}" | cut -d"/" -f 4)
+
+              # Create the mount point before mounting
+              mkdir "/mnt/$${mount_point}"
+              mount "$${devname}" "/mnt/$${mount_point}"
+              echo "$${devname} /mnt ext4 defaults,nofail,discard 0 0" | tee -a /etc/fstab
+            done
           }
 
           persist_data_raid

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -146,7 +146,7 @@ storage:
               local fs=$(blkid "$${devname}")
               [ -z "$${fs}" ] && continue
 
-              local mount_point=$(echo "$${devname}" | cut -d"/" -f 4)
+              local mount_point=$(basename "$${devname}")
               # Create the mount point before mounting
               mkdir "/mnt/$${mount_point}"
               mount "$${devname}" "/mnt/$${mount_point}"

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -141,8 +141,12 @@ storage:
             cat /etc/mdadm.conf | while read line; do
               # Make mount persistent across reboots.
               local devname=$(echo "$${line}" | awk '{print $2}')
-              local mount_point=$(echo "$${devname}" | cut -d"/" -f 4)
 
+              # Mount the RAID device only if there is a filesystem on the device
+              local fs=$(blkid "$${devname}")
+              [ -z "$${fs}" ] && continue
+
+              local mount_point=$(echo "$${devname}" | cut -d"/" -f 4)
               # Create the mount point before mounting
               mkdir "/mnt/$${mount_point}"
               mount "$${devname}" "/mnt/$${mount_point}"

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -99,7 +99,19 @@ EOD
 }
 
 variable "setup_raid" {
-  description = "Attempt to create a RAID 0 from extra disks to be used for persistent container storage. Valid values: 'true', 'false'"
+  description = "Attempt to create a RAID 0 from extra disks to be used for persistent container storage. Valid values: \"true\", \"false\""
+  type        = "string"
+  default     = "false"
+}
+
+variable "setup_raid_hdd" {
+  description = "Attempt to create a RAID 0 from extra Hard Disk drives only, to be used for persistent container storage. Valid values: \"true\", \"false\""
+  type        = "string"
+  default     = "false"
+}
+
+variable "setup_raid_ssd" {
+  description = "Attempt to create a RAID 0 from extra Solid State Drives only, to be used for persistent container storage. Valid values: \"true\", \"false\""
   type        = "string"
   default     = "false"
 }

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -116,6 +116,12 @@ variable "setup_raid_ssd" {
   default     = "false"
 }
 
+variable "setup_raid_ssd_fs" {
+  description = "When set to \"true\" file system will be created on SSD RAID device and will be mounted on /mnt/node-local-ssd-storage. To use the raw device set it to \"false\". Valid values: \"true\", \"false\""
+  type        = "string"
+  default     = "true"
+}
+
 variable "reservation_ids" {
   description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'worker-${index}' and the associated value is the reservation id string. Nodes not present in the map will use the value of reservation_ids_default var. Example: reservation_ids = { worker-0 = '<reservation_id>' }"
   type        = "map"

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -31,6 +31,7 @@ data "template_file" "install" {
     setup_raid           = "${var.setup_raid}"
     setup_raid_hdd       = "${var.setup_raid_hdd}"
     setup_raid_ssd       = "${var.setup_raid_ssd}"
+    setup_raid_ssd_fs    = "${var.setup_raid_ssd_fs}"
   }
 }
 

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -29,6 +29,8 @@ data "template_file" "install" {
     ssh_keys             = "${jsonencode("${var.ssh_keys}")}"
     postinstall_ignition = "${data.ct_config.ignitions.rendered}"
     setup_raid           = "${var.setup_raid}"
+    setup_raid_hdd       = "${var.setup_raid_hdd}"
+    setup_raid_ssd       = "${var.setup_raid_ssd}"
   }
 }
 


### PR DESCRIPTION
* Added following variables:
    
  * `setup_raid_hdd` - If true, create RAID of HDDs only.
  * `setup_raid_ssd` - If true, create RAID of SSDs only.
    
* Add a function to the install template of the worker nodes of packet
to create RAID devices based on the disk types. Disk types here are SSD
or HDD.
    
* Following devices are created, for each:

  * SSD - `/dev/md/node-local-hdd-storage`
  * HDD - `/dev/md/node-local-ssd-storage`

* This can be specified by the user using the variables `setup_raid_hdd`
and `setup_raid_ssd`.

* This functionality is enabled only when `setup_raid` is set to
`"false"`. So you can either use these three flags in following order:

| `setup_raid_hdd`      | `setup_raid_ssd`      | `setup_raid`  |
|------------------     |------------------     |-------------- |
| `false`               | `false`               | `true`        |
| `true`                | `false`               | `false`       |
| `false`               | `true`                | `false`       |
| `true`                | `true`                | `false`       |
    
    
* The RAID persistance script(`function persist_data_raid`) currently
assumes that there will be only one entry in the `/etc/mdadm.conf` file.
This commit adds logic to iterate through the file. This also changes
the hardcoded mount point of `/mnt` to `/mnt/device-name`.