### PR TITLE
Add CI cluster configurations for AWS and Packet

### DIFF
--- a/ci/aws/aws-cluster.tf.envsubst
+++ b/ci/aws/aws-cluster.tf.envsubst
@@ -1,0 +1,21 @@
+module "aws-tempest" {
+  source = "../../aws/flatcar-linux/kubernetes"
+
+  providers = {
+    aws = "aws.default"
+    local = "local.default"
+    null = "null.default"
+    template = "template.default"
+    tls = "tls.default"
+  }
+
+  cluster_name = "$CLUSTER_ID"
+  dns_zone = "$AWS_DNS_ZONE"
+  dns_zone_id = "$AWS_DNS_ZONE_ID"
+  ssh_authorized_key = "$PUB_KEY"
+
+  asset_dir = "${pathexpand("~/lokomotive-assets")}"
+
+  worker_count = 2
+  worker_type  = "t3.small"
+}

--- a/ci/aws/provider.tf
+++ b/ci/aws/provider.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  version = "~> 2.8.0"
+  alias   = "default"
+}
+
+provider "ct" {
+  version = "0.3.1"
+}
+
+provider "local" {
+  version = "~> 1.0"
+  alias = "default"
+}
+
+provider "null" {
+  version = "~> 1.0"
+  alias = "default"
+}
+
+provider "template" {
+  version = "~> 1.0"
+  alias = "default"
+}
+
+provider "tls" {
+  version = "~> 1.0"
+  alias = "default"
+}

--- a/ci/packet/packet-cluster.tf.envsubst
+++ b/ci/packet/packet-cluster.tf.envsubst
@@ -1,0 +1,62 @@
+module "controller" {
+  source = "../../packet/flatcar-linux/kubernetes"
+
+  providers = {
+    aws      = "aws.default"
+    local    = "local.default"
+    null     = "null.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+  dns_zone = "$AWS_DNS_ZONE"
+  dns_zone_id = "$AWS_DNS_ZONE_ID"
+
+  ssh_keys = ["$PUB_KEY"]
+
+  asset_dir = "${pathexpand("~/assets")}"
+  cluster_name = "$CLUSTER_ID"
+  project_id = "$PACKET_PROJECT_ID"
+
+  facility = "sjc1"
+
+  worker_count = 2
+  worker_nodes_hostnames = "${concat("${module.worker-pool-1.worker_nodes_hostname}")}"
+
+  controller_count = 1
+  controller_type  = "t1.small.x86"
+
+  management_cidrs = [
+    "0.0.0.0/0",       # Instances can be SSH-ed into from anywhere on the internet.
+  ]
+
+  node_private_cidr = "10.0.0.0/8"
+}
+
+module "worker-pool-1" {
+  source = "../../packet/flatcar-linux/kubernetes/workers"
+
+  providers = {
+    local    = "local.default"
+    template = "template.default"
+    tls      = "tls.default"
+    packet   = "packet.default"
+  }
+
+
+  ssh_keys = ["$PUB_KEY"]
+
+  cluster_name = "$CLUSTER_ID"
+  project_id = "$PACKET_PROJECT_ID"
+
+  facility     = "sjc1"
+  pool_name    = "pool-1"
+
+  count = 2
+  type  = "t1.small.x86"
+
+  kubeconfig = "${module.controller.kubeconfig}"
+
+  labels = "node.supernova.io/role=backend,node-role.kubernetes.io/backend="
+}

--- a/ci/packet/provider.tf
+++ b/ci/packet/provider.tf
@@ -1,0 +1,33 @@
+provider "aws" {
+  version = "~> 2.8.0"
+  alias   = "default"
+}
+
+provider "ct" {
+  version = "0.3.1"
+}
+
+provider "local" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "null" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "template" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "tls" {
+  version = "~> 1.0"
+  alias   = "default"
+}
+
+provider "packet" {
+  version = "~> 1.2"
+  alias   = "default"
+}


### PR DESCRIPTION
Previously the configuration was part of the CI
pipelines which caused problems when code changed
in a pull request.

By including the CI configurations in the repository
both code and CI configuration can be changed at once.