### PR TITLE
Update to Kubernetes 1.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Lokomotive is an open source project by [Kinvolk](https://kinvolk.io/) which dis
 
 ## Features
 
-* Kubernetes v1.15.3 (upstream, via [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))
+* Kubernetes v1.16.1 (upstream, via [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))
 * Single or multi-master, [Calico](https://www.projectcalico.org/) or [flannel](https://github.com/coreos/flannel) networking
 * On-cluster etcd with TLS, [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)-enabled, [network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 * Advanced features like [worker pools](docs/advanced/worker-pools.md) and [snippets](docs/advanced/customization.md#flatcar-linux) customization

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Lokomotive is an open source project by [Kinvolk](https://kinvolk.io/) which dis
 
 ## Features
 
-* Kubernetes v1.16.1 (upstream, via [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))
+* Kubernetes v1.16.2 (upstream, via [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))
 * Single or multi-master, [Calico](https://www.projectcalico.org/) or [flannel](https://github.com/coreos/flannel) networking
 * On-cluster etcd with TLS, [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)-enabled, [network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 * Advanced features like [worker pools](docs/advanced/worker-pools.md) and [snippets](docs/advanced/customization.md#flatcar-linux) customization

--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -89,8 +89,8 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/master \
-          --node-labels=node-role.kubernetes.io/controller="true" \
+          --node-labels=node.kubernetes.io/master \
+          --node-labels=node.kubernetes.io/controller="true" \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \

--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -121,7 +121,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.3.15"
+            Environment="ETCD_IMAGE_TAG=v3.4.2"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"

--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -121,7 +121,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/aws/flatcar-linux/kubernetes/require.tf
+++ b/aws/flatcar-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "2.25.0"
+  version = "2.31.0"
 }
 
 provider "local" {

--- a/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -100,7 +100,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -131,7 +131,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.16.1 \
+            docker://k8s.gcr.io/hyperkube:v1.16.2 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -65,7 +65,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/node \
+          --node-labels=node.kubernetes.io/node \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -100,7 +100,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -131,7 +131,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.15.3 \
+            docker://k8s.gcr.io/hyperkube:v1.16.1 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/azure/flatcar-linux/kubernetes/bootkube.tf
+++ b/azure/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
 
   cluster_name = "${var.cluster_name}"
   api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/azure/flatcar-linux/kubernetes/bootkube.tf
+++ b/azure/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
 
   cluster_name = "${var.cluster_name}"
   api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -85,8 +85,8 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/master \
-          --node-labels=node-role.kubernetes.io/controller="true" \
+          --node-labels=node.kubernetes.io/master \
+          --node-labels=node.kubernetes.io/controller="true" \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \

--- a/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -123,7 +123,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.3.15"
+            Environment="ETCD_IMAGE_TAG=v3.4.2"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"

--- a/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -123,7 +123,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/azure/flatcar-linux/kubernetes/require.tf
+++ b/azure/flatcar-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "azurerm" {
-  version = "~> 1.21"
+  version = "1.35.0"
 }
 
 provider "local" {

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -46,13 +46,13 @@ variable "worker_count" {
 
 variable "controller_type" {
   type        = "string"
-  default     = "Standard_DS1_v2"
+  default     = "Standard_B2s"
   description = "Machine type for controllers (see `az vm list-skus --location centralus`)"
 }
 
 variable "worker_type" {
   type        = "string"
-  default     = "Standard_F1"
+  default     = "Standard_B2s"
   description = "Machine type for workers (see `az vm list-skus --location centralus`)"
 }
 

--- a/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -63,7 +63,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/node \
+          --node-labels=node.kubernetes.io/node \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -98,7 +98,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -116,7 +116,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.15.3 \
+            docker://k8s.gcr.io/hyperkube:v1.16.1 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname | tr '[:upper:]' '[:lower:]')

--- a/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -98,7 +98,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -116,7 +116,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.16.1 \
+            docker://k8s.gcr.io/hyperkube:v1.16.2 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname | tr '[:upper:]' '[:lower:]')

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -50,7 +50,7 @@ variable "count" {
 
 variable "vm_type" {
   type        = "string"
-  default     = "Standard_F1"
+  default     = "Standard_DS1_v2"
   description = "Machine type for instances (see `az vm list-skus --location centralus`)"
 }
 

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]

--- a/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -128,7 +128,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -128,7 +128,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.3.15"
+            Environment="ETCD_IMAGE_TAG=v3.4.2"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${domain_name}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${domain_name}:2380"

--- a/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -98,8 +98,8 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/master \
-          --node-labels=node-role.kubernetes.io/controller="true" \
+          --node-labels=node.kubernetes.io/master \
+          --node-labels=node.kubernetes.io/controller="true" \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \

--- a/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -89,7 +89,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -71,7 +71,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/node \
+          --node-labels=node.kubernetes.io/node \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -89,7 +89,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/ci/aws/provider.tf
+++ b/ci/aws/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "2.25.0"
+  version = "2.31.0"
   alias   = "default"
 }
 

--- a/ci/aws/provider.tf
+++ b/ci/aws/provider.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/ci/packet/packet-cluster.tf.envsubst
+++ b/ci/packet/packet-cluster.tf.envsubst
@@ -58,5 +58,5 @@ module "worker-pool-1" {
 
   kubeconfig = "${module.controller.kubeconfig}"
 
-  labels = "node.supernova.io/role=backend,node-role.kubernetes.io/backend="
+  labels = "node.supernova.io/role=backend"
 }

--- a/ci/packet/provider.tf
+++ b/ci/packet/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "2.25.0"
+  version = "2.31.0"
   alias   = "default"
 }
 

--- a/ci/packet/provider.tf
+++ b/ci/packet/provider.tf
@@ -4,7 +4,7 @@ provider "aws" {
 }
 
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
 
   cluster_name = "${var.cluster_name}"
   api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
 
   cluster_name = "${var.cluster_name}"
   api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -97,8 +97,8 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/master \
-          --node-labels=node-role.kubernetes.io/controller="true" \
+          --node-labels=node.kubernetes.io/master \
+          --node-labels=node.kubernetes.io/controller="true" \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.3.15"
+            Environment="ETCD_IMAGE_TAG=v3.4.2"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -129,7 +129,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/controller.yaml.tmpl
@@ -129,7 +129,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -99,7 +99,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -117,7 +117,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.16.1 \
+            docker://k8s.gcr.io/hyperkube:v1.16.2 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -99,7 +99,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -117,7 +117,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.15.3 \
+            docker://k8s.gcr.io/hyperkube:v1.16.1 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/digital-ocean/container-linux/kubernetes/cl/worker.yaml.tmpl
@@ -70,7 +70,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/node \
+          --node-labels=node.kubernetes.io/node \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/digital-ocean/container-linux/kubernetes/require.tf
+++ b/digital-ocean/container-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "digitalocean" {
-  version = "~> 1.0"
+  version = "1.8.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -24,9 +24,9 @@ Terraform v0.11.13
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Read [concepts](/docs/architecture/concepts.md) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -57,7 +57,7 @@ provider "aws" {
 }
 
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -49,7 +49,7 @@ Configure the AWS provider to use your access key credentials in a `providers.tf
 
 ```tf
 provider "aws" {
-  version = "2.25.0"
+  version = "2.31.0"
   alias   = "default"
 
   region                  = "eu-central-1"

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -27,9 +27,9 @@ Terraform v0.11.12
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Read [concepts](/architecture/concepts/) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -55,7 +55,7 @@ provider "azurerm" {
 }
 
 provider "ct" {
-  version = "~> 0.3"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -50,7 +50,7 @@ Configure the Azure provider in a `providers.tf` file.
 
 ```tf
 provider "azurerm" {
-  version = "~> 1.27.1"
+  version = "1.35.0"
   alias   = "default"
 }
 

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -125,9 +125,9 @@ mv terraform-provider-matchbox-v0.2.3-linux-amd64/terraform-provider-matchbox ~/
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Read [concepts](/architecture/concepts/) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -150,7 +150,7 @@ provider "matchbox" {
 }
 
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -24,9 +24,9 @@ Terraform v0.11.12
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Read [concepts](/architecture/concepts/) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -58,7 +58,7 @@ provider "google" {
 }
 
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -49,7 +49,7 @@ Configure the Google Cloud provider to use your service account key, project-id,
 
 ```tf
 provider "google" {
-  version = "~> 2.5.1"
+  version = "2.16.0"
   alias   = "default"
 
   credentials = "${file("~/.config/google-cloud/terraform.json")}"

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -81,9 +81,9 @@ Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-c
 to `~/.terraform.d/plugins/`, noting the `_v0.3.1` suffix.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Add the [terraform-provider-libvirt](https://github.com/dmacvicar/terraform-provider-libvirt) plugin binary for your system
@@ -128,7 +128,7 @@ Create a file named `provider.tf` with the following contents:
 
 ```tf
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -219,7 +219,7 @@ module "worker-pool-one" {
 
   kubeconfig = "${module.controller.kubeconfig}"
 
-  labels = "node.supernova.io/role=backend,node-role.kubernetes.io/backend="
+  labels = "node.supernova.io/role=backend"
 }
 ```
 

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -25,9 +25,9 @@ Terraform v0.11.13
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.3.1/terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.3.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.3.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.3.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 Read [concepts](/lokomotive/architecture/concepts.md) to learn about Terraform, modules, and organizing resources. Change to your infrastructure repository (e.g. `infra`).
@@ -63,7 +63,7 @@ provider "aws" {
 }
 
 provider "ct" {
-  version = "0.3.1"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -55,7 +55,7 @@ Configure the AWS provider to use your access key credentials in a `providers.tf
 
 ```
 provider "aws" {
-  version = "2.25.0"
+  version = "2.31.0"
   alias   = "default"
 
   region                  = "eu-central-1"

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -179,7 +179,7 @@ module "worker-pool-helium" {
 
   kubeconfig = "${module.controller.kubeconfig}"
 
-  labels = "node.supernova.io/role=backend,node-role.kubernetes.io/backend="
+  labels = "node.supernova.io/role=backend"
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Lokomotive distributes upstream Kubernetes.
 
 ## Features
 
-* Kubernetes v1.15.3 (upstream, via [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))
+* Kubernetes v1.16.1 (upstream, via [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))
 * Single or multi-master, [Calico](https://www.projectcalico.org/) or [flannel](https://github.com/coreos/flannel) networking
 * On-cluster etcd with TLS, [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)-enabled, [network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 * Advanced features like [worker pools](advanced/worker-pools/) and [snippets](advanced/customization/#flatcar-linux) customization

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Lokomotive distributes upstream Kubernetes.
 
 ## Features
 
-* Kubernetes v1.16.1 (upstream, via [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))
+* Kubernetes v1.16.2 (upstream, via [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube))
 * Single or multi-master, [Calico](https://www.projectcalico.org/) or [flannel](https://github.com/coreos/flannel) networking
 * On-cluster etcd with TLS, [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)-enabled, [network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 * Advanced features like [worker pools](advanced/worker-pools/) and [snippets](advanced/customization/#flatcar-linux) customization

--- a/docs/topics/maintenance.md
+++ b/docs/topics/maintenance.md
@@ -161,9 +161,9 @@ mv ~/.terraformrc ~/.terraform-backup
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`. Download the **same version** of `terraform-provider-ct` you were using with `~/.terraformrc`, updating only be done as a followup and is **only** safe for v1.12.2+ clusters!
 
 ```sh
-wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.2.1/terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-tar xzf terraform-provider-ct-v0.2.1-linux-amd64.tar.gz
-mv terraform-provider-ct-v0.2.1-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.2.1
+wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
+mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
 If you use bare-metal, add the [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox) plugin binary for your system to `~/.terraform.d/plugins/`, noting the versioned name.
@@ -195,7 +195,7 @@ provider "matchbox" {
 }
 
 provider "ct" {
-  version = "0.2.1"
+  version = "0.4.0"
 }
 ```
 
@@ -238,7 +238,7 @@ Update the version of the `ct` plugin in each Terraform working directory.
 ```
 # providers.tf
 provider "ct" {
-  version = "0.3.0"
+  version = "0.4.0"
 }
 ```
 

--- a/google-cloud/flatcar-linux/kubernetes/bootkube.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/flatcar-linux/kubernetes/bootkube.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -86,8 +86,8 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/master \
-          --node-labels=node-role.kubernetes.io/controller="true" \
+          --node-labels=node.kubernetes.io/master \
+          --node-labels=node.kubernetes.io/controller="true" \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
           --read-only-port=0 \

--- a/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -124,7 +124,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.3.15"
+            Environment="ETCD_IMAGE_TAG=v3.4.2"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"

--- a/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -124,7 +124,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/google-cloud/flatcar-linux/kubernetes/require.tf
+++ b/google-cloud/flatcar-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "google" {
-  version = ">= 1.19, < 3.0"
+  version = "2.16.0"
 }
 
 provider "local" {

--- a/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -59,7 +59,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/node \
+          --node-labels=node.kubernetes.io/node \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -94,7 +94,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -112,7 +112,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.15.3 \
+            docker://k8s.gcr.io/hyperkube:v1.16.1 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -94,7 +94,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -112,7 +112,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.16.1 \
+            docker://k8s.gcr.io/hyperkube:v1.16.2 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
+  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
 
   cluster_name = "${var.cluster_name}"
 

--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
+  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
 
   cluster_name = "${var.cluster_name}"
 

--- a/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -126,7 +126,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.3.15"
+            Environment="ETCD_IMAGE_TAG=v3.4.2"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"

--- a/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -126,7 +126,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -88,8 +88,8 @@ systemd:
           --lock-file=/var/run/lock/kubelet.lock \
           --hostname-override=${etcd_domain} \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/master \
-          --node-labels=node-role.kubernetes.io/controller="true" \
+          --node-labels=node.kubernetes.io/master \
+          --node-labels=node.kubernetes.io/controller="true" \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "ct" {
-  version = "~> 0.3"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -101,7 +101,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -138,7 +138,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.15.3 \
+            docker://k8s.gcr.io/hyperkube:v1.16.1 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -66,7 +66,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/node \
+          --node-labels=node.kubernetes.io/node \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -101,7 +101,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -138,7 +138,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.16.1 \
+            docker://k8s.gcr.io/hyperkube:v1.16.2 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "ct" {
-  version = "~> 0.3"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
 
   cluster_name = "${var.cluster_name}"
 

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=aec4326328bb7bdbd132a6e0b9c202e40f1ec04c"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=d3bf881fe7c2819ee1752f05c34cf43db26f16d4"
 
   cluster_name = "${var.cluster_name}"
 

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -147,7 +147,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -147,7 +147,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -102,8 +102,8 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/master \
-          --node-labels=node-role.kubernetes.io/controller="true" \
+          --node-labels=node.kubernetes.io/master \
+          --node-labels=node.kubernetes.io/controller="true" \
           --node-labels=lokomotive.alpha.kinvolk.io/public-ipv4=$${COREOS_PACKET_IPV4_PUBLIC_0} \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.3.15"
+            Environment="ETCD_IMAGE_TAG=v3.4.2"
             Environment="ETCD_NAME=${etcd_name}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=https://${etcd_domain}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://${etcd_domain}:2380"

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "ct" {
-  version = "~> 0.3"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -29,5 +29,5 @@ provider "packet" {
 }
 
 provider "aws" {
-  version = "2.25.0"
+  version = "2.31.0"
 }

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -237,7 +237,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.15.3
+          KUBELET_IMAGE_TAG=v1.16.1
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -255,7 +255,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.15.3 \
+            docker://k8s.gcr.io/hyperkube:v1.16.1 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -92,7 +92,7 @@ systemd:
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \
-          --node-labels=node-role.kubernetes.io/node \
+          --node-labels=node.kubernetes.io/node \
           --node-labels=${worker_labels} \
           --node-labels=lokomotive.alpha.kinvolk.io/public-ipv4=$${COREOS_PACKET_IPV4_PUBLIC_0} \
           --pod-manifest-path=/etc/kubernetes/manifests \

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -237,7 +237,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.1
+          KUBELET_IMAGE_TAG=v1.16.2
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -255,7 +255,7 @@ storage:
             --volume config,kind=host,source=/etc/kubernetes \
             --mount volume=config,target=/etc/kubernetes \
             --insecure-options=image \
-            docker://k8s.gcr.io/hyperkube:v1.16.1 \
+            docker://k8s.gcr.io/hyperkube:v1.16.2 \
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)

--- a/packet/flatcar-linux/kubernetes/workers/require.tf
+++ b/packet/flatcar-linux/kubernetes/workers/require.tf
@@ -5,7 +5,7 @@ terraform {
 }
 
 provider "ct" {
-  version = "~> 0.3"
+  version = "0.4.0"
 }
 
 provider "local" {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs==1.0.4
-mkdocs-material==4.4.2
+mkdocs-material==4.4.3
 pygments==2.2.0
 pymdown-extensions==5.0.0


### PR DESCRIPTION
- Dependent on https://github.com/kinvolk/terraform-render-bootkube/pull/23
- Update etcd to v3.4.2
- Update the provider versions
- Update the terraform ct provider to 0.4.0
- Update Kubernetes to 1.16.2
- Update Calico to 3.9.2
- Remove labels `node-role.kubernetes.io`, kubelet cannot set these labels using the flag --node-labels. This is enforced as a security feature. But this can be set manually by cluster-admin.