### PR TITLE
packet: Merge RAID setup function

### DIFF
--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -51,8 +51,7 @@ storage:
           function select_install_disk() {
             local major_numbers="$1"
 
-            local disk=$(lsblk -lnpd -I "$${major_numbers}" \
-              | sort -h -k 4,4 \
+            local disk=$(lsblk -lnpd -I "$${major_numbers}" -x size \
               | head -1 \
               | awk '{print $1}'
             )
@@ -64,44 +63,20 @@ storage:
             # Ignore the disk on which Linux is installed when selecting disks for RAID.
             local osdisk="$1"
             local major_numbers="$2"
-
-            # Select disks for RAID.
-            local disks=$(lsblk -lnpd -I "$${major_numbers}" \
-              | sort -h -k 4,4 \
-              | grep -vE "^$${osdisk} " \
-              | awk '{x=$1 " " x;} END{print x}'
-            )
-            local count=$(echo "$$disks" | wc -w)
-
-            # Exit if we don't have any disks to create an array
-            [ $$count -lt 1 ] && return 0
-
-            # Create, format and mount array.
-            local extra_opts=""
-            if [ $$count -lt 2 ]; then
-              # Force array creation even with one disk
-              extra_opts="--force"
-            fi
-
-            mdadm --create /dev/md/node-local-storage --homehost=any $$extra_opts --verbose --name=node-local-storage --level=0 --raid-devices="$${count}" $${disks}
-            cat /proc/mdstat
-            mkfs.ext4 /dev/md/node-local-storage
-          }
-
-          function create_disk_specific_data_raid() {
-            # Ignore the disk on which Linux is installed when selecting disks for RAID.
-            local osdisk="$1"
-            local major_numbers="$2"
             # for hdd value is 1 and for ssd value is 0
             local disk_type="$3"
             # RAID device path on disk
             local device_path="$4"
             local setup_fs_on_raid="$5"
 
-            # Select disks for RAID.
-            local disks=$(lsblk -lnpd -o name,rota -I "$${major_numbers}" \
-              | grep "$${disk_type}" \
-              | sort -h -k 4,4 \
+            if [ $$disk_type -lt 0 ]; then
+              local d=$(lsblk -lnpd -I "$${major_numbers}" -x size)
+            else
+              local d=$(lsblk -lnpd -o name,rota -I "$${major_numbers}" -x size \
+                | grep " $${disk_type}"
+              )
+            fi
+            local disks=$(echo "$$d" \
               | grep -vE "^$${osdisk} " \
               | awk '{x=$1 " " x;} END{print x}'
             )
@@ -131,13 +106,13 @@ storage:
 
           # Create a RAID 0 from extra disks to be used for persistent container storage.
           if [ ${setup_raid} = true ]; then
-            create_data_raid "$${os_disk}" "$${major_numbers}"
+            create_data_raid "$${os_disk}" "$${major_numbers}" -1 /dev/md/node-local-storage true
           else
             if [ ${setup_raid_hdd} = true ]; then
-              create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 1 /dev/md/node-local-hdd-storage true
+              create_data_raid "$${os_disk}" "$${major_numbers}" 1 /dev/md/node-local-hdd-storage true
             fi
             if [ ${setup_raid_ssd} = true ]; then
-              create_disk_specific_data_raid "$${os_disk}" "$${major_numbers}" 0 /dev/md/node-local-ssd-storage ${setup_raid_ssd_fs}
+              create_data_raid "$${os_disk}" "$${major_numbers}" 0 /dev/md/node-local-ssd-storage ${setup_raid_ssd_fs}
             fi
           fi
 

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -150,7 +150,7 @@ storage:
               # Create the mount point before mounting
               mkdir "/mnt/$${mount_point}"
               mount "$${devname}" "/mnt/$${mount_point}"
-              echo "$${devname} /mnt ext4 defaults,nofail,discard 0 0" | tee -a /etc/fstab
+              echo "$${devname} "/mnt/$${mount_point}" ext4 defaults,nofail,discard 0 0" | tee -a /etc/fstab
             done
           }
 


### PR DESCRIPTION
Currently there is a generic RAID setup function which creates RAID for
all the disks and another function that creates RAID setup depending on
the disk type. This commit merges the two functions into one.

Also this commit removes the use of sort bash tool and uses `lsblk`'s
flags to sort the results on the basis of size.

Fixes #53 