### PR TITLE
Certificates: Parameterize the certs validity

### DIFF
--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e237ffa21fd85f76ddf2a215073aa7cd6ef2476"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
@@ -13,4 +13,6 @@ module "bootkube" {
   cluster_domain_suffix = "${var.cluster_domain_suffix}"
   enable_reporting      = "${var.enable_reporting}"
   enable_aggregation    = "${var.enable_aggregation}"
+
+  certs_validity_period_hours = "${var.certs_validity_period_hours}"
 }

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -152,3 +152,11 @@ variable "enable_aggregation" {
   type        = "string"
   default     = "false"
 }
+
+# Certificates
+
+variable "certs_validity_period_hours" {
+  description = "Validity of all the certificates in hours"
+  type        = "string"
+  default     = 8760
+}

--- a/azure/flatcar-linux/kubernetes/bootkube.tf
+++ b/azure/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e237ffa21fd85f76ddf2a215073aa7cd6ef2476"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
 
   cluster_name = "${var.cluster_name}"
   api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
@@ -20,4 +20,6 @@ module "bootkube" {
   cluster_domain_suffix = "${var.cluster_domain_suffix}"
   enable_reporting      = "${var.enable_reporting}"
   enable_aggregation    = "${var.enable_aggregation}"
+
+  certs_validity_period_hours = "${var.certs_validity_period_hours}"
 }

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -143,3 +143,11 @@ variable "enable_aggregation" {
   type        = "string"
   default     = "false"
 }
+
+# Certificates
+
+variable "certs_validity_period_hours" {
+  description = "Validity of all the certificates in hours"
+  type        = "string"
+  default     = 8760
+}

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e237ffa21fd85f76ddf2a215073aa7cd6ef2476"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]
@@ -14,4 +14,6 @@ module "bootkube" {
   cluster_domain_suffix           = "${var.cluster_domain_suffix}"
   enable_reporting                = "${var.enable_reporting}"
   enable_aggregation              = "${var.enable_aggregation}"
+
+  certs_validity_period_hours = "${var.certs_validity_period_hours}"
 }

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -159,3 +159,11 @@ variable "enable_aggregation" {
   type        = "string"
   default     = "false"
 }
+
+# Certificates
+
+variable "certs_validity_period_hours" {
+  description = "Validity of all the certificates in hours"
+  type        = "string"
+  default     = 8760
+}

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e237ffa21fd85f76ddf2a215073aa7cd6ef2476"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
 
   cluster_name = "${var.cluster_name}"
   api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
@@ -19,4 +19,6 @@ module "bootkube" {
   cluster_domain_suffix = "${var.cluster_domain_suffix}"
   enable_reporting      = "${var.enable_reporting}"
   enable_aggregation    = "${var.enable_aggregation}"
+
+  certs_validity_period_hours = "${var.certs_validity_period_hours}"
 }

--- a/digital-ocean/container-linux/kubernetes/variables.tf
+++ b/digital-ocean/container-linux/kubernetes/variables.tf
@@ -110,3 +110,11 @@ variable "enable_aggregation" {
   type        = "string"
   default     = "false"
 }
+
+# Certificates
+
+variable "certs_validity_period_hours" {
+  description = "Validity of all the certificates in hours"
+  type        = "string"
+  default     = 8760
+}

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -249,6 +249,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
+| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
 
 Check the list of valid [instance types](https://aws.amazon.com/ec2/instance-types/).
 

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -257,6 +257,7 @@ Reference the DNS zone with `"${azurerm_dns_zone.clusters.name}"` and its resour
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
+| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
 
 Check the list of valid [machine types](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/) and their [specs](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-general). Use `az vm list-skus` to get the identifier.
 

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -387,4 +387,5 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | kernel_args | Additional kernel args to provide at PXE boot | [] | "kvm-intel.nested=1" |
+| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
 

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -252,6 +252,7 @@ resource "google_dns_managed_zone" "zone-for-clusters" {
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
+| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
 
 Check the list of valid [machine types](https://cloud.google.com/compute/docs/machine-types).
 

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -337,6 +337,7 @@ source.
 | service_cidr | CIDR IPv4 range to assign Kubernetes services. The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns. | "10.2.0.0/16" |
 | virtual_cpus | Number of virtual CPUs | "1" |
 | virtual_memory | Virtual RAM in MB | "2048" |
+| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
 
 ### Worker
 

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -308,6 +308,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | enable_aggregation | Enable the Kubernetes Aggreagation Layer | false | true |
 | reservation_ids | Map Packet hardware reservation IDs to instances. | {} | { controller-0 = "55555f20-a1fb-55bd-1e11-11af11d11111" } |
 | reservation_ids_default | Default hardware reservation ID for nodes not listed in the `reservation_ids` map. | "" | "next-available"|
+| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
 
 
 #### Worker module

--- a/google-cloud/flatcar-linux/kubernetes/bootkube.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e237ffa21fd85f76ddf2a215073aa7cd6ef2476"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
@@ -16,4 +16,6 @@ module "bootkube" {
 
   // temporary
   external_apiserver_port = 443
+
+  certs_validity_period_hours = "${var.certs_validity_period_hours}"
 }

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -127,3 +127,11 @@ variable "enable_aggregation" {
   type        = "string"
   default     = "false"
 }
+
+# Certificates
+
+variable "certs_validity_period_hours" {
+  description = "Validity of all the certificates in hours"
+  type        = "string"
+  default     = 8760
+}

--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=7e237ffa21fd85f76ddf2a215073aa7cd6ef2476"
+  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
 
   cluster_name = "${var.cluster_name}"
 
@@ -19,6 +19,8 @@ module "bootkube" {
   cluster_domain_suffix = "${var.cluster_domain_suffix}"
   enable_reporting      = "${var.enable_reporting}"
   enable_aggregation    = "${var.enable_aggregation}"
+
+  certs_validity_period_hours = "${var.certs_validity_period_hours}"
 }
 
 data "template_file" "controllernames" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
@@ -103,3 +103,11 @@ variable "enable_aggregation" {
   type        = "string"
   default     = "false"
 }
+
+# Certificates
+
+variable "certs_validity_period_hours" {
+  description = "Validity of all the certificates in hours"
+  type        = "string"
+  default     = 8760
+}

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e237ffa21fd85f76ddf2a215073aa7cd6ef2476"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
 
   cluster_name = "${var.cluster_name}"
 
@@ -20,4 +20,6 @@ module "bootkube" {
   cluster_domain_suffix = "${var.cluster_domain_suffix}"
   enable_reporting      = "${var.enable_reporting}"
   enable_aggregation    = "${var.enable_aggregation}"
+
+  certs_validity_period_hours = "${var.certs_validity_period_hours}"
 }

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -146,3 +146,11 @@ EOD
   type    = "string"
   default = ""
 }
+
+# Certificates
+
+variable "certs_validity_period_hours" {
+  description = "Validity of all the certificates in hours"
+  type        = "string"
+  default     = 8760
+}


### PR DESCRIPTION
Add a variable `certs_validity_period_hours` to parameterize the certs
validity in hours. Defaults to 8760 hours, which is 1 year.

Related PR https://github.com/kinvolk/terraform-render-bootkube/pull/22