### PR TITLE
AWS/Packet: Rejoin etcd as fresh member when it fails to join

### DIFF
--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -25,6 +25,7 @@ systemd:
             Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt"
             Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
             Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
+            ExecStopPost=-/opt/etcd-rejoin
     - name: docker.service
       enable: true
     - name: locksmithd.service
@@ -156,6 +157,55 @@ storage:
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"
+    - path: /opt/etcd-rejoin
+      filesystem: root
+      mode: 0555
+      contents:
+        inline: |
+          #!/bin/bash
+          set -eou pipefail
+          # Rejoin a cluster as fresh node when etcd cannot join
+          # (e.g., after repovisioning, crashing or node being down).
+          # Set ExecStopPost=-/opt/etcd-rejoin to run when etcd failed and
+          # use env vars of etcd-member.service.
+          # Skip if not provisioned
+          if [ ! -d "/etc/ssl/etcd/" ]; then exit 0; fi
+          # or got stopped.
+          if [ "$EXIT_CODE" = "killed" ]; then exit 0; fi
+          now=$(date +%s)
+          if [ -f /var/lib/etcd-last-fail ]; then
+            last=$(cat /var/lib/etcd-last-fail)
+          else
+            last=0
+          fi
+          echo "$now" > /var/lib/etcd-last-fail
+          let "d = $now - $last"
+          # Skip and restart regularly if it does not fail within 120s.
+          if [ "$d" -gt 120 ]; then exit 0; fi
+          export ETCDCTL_API=3
+          urls=$(echo "$ETCD_INITIAL_CLUSTER" | tr "," "\n" | cut -d "=" -f 2 | tr "\n" "," | head -c -1)
+          # $$ for terraform
+          endpoints="$${urls//2380/2379}"
+          ARGS="--cacert=/etc/ssl/etcd/etcd-client-ca.crt --cert=/etc/ssl/etcd/etcd-client.crt --key=/etc/ssl/etcd/etcd-client.key --endpoints=$endpoints"
+          # Check if unhealthy (should be because etcd is not running)
+          unhealty=$((etcdctl endpoint health $ARGS 2> /dev/stdout | grep "is unhealthy" | grep "$ETCD_NAME") || true)
+          if [ -z "$unhealty" ]; then exit 0; fi
+          # Remove old ID if still exists
+          ID=$((etcdctl member list $ARGS | grep "$ETCD_NAME" | cut -d "," -f 1) || true)
+          if [ ! -z "$ID" ]; then
+            etcdctl member remove "$ID" $ARGS
+          fi
+          # Re-add as new member
+          etcdctl member add "$ETCD_NAME" --peer-urls="$ETCD_INITIAL_ADVERTISE_PEER_URLS" $ARGS
+          # Join fresh without state
+          mv /var/lib/etcd "/var/lib/etcd-bkp-$(date +%s)" || true
+          if [ -z "$(grep ETCD_INITIAL_CLUSTER_STATE=existing /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf)" ]; then
+            echo 'Environment="ETCD_INITIAL_CLUSTER_STATE=existing"' >> /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf
+            # Apply change
+            systemctl daemon-reload
+          fi
+          # Restart unit (yes, within itself)
+          systemctl restart etcd-member &
     - path: /etc/kubernetes/configure-kubelet-cgroup-driver
       filesystem: root
       mode: 0744

--- a/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/aws/flatcar-linux/kubernetes/ssh.tf
@@ -58,6 +58,10 @@ resource "null_resource" "copy-controller-secrets" {
       "sudo chmod -R 500 /etc/ssl/etcd",
     ]
   }
+
+  triggers = {
+    controller_id = "${aws_instance.controllers.*.id[count.index]}"
+  }
 }
 
 # Secure copy bootkube assets to ONE controller and start bootkube to perform

--- a/docs/topics/maintenance.md
+++ b/docs/topics/maintenance.md
@@ -1,5 +1,25 @@
 # Maintenance
 
+## Emergency handling
+
+When a node failed and cannot be restarted, delete it completely and recreate it by running Terraform:
+
+```
+terraform apply
+```
+
+This works for both worker and controller nodes. Exactly the same
+configuration and Lokomotive revision should be used because otherwise
+not only the deleted node will be recreated but others might be as well.
+
+However, when more than half of the controller nodes failed,
+etcd lost its quorum and is in read-only mode. Recreated nodes
+are not able to join as new members anymore. Read up how to
+manually restore the etcd cluster starting a new etcd cluster
+from a single etcd member with backup data. The alternative is
+creating an empty new Kubernetes cluster and migrating your
+applications to the new cluster.
+
 ## Best Practices
 
 * Run multiple Kubernetes clusters. Run across platforms. Plan for regional and cloud outages.

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -25,6 +25,7 @@ systemd:
             Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt"
             Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
             Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
