### PR TITLE
Update the libvirt platform to use fw_cfg_name

### DIFF
--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -87,19 +87,28 @@ mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d
 ```
 
 Add the [terraform-provider-libvirt](https://github.com/dmacvicar/terraform-provider-libvirt) plugin binary for your system
-to `~/.terraform.d/plugins/`, noting the `_v0.5.2` suffix.
-You should use the 0.5.2 release because it includes the experimental
-[pool definition feature](https://github.com/dmacvicar/terraform-provider-libvirt/commit/9f00f3d46c489f24c71d02fde816f5fda34d3f7c)
-but building from source is also an option.
+to `~/.terraform.d/plugins/`, noting the `_v0.5.3` suffix. As long as this version is unreleased you have to build the plugin
+yourself. The version must include the `fw_cfg_name` feature as well as the experimental
+[pool definition feature](https://github.com/dmacvicar/terraform-provider-libvirt/commit/9f00f3d46c489f24c71d02fde816f5fda34d3f7c).
 
-Use the tar file for your distribution when you download it from the [release page](https://github.com/dmacvicar/terraform-provider-libvirt/releases).
-When building from source, you would do a final `mv $GOPATH/bin/terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.2`.
+When building from source, you have to do a final `mv $GOPATH/bin/terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.3`:
 
 ```sh
-wget https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.5.2/terraform-provider-libvirt-0.5.2.Fedora_28.x86_64.tar.gz
-# or, e.g., https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.5.2/terraform-provider-libvirt-0.5.2.Ubuntu_18.04.amd64.tar.gz
-tar xzf terraform-provider-libvirt-0.5.2.Fedora_28.x86_64.tar.gz
-mv terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.2
+$ # From any (even temporary) directory
+$ git clone https://github.com/dmacvicar/terraform-provider-libvirt.git
+$ export GO111MODULE=on
+$ export GOFLAGS=-mod=vendor
+$ make install
+$ mv "$GOPATH/bin/terraform-provider-libvirt" ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.3
+```
+
+In the future you can download the tar file for your distribution from the [release page](https://github.com/dmacvicar/terraform-provider-libvirt/releases):
+
+```sh
+wget https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.5.3/terraform-provider-libvirt-0.5.3.Fedora_28.x86_64.tar.gz
+# or, e.g., https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.5.2/terraform-provider-libvirt-0.5.3.Ubuntu_18.04.amd64.tar.gz
+tar xzf terraform-provider-libvirt-0.5.3.Fedora_28.x86_64.tar.gz
+mv terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.3
 ```
 
 
@@ -143,7 +152,7 @@ provider "tls" {
 }
 
 provider "libvirt" {
-  version = "~> 0.5.2"
+  version = "~> 0.5.3"
   uri = "qemu:///system"
   alias = "default"
 }

--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=7c30aca430ea17c8a377d47b83a783428dc8a2a4"
+  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=89d11c3ac11973f215265b909d2284c996ad2214"
 
   cluster_name = "${var.cluster_name}"
 

--- a/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
@@ -49,6 +49,7 @@ resource "libvirt_domain" "controller-machine" {
   vcpu   = "${var.virtual_cpus}"
   memory = "${var.virtual_memory}"
 
+  fw_cfg_name     = "opt/org.flatcar-linux/config"
   coreos_ignition = "${element(libvirt_ignition.ignition.*.id, count.index)}"
 
   disk {

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -25,7 +25,7 @@ provider "tls" {
 }
 
 provider "libvirt" {
-  version = "~> 0.5.2"
+  version = "~> 0.5.3"
   uri = "qemu:///system"
 }
 

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
@@ -21,7 +21,7 @@ provider "tls" {
 }
 
 provider "libvirt" {
-  version = "~> 0.5.2"
+  version = "~> 0.5.3"
   uri = "qemu:///system"
 }
 

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
@@ -19,6 +19,7 @@ resource "libvirt_domain" "worker-machine" {
   vcpu   = "${var.virtual_cpus}"
   memory = "${var.virtual_memory}"
 
+  fw_cfg_name     = "opt/org.flatcar-linux/config"
   coreos_ignition = "${element(libvirt_ignition.ignition.*.id, count.index)}"
 
   disk {


### PR DESCRIPTION
Recently Flatcar changed to expect the ignition
config under the name org.flatcar-linux.
The terraform libvirt provider has a commit in
its master branch that allows to set this option.
Use it and document how to build from source for
the mean time.