### PR TITLE
Adding a line for requirement for libvirt-dev or libvirt-devel package.

### DIFF
--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -93,6 +93,8 @@ yourself. The version must include the `fw_cfg_name` feature as well as the expe
 
 When building from source, you have to do a final `mv $GOPATH/bin/terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.3`:
 
+When building from source, you will need to install the package `libvirt-dev` for Debian/Ubuntu or `libvirt-devel` for Fedora/Centos.
+
 ```sh
 $ # From any (even temporary) directory
 $ git clone https://github.com/dmacvicar/terraform-provider-libvirt.git

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -93,7 +93,7 @@ yourself. The version must include the `fw_cfg_name` feature as well as the expe
 
 When building from source, you have to do a final `mv $GOPATH/bin/terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.3`:
 
-When building from source, you will need to install the package `libvirt-dev` for Debian/Ubuntu or `libvirt-devel` for Fedora/Centos.
+When building from source, you will need to install the package `libvirt-dev` for Debian/Ubuntu or `libvirt-devel` for Fedora/CentOS.
 
 ```sh
 $ # From any (even temporary) directory


### PR DESCRIPTION
When building terraform-libvirt provider from source,
we need libvirt-dev package installed.

Signed-off-by: Imran Pochi <imran@kinvolk.io>