### PR TITLE
baremetal: Fix interpolation error from terraform escaping change

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -160,7 +160,7 @@ storage:
             --mount volume=assets,target=/assets \
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
-            $$RKT_OPTS \
+            $${RKT_OPTS} \
             quay.io/coreos/bootkube:v0.14.0 \
             --net=host \
             --dns=host \


### PR DESCRIPTION
Terraform only needs ${} to be escaped as $${} and now does not
replace $$SOMETHING to $SOMETHING anymore as before, so we have
to either use $SOMETHING or $${SOMETHING}.