### PR TITLE
Bring back iPXE installation for Flatcar ARM images

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -296,7 +296,8 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | controller_count | Number of controllers (i.e. masters) | 1 | 1 |
 | controller_type | Type of nodes to provision | "baermetal_0" | "t1.small.x86". See https://www.packet.com/developers/api/#plans for more |
 | os_channel | Flatcar Container Linux channel to install from | stable | stable, beta, alpha, edge |
-| os_version | Version of a Flatcar Linux release | current | 2191.5.0 |
+| os_arch    | Flatcar Container Linux architecture to install | amd64  | amd64, arm64 |
+| os_version | Version of a Flatcar Container Linux release, only for iPXE | current | 2191.5.0 |
 | ipxe_script_url | URL that contains iPXE script to boot Flatcar on the node over PXE | "" | https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/amd64-usr/packet.ipxe |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | network_mtu | CNI interface MTU (calico only) | 1480 | 8981 |
@@ -318,7 +319,8 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | type | Type of nodes to provision | "baremetal_0" | "t1.small.x86". See https://www.packet.com/developers/api/#plans for more |
 | labels | Comma separated labels to be added to the worker nodes | "" | "node.supernova.io/role=backend" |
 | os_channel | Flatcar Container Linux channel to install from | stable | stable, beta, alpha, edge |
-| os_version | Version of a Flatcar Linux release | current | 2191.5.0 |
+| os_arch    | Flatcar Container Linux architecture to install | amd64  | amd64, arm64 |
+| os_version | Version of a Flatcar Container Linux release, only for iPXE | current | 2191.5.0 |
 | ipxe_script_url | URL that contains iPXE script to boot Flatcar on the node over PXE | "" | https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/amd64-usr/packet.ipxe |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -296,6 +296,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | controller_count | Number of controllers (i.e. masters) | 1 | 1 |
 | controller_type | Type of nodes to provision | "baermetal_0" | "t1.small.x86". See https://www.packet.com/developers/api/#plans for more |
 | os_channel | Flatcar Container Linux channel to install from | stable | stable, beta, alpha, edge |
+| os_version | Version of a Flatcar Linux release | current | 2191.5.0 |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | network_mtu | CNI interface MTU (calico only) | 1480 | 8981 |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
@@ -316,6 +317,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | type | Type of nodes to provision | "baremetal_0" | "t1.small.x86". See https://www.packet.com/developers/api/#plans for more |
 | labels | Comma separated labels to be added to the worker nodes | "" | "node.supernova.io/role=backend" |
 | os_channel | Flatcar Container Linux channel to install from | stable | stable, beta, alpha, edge |
