### PR TITLE
Fix Kubelet cgroup driver selection

### DIFF
--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -213,7 +213,7 @@ storage:
         inline: |
           #!/bin/bash
           set -e
-          readonly docker_cgroup_driver="$(docker info | awk '/^Cgroup Driver/ { print $3 }')"
+          readonly docker_cgroup_driver="$(docker info -f '{{.CgroupDriver}}')"
           cat <<EOF >/etc/kubernetes/kubelet.config
           apiVersion: kubelet.config.k8s.io/v1beta1
           kind: KubeletConfiguration

--- a/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -113,7 +113,7 @@ storage:
         inline: |
           #!/bin/bash
           set -e
-          readonly docker_cgroup_driver="$(docker info | awk '/^Cgroup Driver/ { print $3 }')"
+          readonly docker_cgroup_driver="$(docker info -f '{{.CgroupDriver}}')"
           cat <<EOF >/etc/kubernetes/kubelet.config
           apiVersion: kubelet.config.k8s.io/v1beta1
           kind: KubeletConfiguration

--- a/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -170,7 +170,7 @@ storage:
         inline: |
           #!/bin/bash
           set -e
-          readonly docker_cgroup_driver="$(docker info | awk '/^Cgroup Driver/ { print $3 }')"
+          readonly docker_cgroup_driver="$(docker info -f '{{.CgroupDriver}}')"
           cat <<EOF >/etc/kubernetes/kubelet.config
           apiVersion: kubelet.config.k8s.io/v1beta1
           kind: KubeletConfiguration

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -120,7 +120,7 @@ storage:
         inline: |
           #!/bin/bash
           set -e
-          readonly docker_cgroup_driver="$(docker info | awk '/^Cgroup Driver/ { print $3 }')"
+          readonly docker_cgroup_driver="$(docker info -f '{{.CgroupDriver}}')"
           cat <<EOF >/etc/kubernetes/kubelet.config
           apiVersion: kubelet.config.k8s.io/v1beta1
           kind: KubeletConfiguration

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -267,7 +267,7 @@ storage:
         inline: |
           #!/bin/bash
           set -e
-          readonly docker_cgroup_driver="$(docker info | awk '/^Cgroup Driver/ { print $3 }')"
+          readonly docker_cgroup_driver="$(docker info -f '{{.CgroupDriver}}')"
           cat <<EOF >/etc/kubernetes/kubelet.config
           apiVersion: kubelet.config.k8s.io/v1beta1
           kind: KubeletConfiguration

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -291,7 +291,7 @@ storage:
         inline: |
           #!/bin/bash
           set -e
-          readonly docker_cgroup_driver="$(docker info | awk '/^Cgroup Driver/ { print $3 }')"
+          readonly docker_cgroup_driver="$(docker info -f '{{.CgroupDriver}}')"
           cat <<EOF >/etc/kubernetes/kubelet.config
           apiVersion: kubelet.config.k8s.io/v1beta1
           kind: KubeletConfiguration


### PR DESCRIPTION
The selection mechanism was broken so that
the Kubelet always chose the default cgroup driver
which broke Flatcar Edge.