### PR TITLE
packet: add controller resertavions ids

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -306,6 +306,9 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | enable_reporting | Enable usage or analytics reporting to upstreams (Calico) | false | true |
 | enable_aggregation | Enable the Kubernetes Aggreagation Layer | false | true |
+| reservation_ids | Map Packet hardware reservation IDs to instances. | {} | { controller-0 = "55555f20-a1fb-55bd-1e11-11af11d11111" } |
+| reservation_ids_default | Default hardware reservation ID for nodes not listed in the `reservation_ids` map. | "" | "next-available"|
+
 
 #### Worker module
 

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -45,6 +45,9 @@ resource "packet_device" "controllers" {
   billing_cycle    = "hourly"
   project_id       = "${var.project_id}"
   user_data        = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+
+  # If not present in the map, it uses ${var.reservation_ids_default}.
+  hardware_reservation_id = "${lookup(var.reservation_ids, format("controller-%v", count.index), var.reservation_ids_default)}"
 }
 
 data "ct_config" "controller-ignitions" {

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -36,7 +36,6 @@ resource "aws_route53_record" "apiservers_private" {
   records = ["${packet_device.controllers.*.access_private_ipv4}"]
 }
 
-
 resource "packet_device" "controllers" {
   count            = "${var.controller_count}"
   hostname         = "${var.cluster_name}-controller-${count.index}"

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -127,3 +127,22 @@ variable "enable_aggregation" {
   type        = "string"
   default     = "false"
 }
+
+variable "reservation_ids" {
+  description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'controller-${index}' and the value is the reservation ID. Nodes not present in the map will use the value of `reservation_ids_default` variable. Example: reservation_ids = { controller-0 = \"<reservation_id>\" }"
+  type        = "map"
+  default     = {}
+}
+
+variable "reservation_ids_default" {
+  description = <<EOD
+Possible values: "" and "next-available".
+
+Specify a default reservation ID for nodes not listed in the `reservation_ids`
+map. An empty string means "use no hardware reservation". `next-available` will
+choose any reservation that matches the pool's device type and facility.
+EOD
+
+  type    = "string"
+  default = ""
+}

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -33,9 +33,9 @@ data "template_file" "configs" {
     cluster_domain_suffix = "${var.cluster_domain_suffix}"
     worker_labels         = "${var.labels}"
     taints                = "${var.taints}"
-    setup_raid           = "${var.setup_raid}"
-    setup_raid_hdd       = "${var.setup_raid_hdd}"
-    setup_raid_ssd       = "${var.setup_raid_ssd}"
-    setup_raid_ssd_fs    = "${var.setup_raid_ssd_fs}"
+    setup_raid            = "${var.setup_raid}"
+    setup_raid_hdd        = "${var.setup_raid_hdd}"
+    setup_raid_ssd        = "${var.setup_raid_ssd}"
+    setup_raid_ssd_fs     = "${var.setup_raid_ssd_fs}"
   }
 }


### PR DESCRIPTION
Commit 9211118c75b0f3463d616bbcddea07af4c38aee1 and 
b16e99c182f9c3da1905d649d3e487607f73347a already added hardware
reservation id support for workers. This patch is very similar, but it
adds support for controllers.

The motivation behind is the same as for workers (use reserved instances
is always nice, specially for controllers that will always be running)
added to that with reservations you can also guarantee that controllers,
for example, are isolated (different racks, etc.) as much as possible in
the Packet facility for better resilency.

We've seen issues in the past were controllers landed behind the same
Packet switch and all the control plane was down due to an issue in the 
switch.