+| os_version | Version of a Flatcar Linux release | current | 2191.5.0 |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | setup_raid | Flag to create a RAID 0 from extra disks on a Packet node | "false" | "true" |

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -142,8 +142,6 @@ module "controller" {
   controller_count = 1
   controller_type  = "t1.small.x86"
 
-  ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe"
-
   management_cidrs = [
     "0.0.0.0/0",       # Instances can be SSH-ed into from anywhere on the internet.
   ]
@@ -177,8 +175,6 @@ module "worker-pool-helium" {
 
   count = 2
   type  = "t1.small.x86"
-
-  ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe"
 
   kubeconfig = "${module.controller.kubeconfig}"
 
@@ -301,7 +297,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | controller_type | Type of nodes to provision | "baermetal_0" | "t1.small.x86". See https://www.packet.com/developers/api/#plans for more |
 | os_channel | Flatcar Container Linux channel to install from | stable | stable, beta, alpha, edge |
 | os_version | Version of a Flatcar Linux release | current | 2191.5.0 |
-| ipxe_script_url | URL that contains iPXE script to boot Flatcar on the node over PXE | https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe |
+| ipxe_script_url | URL that contains iPXE script to boot Flatcar on the node over PXE | "" | https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/amd64-usr/packet.ipxe |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | network_mtu | CNI interface MTU (calico only) | 1480 | 8981 |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
@@ -323,7 +319,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | labels | Comma separated labels to be added to the worker nodes | "" | "node.supernova.io/role=backend" |
 | os_channel | Flatcar Container Linux channel to install from | stable | stable, beta, alpha, edge |
 | os_version | Version of a Flatcar Linux release | current | 2191.5.0 |
-| ipxe_script_url | URL that contains iPXE script to boot Flatcar on the node over PXE | https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe | https://scripts.foobar.com/ipxe-flatcar.ipxe |
+| ipxe_script_url | URL that contains iPXE script to boot Flatcar on the node over PXE | "" | https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/amd64-usr/packet.ipxe |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | setup_raid | Flag to create a RAID 0 from extra disks on a Packet node | "false" | "true" |

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -142,6 +142,8 @@ module "controller" {
   controller_count = 1
   controller_type  = "t1.small.x86"
 
+  ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe"
+
   management_cidrs = [
     "0.0.0.0/0",       # Instances can be SSH-ed into from anywhere on the internet.
   ]
@@ -175,6 +177,8 @@ module "worker-pool-helium" {
 
   count = 2
   type  = "t1.small.x86"
+
+  ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe"
 
   kubeconfig = "${module.controller.kubeconfig}"
 
@@ -297,6 +301,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | controller_type | Type of nodes to provision | "baermetal_0" | "t1.small.x86". See https://www.packet.com/developers/api/#plans for more |
 | os_channel | Flatcar Container Linux channel to install from | stable | stable, beta, alpha, edge |
 | os_version | Version of a Flatcar Linux release | current | 2191.5.0 |
+| ipxe_script_url | URL that contains iPXE script to boot Flatcar on the node over PXE | https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | network_mtu | CNI interface MTU (calico only) | 1480 | 8981 |
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
@@ -318,6 +323,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | labels | Comma separated labels to be added to the worker nodes | "" | "node.supernova.io/role=backend" |
 | os_channel | Flatcar Container Linux channel to install from | stable | stable, beta, alpha, edge |
 | os_version | Version of a Flatcar Linux release | current | 2191.5.0 |
+| ipxe_script_url | URL that contains iPXE script to boot Flatcar on the node over PXE | https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe | https://scripts.foobar.com/ipxe-flatcar.ipxe |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | setup_raid | Flag to create a RAID 0 from extra disks on a Packet node | "false" | "true" |

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=a8c27deb0e2390c632a82512657310b9c4eb7782"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=721a2bf5edd790ad50fa98797b59e16774bd6535"
 
   cluster_name = "${var.cluster_name}"
 
@@ -22,4 +22,6 @@ module "bootkube" {
   enable_aggregation    = "${var.enable_aggregation}"
 
   certs_validity_period_hours = "${var.certs_validity_period_hours}"
+
+  container_arch = "${var.os_arch}"
 }

--- a/packet/flatcar-linux/kubernetes/calico/host-endpoint-controller.yaml
+++ b/packet/flatcar-linux/kubernetes/calico/host-endpoint-controller.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       serviceAccountName: calico-hostendpoint-controller
       containers:
-      - image: quay.io/kinvolk/calico-hostendpoint-controller:v0.0.2
+      - image: kinvolk/calico-hostendpoint-controller:v0.0.2
         name: calico-hostendpoint-controller
         volumeMounts:
         - mountPath: /tmp/

--- a/packet/flatcar-linux/kubernetes/cl/controller-install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller-install.yaml.tmpl
@@ -40,34 +40,20 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-
-          # A comma-separated list of major device numbers. Modify to control which device types
-          # are considered for OS installation.
-          # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
-          major_numbers="8,259"
-
-          # This function returns the path to the block device which represents the smallest disk
-          # attached to the system. The output can be passed to the flatcar-install script.
-          function select_install_disk() {
-            local major_numbers="$1"
-
-            local disk=$(lsblk -lnpd -I "$${major_numbers}" \
-              | sort -h -k 4,4 \
-              | head -1 \
-              | awk '{print $1}'
-            )
-
-            echo "$${disk}"
-          }
-
-          os_disk="$(select_install_disk $${major_numbers})"
+          if [ "${os_arch}" = arm64 ]; then
+            curl -o /tmp/Flatcar_ARM_Testing_Key.asc \
+              https://www.flatcar-linux.org/security/image-signing-key/Flatcar_ARM_Testing_Key.asc
+            ARG="-d /dev/sda -k /tmp/Flatcar_ARM_Testing_Key.asc"
+          else
+            ARG="-s"
+          fi
 
           flatcar-install \
-            -d "$${os_disk}" \
             -C "${os_channel}" \
             -V "${os_version}" \
             -o "${flatcar_linux_oem}" \
-            -i /opt/postinstall-ignition.json
+            -i /opt/postinstall-ignition.json \
+            $ARG
           udevadm settle
           systemctl reboot
 passwd:

--- a/packet/flatcar-linux/kubernetes/cl/controller-install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller-install.yaml.tmpl
@@ -1,0 +1,76 @@
+---
+systemd:
+  units:
+    - name: installer.service
+      enable: true
+      contents: |
+        [Unit]
+        StartLimitBurst=5
+        StartLimitIntervalSec=3600s
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        Type=simple
+        Restart=always
+        RestartSec=60
+        ExecStart=/opt/installer
+        [Install]
+        WantedBy=multi-user.target
+    # Avoid using the standard SSH port so terraform apply cannot SSH until
+    # post-install. But admins may SSH to debug disk install problems.
+    # After install, sshd will use port 22 and users/terraform can connect.
+    - name: sshd.socket
+      dropins:
+        - name: 10-sshd-port.conf
+          contents: |
+            [Socket]
+            ListenStream=
+            ListenStream=2222
+storage:
+  files:
+    - path: /opt/postinstall-ignition.json
+      filesystem: root
+      mode: 0500
+      contents:
+        inline: |
+          ${postinstall_ignition}
+    - path: /opt/installer
+      filesystem: root
+      mode: 0500
+      contents:
+        inline: |
+          #!/bin/bash -ex
+
+          # A comma-separated list of major device numbers. Modify to control which device types
+          # are considered for OS installation.
+          # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
+          major_numbers="8,259"
+
+          # This function returns the path to the block device which represents the smallest disk
+          # attached to the system. The output can be passed to the flatcar-install script.
+          function select_install_disk() {
+            local major_numbers="$1"
+
+            local disk=$(lsblk -lnpd -I "$${major_numbers}" \
+              | sort -h -k 4,4 \
+              | head -1 \
+              | awk '{print $1}'
+            )
+
+            echo "$${disk}"
+          }
+
+          os_disk="$(select_install_disk $${major_numbers})"
+
+          flatcar-install \
+            -d "$${os_disk}" \
+            -C "${os_channel}" \
+            -V "${os_version}" \
+            -o "${flatcar_linux_oem}" \
+            -i /opt/postinstall-ignition.json
+          udevadm settle
+          systemctl reboot
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys: ${ssh_keys}

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,8 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.4.3"
+            Environment="ETCD_IMAGE_URL=${etcd_arch_url_prefix}quay.io/coreos/etcd"
+            Environment="ETCD_IMAGE_TAG=v3.4.3${etcd_arch_tag_suffix}"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"
@@ -25,6 +26,8 @@ systemd:
             Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt"
             Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
             Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
+            Environment="RKT_RUN_ARGS=${etcd_arch_rkt_args}"
+            Environment="${etcd_arch_options}"
             ExecStopPost=-/opt/etcd-rejoin
     - name: docker.service
       enable: true
@@ -176,7 +179,7 @@ storage:
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            docker://quay.io/kinvolk/bootkube:v0.14.0-${os_arch} \
+            ${etcd_arch_url_prefix}quay.io/kinvolk/bootkube:v0.14.0-${os_arch} \
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -168,13 +168,15 @@ storage:
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume assets,kind=host,source=/opt/bootkube/assets \
             --mount volume=assets,target=/assets \
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            quay.io/kinvolk/bootkube:v0.14.0-${os_arch} \
+            docker://quay.io/kinvolk/bootkube:v0.14.0-${os_arch} \
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -146,7 +146,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
+          KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube-${os_arch}
           KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
@@ -174,7 +174,7 @@ storage:
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            quay.io/coreos/bootkube:v0.14.0 \
+            quay.io/kinvolk/bootkube:v0.14.0-${os_arch} \
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -65,6 +65,7 @@ data "template_file" "controller-install" {
   vars {
     os_channel           = "${var.os_channel}"
     os_version           = "${var.os_version}"
+    os_arch              = "${var.os_arch}"
     flatcar_linux_oem    = "packet"
     ssh_keys             = "${jsonencode("${var.ssh_keys}")}"
     postinstall_ignition = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -41,7 +41,7 @@ resource "packet_device" "controllers" {
   hostname         = "${var.cluster_name}-controller-${count.index}"
   plan             = "${var.controller_type}"
   facilities       = ["${var.facility}"]
-  operating_system = "flatcar_${var.os_channel}"
+  operating_system = "${var.ipxe_script_url != "" ? "custom_ipxe" : format("flatcar_%s", var.os_channel)}"
   billing_cycle    = "hourly"
   project_id       = "${var.project_id}"
   user_data        = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -44,7 +44,7 @@ resource "packet_device" "controllers" {
   operating_system = "${var.ipxe_script_url != "" ? "custom_ipxe" : format("flatcar_%s", var.os_channel)}"
   billing_cycle    = "hourly"
   project_id       = "${var.project_id}"
-  user_data        = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+  user_data        = "${var.ipxe_script_url != "" ? element(data.ct_config.controller-install-ignitions.*.rendered, count.index) : element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
 
   # If not present in the map, it uses ${var.reservation_ids_default}.
   hardware_reservation_id = "${lookup(var.reservation_ids, format("controller-%v", count.index), var.reservation_ids_default)}"

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -82,6 +82,8 @@ data "template_file" "controller-configs" {
   template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
 
   vars {
+    os_arch = "${var.os_arch}"
+
     # Cannot use cyclic dependencies on controllers or their DNS records
     etcd_name   = "etcd${count.index}"
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -85,8 +85,15 @@ data "template_file" "controller-configs" {
     os_arch = "${var.os_arch}"
 
     # Cannot use cyclic dependencies on controllers or their DNS records
-    etcd_name   = "etcd${count.index}"
-    etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
+    etcd_name             = "etcd${count.index}"
+    etcd_domain           = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
+    # we need to prepend a prefix 'docker://' for arm64, because arm64 images
+    # on quay prevent us from downloading ACI correctly.
+    # So it's workaround to download arm64 images until quay images could be fixed.
+    etcd_arch_url_prefix  = "${var.os_arch == "arm64" ? "docker://" : ""}"
+    etcd_arch_tag_suffix  = "${var.os_arch == "arm64" ? "-arm64" : ""}"
+    etcd_arch_rkt_args    = "${var.os_arch == "arm64" ? "--insecure-options=image" : ""}"
+    etcd_arch_options     = "${var.os_arch == "arm64" ? "ETCD_UNSUPPORTED_ARCH=arm64" : ""}"
 
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
     etcd_initial_cluster  = "${join(",", data.template_file.etcds.*.rendered)}"

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -48,7 +48,7 @@ variable "controller_type" {
 variable "ipxe_script_url" {
   type = "string"
 
-  # Workaround. iPXE-booting Flatcar on Packet over HTTPS is failing due to a bug in iPXE.
+  # Note: iPXE-booting Flatcar on Packet over HTTPS is failing due to a bug in iPXE.
   # This patch is supposed to fix this: http://git.ipxe.org/ipxe.git/commitdiff/b6ffe28a2
   # However, the upstream fix can work only when the HTTPS server does not rely on elliptic
   # curves. So we should use HTTPS only for servers without elliptic curves, and otherwise
@@ -56,8 +56,7 @@ variable "ipxe_script_url" {
   # curves. it should not be a problem in that case.
   # It has been possible to natively install Flatcar images as official OS option on Packet,
   # but only for amd64. There is no arm64 Flatcar image available on Packet.
-  # So we are not able to simply remove iPXE boot altogether.
-  default = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe"
+  default = ""
 
   description = "Location to load the pxe boot script from"
 }

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -30,7 +30,7 @@ variable "os_channel" {
 variable "os_version" {
   type        = "string"
   default     = "current"
-  description = "Flatcar Linux version to install (for example '2191.5.0' - see https://www.flatcar-linux.org/releases/)"
+  description = "Flatcar Container Linux version to install (for example '2191.5.0' - see https://www.flatcar-linux.org/releases/), only for iPXE"
 }
 
 variable "controller_count" {

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -21,6 +21,12 @@ variable "project_id" {
 
 # Nodes
 
+variable "os_arch" {
+  type        = "string"
+  default     = "amd64"
+  description = "Flatcar Container Linux architecture to install (amd64, arm64)"
+}
+
 variable "os_channel" {
   type        = "string"
   default     = "stable"

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -39,6 +39,23 @@ variable "controller_type" {
   description = "Packet instance type for controllers"
 }
 
+variable "ipxe_script_url" {
+  type = "string"
+
+  # Workaround. iPXE-booting Flatcar on Packet over HTTPS is failing due to a bug in iPXE.
+  # This patch is supposed to fix this: http://git.ipxe.org/ipxe.git/commitdiff/b6ffe28a2
+  # However, the upstream fix can work only when the HTTPS server does not rely on elliptic
+  # curves. So we should use HTTPS only for servers without elliptic curves, and otherwise
+  # use HTTP. Fortunately, since stable.release.flatcar-linux.net does not rely on elliptic
+  # curves. it should not be a problem in that case.
+  # It has been possible to natively install Flatcar images as official OS option on Packet,
+  # but only for amd64. There is no arm64 Flatcar image available on Packet.
+  # So we are not able to simply remove iPXE boot altogether.
+  default = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe"
+
+  description = "Location to load the pxe boot script from"
+}
+
 variable "facility" {
   type        = "string"
   description = "Packet facility to deploy the cluster in"

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -27,6 +27,12 @@ variable "os_channel" {
   description = "Flatcar Container Linux channel to install from (stable, beta, alpha, edge)"
 }
 
+variable "os_version" {
+  type        = "string"
+  default     = "current"
+  description = "Flatcar Linux version to install (for example '2191.5.0' - see https://www.flatcar-linux.org/releases/)"
+}
+
 variable "controller_count" {
   type        = "string"
   default     = "1"

--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -40,34 +40,21 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-
-          # A comma-separated list of major device numbers. Modify to control which device types
-          # are considered for OS installation and data RAID.
-          # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
-          major_numbers="8,259"
-
-          # This function returns the path to the block device which represents the smallest disk
-          # attached to the system. The output can be passed to the flatcar-install script.
-          function select_install_disk() {
-            local major_numbers="$1"
-
-            local disk=$(lsblk -lnpd -I "$${major_numbers}" \
-              | sort -h -k 4,4 \
-              | head -1 \
-              | awk '{print $1}'
-            )
-
-            echo "$${disk}"
-          }
-
-          os_disk="$(select_install_disk $${major_numbers})"
+          if [ "${os_arch}" = arm64 ]; then
+            curl -o /tmp/Flatcar_ARM_Testing_Key.asc \
+              https://www.flatcar-linux.org/security/image-signing-key/Flatcar_ARM_Testing_Key.asc
+            ARG="-d /dev/sda -k /tmp/Flatcar_ARM_Testing_Key.asc"
+          else
+            ARG="-s"
+          fi
 
           flatcar-install \
-            -d "$${os_disk}" \
             -C "${os_channel}" \
             -V "${os_version}" \
             -o "${flatcar_linux_oem}" \
-            -i /opt/postinstall-ignition.json
+            -i /opt/postinstall-ignition.json \
+            $ARG
+
           udevadm settle
           systemctl reboot
 passwd:

--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -1,0 +1,76 @@
+---
+systemd:
+  units:
+    - name: installer.service
+      enable: true
+      contents: |
+        [Unit]
+        StartLimitBurst=5
+        StartLimitIntervalSec=3600s
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        Type=simple
+        Restart=always
+        RestartSec=60
+        ExecStart=/opt/installer
+        [Install]
+        WantedBy=multi-user.target
+    # Avoid using the standard SSH port so terraform apply cannot SSH until
+    # post-install. But admins may SSH to debug disk install problems.
+    # After install, sshd will use port 22 and users/terraform can connect.
+    - name: sshd.socket
+      dropins:
+        - name: 10-sshd-port.conf
+          contents: |
+            [Socket]
+            ListenStream=
+            ListenStream=2222
+storage:
+  files:
+    - path: /opt/postinstall-ignition.json
+      filesystem: root
+      mode: 0500
+      contents:
+        inline: |
+          ${postinstall_ignition}
+    - path: /opt/installer
+      filesystem: root
+      mode: 0500
+      contents:
+        inline: |
+          #!/bin/bash -ex
+
+          # A comma-separated list of major device numbers. Modify to control which device types
+          # are considered for OS installation and data RAID.
+          # https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
+          major_numbers="8,259"
+
+          # This function returns the path to the block device which represents the smallest disk
+          # attached to the system. The output can be passed to the flatcar-install script.
+          function select_install_disk() {
+            local major_numbers="$1"
+
+            local disk=$(lsblk -lnpd -I "$${major_numbers}" \
+              | sort -h -k 4,4 \
+              | head -1 \
+              | awk '{print $1}'
+            )
+
+            echo "$${disk}"
+          }
+
+          os_disk="$(select_install_disk $${major_numbers})"
+
+          flatcar-install \
+            -d "$${os_disk}" \
+            -C "${os_channel}" \
+            -V "${os_version}" \
+            -o "${flatcar_linux_oem}" \
+            -i /opt/postinstall-ignition.json
+          udevadm settle
+          systemctl reboot
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys: ${ssh_keys}

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -251,6 +251,8 @@ storage:
           #!/bin/bash
           set -e
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -236,7 +236,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
+          KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube-${os_arch}
           KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
@@ -255,7 +255,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.16.2 \
+            docker://k8s.gcr.io/hyperkube-${os_arch}:v1.16.2 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -42,6 +42,23 @@ variable "taints" {
   description = "Comma separated list of taints. eg. 'clusterType=staging:NoSchedule,nodeType=storage:NoSchedule'"
 }
 
+variable "ipxe_script_url" {
+  type = "string"
+
+  # Workaround. iPXE-booting Flatcar on Packet over HTTPS is failing due to a bug in iPXE.
+  # This patch is supposed to fix this: http://git.ipxe.org/ipxe.git/commitdiff/b6ffe28a2
+  # However, the upstream fix can work only when the HTTPS server does not rely on elliptic
+  # curves. So we should use HTTPS only for servers without elliptic curves, and otherwise
+  # use HTTP. Fortunately, since stable.release.flatcar-linux.net does not rely on elliptic
+  # curves. it should not be a problem in that case.
+  # It has been possible to natively install Flatcar images as official OS option on Packet,
+  # but only for amd64. There is no arm64 Flatcar image available on Packet.
+  # So we are not able to simply remove iPXE boot altogether.
+  default = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe"
+
+  description = "Location to load the pxe boot script from"
+}
+
 variable "facility" {
   type        = "string"
   description = "Packet facility to deploy the cluster in"

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -63,6 +63,12 @@ variable "facility" {
   description = "Packet facility to deploy the cluster in"
 }
 
+variable "os_arch" {
+  type        = "string"
+  default     = "amd64"
+  description = "Flatcar Container Linux architecture to install (amd64, arm64)"
+}
+
 variable "os_channel" {
   type        = "string"
   default     = "stable"

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -70,6 +70,12 @@ variable "os_channel" {
   description = "Flatcar Container Linux channel to install from (stable, beta, alpha, edge)"
 }
 
+variable "os_version" {
+  type        = "string"
+  default     = "current"
+  description = "Flatcar Linux version to install (for example '2191.5.0' - see https://www.flatcar-linux.org/releases/)"
+}
+
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
   type        = "string"

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -45,7 +45,7 @@ variable "taints" {
 variable "ipxe_script_url" {
   type = "string"
 
-  # Workaround. iPXE-booting Flatcar on Packet over HTTPS is failing due to a bug in iPXE.
+  # Note: iPXE-booting Flatcar on Packet over HTTPS is failing due to a bug in iPXE.
   # This patch is supposed to fix this: http://git.ipxe.org/ipxe.git/commitdiff/b6ffe28a2
   # However, the upstream fix can work only when the HTTPS server does not rely on elliptic
   # curves. So we should use HTTPS only for servers without elliptic curves, and otherwise
@@ -53,8 +53,7 @@ variable "ipxe_script_url" {
   # curves. it should not be a problem in that case.
   # It has been possible to natively install Flatcar images as official OS option on Packet,
   # but only for amd64. There is no arm64 Flatcar image available on Packet.
-  # So we are not able to simply remove iPXE boot altogether.
-  default = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/add-packet-ipxe/packet.ipxe"
+  default = ""
 
   description = "Location to load the pxe boot script from"
 }

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -72,7 +72,7 @@ variable "os_channel" {
 variable "os_version" {
   type        = "string"
   default     = "current"
-  description = "Flatcar Linux version to install (for example '2191.5.0' - see https://www.flatcar-linux.org/releases/)"
+  description = "Flatcar Container Linux version to install (for example '2191.5.0' - see https://www.flatcar-linux.org/releases/), only for iPXE"
 }
 
 variable "cluster_domain_suffix" {

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -42,6 +42,7 @@ data "template_file" "configs" {
   template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
 
   vars {
+    os_arch               = "${var.os_arch}"
     kubeconfig            = "${indent(10, "${var.kubeconfig}")}"
     ssh_keys              = "${jsonencode("${var.ssh_keys}")}"
     k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -25,6 +25,7 @@ data "template_file" "install" {
   vars {
     os_channel           = "${var.os_channel}"
     os_version           = "${var.os_version}"
+    os_arch              = "${var.os_arch}"
     flatcar_linux_oem    = "packet"
     ssh_keys             = "${jsonencode("${var.ssh_keys}")}"
     postinstall_ignition = "${data.ct_config.ignitions.rendered}"

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -8,10 +8,14 @@ resource "packet_device" "nodes" {
   project_id       = "${var.project_id}"
   ipxe_script_url  = "${var.ipxe_script_url}"
   always_pxe       = "false"
-  user_data        = "${data.ct_config.ignitions.rendered}"
+  user_data        = "${var.ipxe_script_url != "" ? data.ct_config.install-ignitions.rendered : data.ct_config.ignitions.rendered}"
 
   # If not present in the map, it uses ${var.reservation_ids_default}.
   hardware_reservation_id = "${lookup(var.reservation_ids, format("worker-%v", count.index), var.reservation_ids_default)}"
+}
+
+data "ct_config" "install-ignitions" {
+  content = "${data.template_file.install.rendered}"
 }
 
 # These configs are used for the fist boot, to run flatcar-install

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -3,7 +3,7 @@ resource "packet_device" "nodes" {
   hostname         = "${var.cluster_name}-${var.pool_name}-worker-${count.index}"
   plan             = "${var.type}"
   facilities       = ["${var.facility}"]
-  operating_system = "flatcar_${var.os_channel}"
+  operating_system = "${var.ipxe_script_url != "" ? "custom_ipxe" : format("flatcar_%s", var.os_channel)}"
   billing_cycle    = "hourly"
   project_id       = "${var.project_id}"
   ipxe_script_url  = "${var.ipxe_script_url}"


### PR DESCRIPTION
There is on-going work to support Flatcar Linux images for ARM64 architecture. (for example https://github.com/flatcar-linux/coreos-overlay/pull/88)
To make it integrated with Lokomotive, we should bring back the old iPXE installation code, because at the moment there is no way to natively install Flatcar ARM64 images on Packet.

This PR partly reverts https://github.com/kinvolk/lokomotive-kubernetes/pull/28.

**How to test:**

Add these variables to your arm64 workers/controllers:
```
ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/arm64-usr/packet.ipxe"
(controller_)type  = "c2.large.arm"
os_arch = "arm64"
os_channel = "alpha"
```
To test it for amd64 only the following variable is needed for workers/controllers:
```
ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/amd64-usr/packet.ipxe"
```
You can mix both types in controller and worker pools.