### PR TITLE
Copy kubeconfig via SSH to reduce AWS Ignition file size

### DIFF
--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -51,6 +51,7 @@ systemd:
         Description=Kubelet via Hyperkube
         Wants=rpc-statd.service
         [Service]
+        ConditionPathExists=/etc/kubernetes/kubeconfig
         EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
@@ -114,12 +115,6 @@ systemd:
         WantedBy=multi-user.target
 storage:
   files:
-    - path: /etc/kubernetes/kubeconfig
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          ${kubeconfig}
     - path: /etc/kubernetes/kubelet.env
       filesystem: root
       mode: 0644

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -68,7 +68,6 @@ data "template_file" "controller-configs" {
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
     etcd_initial_cluster = "${join(",", data.template_file.etcds.*.rendered)}"
 
-    kubeconfig             = "${indent(10, module.bootkube.kubeconfig-kubelet)}"
     ssh_authorized_key     = "${var.ssh_authorized_key}"
     cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
     cluster_domain_suffix  = "${var.cluster_domain_suffix}"

--- a/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/aws/flatcar-linux/kubernetes/ssh.tf
@@ -82,12 +82,20 @@ resource "null_resource" "bootkube-start" {
   }
 
   provisioner "file" {
+    content     = "${module.bootkube.kubeconfig-kubelet}"
+    destination = "$HOME/kubeconfig"
+  }
+
+  provisioner "file" {
     source      = "${var.asset_dir}"
     destination = "$HOME/assets"
   }
 
   provisioner "remote-exec" {
     inline = [
+      "sudo mv $HOME/kubeconfig /etc/kubernetes/kubeconfig",
+      "sudo chown root:root /etc/kubernetes/kubeconfig",
+      "sudo chmod 644 /etc/kubernetes/kubeconfig",
       "sudo mv $HOME/assets /opt/bootkube",
       "sudo systemctl start bootkube",
     ]


### PR DESCRIPTION
Sometimes the AWS Ignition file for the controller hit the
size limit of 16 kB, thus the cluster could not be created.

Move the big kubeconfig out of the controller Ignition file by
copying it through SSH. It contains more scripts than the worker
Ignition file. This brings the controller Ignition down to ~10 kB
while the worker stays as ~11 kB. If needed, the worker kubeconfig
can later also be moved out by copying it through SSH but for now
both Ignition files have each ~5 kB free for encoded data.