### PR TITLE
enable_aggregation: Set the default to true

### DIFF
--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -149,9 +149,9 @@ variable "enable_reporting" {
 }
 
 variable "enable_aggregation" {
-  description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
+  description = "Enable the Kubernetes Aggregation Layer (defaults to true)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 # Certificates

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -140,9 +140,9 @@ variable "enable_reporting" {
 }
 
 variable "enable_aggregation" {
-  description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
+  description = "Enable the Kubernetes Aggregation Layer (defaults to true)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 # Certificates

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -156,9 +156,9 @@ variable "enable_reporting" {
 }
 
 variable "enable_aggregation" {
-  description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
+  description = "Enable the Kubernetes Aggregation Layer (defaults to true)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 # Certificates

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -309,7 +309,7 @@ source.
 |:-----|:------------|:--------|:--------|
 | cluster_domain_suffix | Queries for domains with the suffix will be answered by coredns | "cluster.local" | "k8s.example.com" |
 | controller_count | Number of controller VMs | 1 | 1 |
-| enable_aggregation | Enable the Kubernetes Aggregation Layer | false | true |
+| enable_aggregation | Enable the Kubernetes Aggregation Layer | true | false |
 | enable_reporting | Enable usage or analytics reporting to upstreams (Calico) | false | true |
 | network_mtu | CNI interface MTU (applies to calico only) | 1480 | 8981 |
 | network_ip_autodetection_method | Method to autodetect the host IPv4 address (applies to calico only) | "first-found" or "can-reach=192.168.192.1" |

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -340,7 +340,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | enable_reporting | Enable usage or analytics reporting to upstreams (Calico) | false | true |
-| enable_aggregation | Enable the Kubernetes Aggreagation Layer | false | true |
+| enable_aggregation | Enable the Kubernetes Aggreagation Layer | true | false |
 | reservation_ids | Map Packet hardware reservation IDs to instances. | {} | { controller-0 = "55555f20-a1fb-55bd-1e11-11af11d11111" } |
 | reservation_ids_default | Default hardware reservation ID for nodes not listed in the `reservation_ids` map. | "" | "next-available"|
 | certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -124,9 +124,9 @@ variable "enable_reporting" {
 }
 
 variable "enable_aggregation" {
-  description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
+  description = "Enable the Kubernetes Aggregation Layer (defaults to true)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 # Certificates

--- a/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
@@ -106,9 +106,9 @@ variable "enable_reporting" {
 }
 
 variable "enable_aggregation" {
-  description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
+  description = "Enable the Kubernetes Aggregation Layer (defaults to true)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 # Certificates

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -148,9 +148,9 @@ variable "node_private_cidr" {
 }
 
 variable "enable_aggregation" {
-  description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
+  description = "Enable the Kubernetes Aggregation Layer (defaults to true)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "reservation_ids" {


### PR DESCRIPTION
With usage of the latest cert-manager it is obligatory to enable api
aggregation on the apiserver.

This commit changes the default behavior of the installer to always
enable aggregation.