+            ExecStopPost=-/opt/etcd-rejoin
     - name: docker.service
       enable: true
     - name: locksmithd.service
@@ -177,6 +178,55 @@ storage:
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"
+    - path: /opt/etcd-rejoin
+      filesystem: root
+      mode: 0555
+      contents:
+        inline: |
+          #!/bin/bash
+          set -eou pipefail
+          # Rejoin a cluster as fresh node when etcd cannot join
+          # (e.g., after repovisioning, crashing or node being down).
+          # Set ExecStopPost=-/opt/etcd-rejoin to run when etcd failed and
+          # use env vars of etcd-member.service.
+          # Skip if not provisioned
+          if [ ! -d "/etc/ssl/etcd/" ]; then exit 0; fi
+          # or got stopped.
+          if [ "$EXIT_CODE" = "killed" ]; then exit 0; fi
+          now=$(date +%s)
+          if [ -f /var/lib/etcd-last-fail ]; then
+            last=$(cat /var/lib/etcd-last-fail)
+          else
+            last=0
+          fi
+          echo "$now" > /var/lib/etcd-last-fail
+          let "d = $now - $last"
+          # Skip and restart regularly if it does not fail within 120s.
+          if [ "$d" -gt 120 ]; then exit 0; fi
+          export ETCDCTL_API=3
+          urls=$(echo "$ETCD_INITIAL_CLUSTER" | tr "," "\n" | cut -d "=" -f 2 | tr "\n" "," | head -c -1)
+          # $$ for terraform
+          endpoints="$${urls//2380/2379}"
+          ARGS="--cacert=/etc/ssl/etcd/etcd-client-ca.crt --cert=/etc/ssl/etcd/etcd-client.crt --key=/etc/ssl/etcd/etcd-client.key --endpoints=$endpoints"
+          # Check if unhealthy (should be because etcd is not running)
+          unhealty=$((etcdctl endpoint health $ARGS 2> /dev/stdout | grep "is unhealthy" | grep "$ETCD_NAME") || true)
+          if [ -z "$unhealty" ]; then exit 0; fi
+          # Remove old ID if still exists
+          ID=$((etcdctl member list $ARGS | grep "$ETCD_NAME" | cut -d "," -f 1) || true)
+          if [ ! -z "$ID" ]; then
+            etcdctl member remove "$ID" $ARGS
+          fi
+          # Re-add as new member
+          etcdctl member add "$ETCD_NAME" --peer-urls="$ETCD_INITIAL_ADVERTISE_PEER_URLS" $ARGS
+          # Join fresh without state
+          mv /var/lib/etcd "/var/lib/etcd-bkp-$(date +%s)" || true
+          if [ -z "$(grep ETCD_INITIAL_CLUSTER_STATE=existing /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf)" ]; then
+            echo 'Environment="ETCD_INITIAL_CLUSTER_STATE=existing"' >> /etc/systemd/system/etcd-member.service.d/40-etcd-cluster.conf
+            # Apply change
+            systemctl daemon-reload
+          fi
+          # Restart unit (yes, within itself)
+          systemctl restart etcd-member &
     - path: /var/lib/iptables/rules-save
       filesystem: root
       mode: 0644

--- a/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/packet/flatcar-linux/kubernetes/ssh.tf
@@ -58,6 +58,10 @@ resource "null_resource" "copy-controller-secrets" {
       "sudo chmod -R 500 /etc/ssl/etcd",
     ]
   }
+
+  triggers = {
+    controller_id = "${packet_device.controllers.*.id[count.index]}"
+  }
 }
 
 # Secure copy bootkube assets to ONE controller and start bootkube to perform


### PR DESCRIPTION
Recreated controller nodes most times failed to join
    the etcd cluster because they got removed or their
    state now mismatches (cluster state is "initial").
    This is related to an etcd limitation (by design)
    described in https://github.com/etcd-io/etcd/issues/5422
    
Add a rejoin script that is run when etcd fails twice during
    a short amount of time. It removes the old reference (because
    otherwise it is not allowed to join as fresh member), clears
    the data directory (because it may have synced some data if
    it still was an active member but then panics because the
    state mismatches), and sets the initial cluster state to
    "existing". Then it restarts etcd. The script is not run
    if the etcd service errors because it is not yet provisioned
    or it got killed through "systemctl stop/restart".


Tested on AWS and Packet.