### PR TITLE
packet: fix issues when downloading rkt images

### DIFF
--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -142,13 +142,15 @@ storage:
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume assets,kind=host,source=/opt/bootkube/assets \
             --mount volume=assets,target=/assets \
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            quay.io/coreos/bootkube:v0.14.0 \
+            docker://quay.io/coreos/bootkube:v0.14.0 \
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"

--- a/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -127,6 +127,8 @@ storage:
           #!/bin/bash
           set -e
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \

--- a/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -144,13 +144,15 @@ storage:
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume assets,kind=host,source=/opt/bootkube/assets \
             --mount volume=assets,target=/assets \
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            quay.io/coreos/bootkube:v0.14.0 \
+            docker://quay.io/coreos/bootkube:v0.14.0 \
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"

--- a/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -112,6 +112,8 @@ storage:
           #!/bin/bash
           set -e
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \

--- a/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -155,13 +155,15 @@ storage:
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume assets,kind=host,source=/opt/bootkube/assets \
             --mount volume=assets,target=/assets \
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            quay.io/coreos/bootkube:v0.14.0 \
+            docker://quay.io/coreos/bootkube:v0.14.0 \
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -150,13 +150,15 @@ storage:
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume assets,kind=host,source=/opt/bootkube/assets \
             --mount volume=assets,target=/assets \
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            quay.io/coreos/bootkube:v0.14.0 \
+            docker://quay.io/coreos/bootkube:v0.14.0 \
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -113,6 +113,8 @@ storage:
           #!/bin/bash
           set -e
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \

--- a/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -145,13 +145,15 @@ storage:
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume assets,kind=host,source=/opt/bootkube/assets \
             --mount volume=assets,target=/assets \
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            quay.io/coreos/bootkube:v0.14.0 \
+            docker://quay.io/coreos/bootkube:v0.14.0 \
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"

--- a/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -108,6 +108,8 @@ storage:
           #!/bin/bash
           set -e
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \

--- a/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -153,13 +153,15 @@ storage:
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume assets,kind=host,source=/opt/bootkube/assets \
             --mount volume=assets,target=/assets \
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            quay.io/coreos/bootkube:v0.14.0 \
+            docker://quay.io/coreos/bootkube:v0.14.0 \
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -134,6 +134,8 @@ storage:
           #!/bin/bash
           set -e
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -168,13 +168,15 @@ storage:
           # Move experimental manifests
           [ -n "$(ls /opt/bootkube/assets/manifests-*/* 2>/dev/null)" ] && mv /opt/bootkube/assets/manifests-*/* /opt/bootkube/assets/manifests && rm -rf /opt/bootkube/assets/manifests-*
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume assets,kind=host,source=/opt/bootkube/assets \
             --mount volume=assets,target=/assets \
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
             $${RKT_OPTS} \
-            quay.io/coreos/bootkube:v0.14.0 \
+            docker://quay.io/coreos/bootkube:v0.14.0 \
             --net=host \
             --dns=host \
             --exec=/bootkube -- start --asset-dir=/assets "$@"

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -251,6 +251,8 @@ storage:
           #!/bin/bash
           set -e
           exec /usr/bin/rkt run \
+            --stage1-path=/usr/lib64/rkt/stage1-images/stage1-fly.aci \
+            --insecure-options=image \
             --trust-keys-from-https \
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \


### PR DESCRIPTION
Let's fix hidden issues discovered during tests for ARM support.

* rkt image name should have a prefix `docker://`
* rkt run should be running with stage1-fly
* rkt run/fetch should have an option `--insecure-options=image` to
  avoid intermittent cert errors.