### PR TITLE
docs: Use relative path to the assets dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 kubeconfig := $(KUBECONFIG)
 ## Following kubeconfig path is only valid from CI
 ifeq ($(RUN_FROM_CI),"true")
-	kubeconfig := "${HOME}/assets/auth/kubeconfig"
+	kubeconfig := "${PWD}/assets/auth/kubeconfig"
 endif
 kubehunter := ./scripts/kube-hunter.sh
 ifeq ($(SKIP_KUBE_HUNTER),"true")
@@ -10,6 +10,8 @@ endif
 
 .PHONY: run-e2e-tests
 run-e2e-tests: kube-hunter
+	# debug: adding to find the assets dir
+	ls -lR
 	KUBECONFIG=${kubeconfig} ./scripts/check-version-skew.sh
 
 kube-hunter:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "aws-tempest" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "./assets"
+  asset_dir = "./assets"
 
   # optional
   worker_count = 2

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "aws-tempest" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "/home/user/.secrets/clusters/yavin"
+  asset_dir          = "./assets"
 
   # optional
   worker_count = 2
@@ -65,7 +65,7 @@ Apply complete! Resources: 64 added, 0 changed, 0 destroyed.
 In 4-8 minutes (varies by platform), the cluster will be ready. This AWS example creates a `yavin.example.com` DNS record to resolve to a network load balancer backed by controller instances.
 
 ```sh
-$ export KUBECONFIG=/home/user/.secrets/clusters/yavin/auth/kubeconfig
+$ export KUBECONFIG=$PWD/assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                                       ROLES              STATUS  AGE  VERSION
 yavin-controller-0.c.example-com.internal  controller,master  Ready   6m   v1.14.1

--- a/ci/aws/aws-cluster.tf.envsubst
+++ b/ci/aws/aws-cluster.tf.envsubst
@@ -6,7 +6,7 @@ module "aws-tempest" {
   dns_zone_id = "$AWS_DNS_ZONE_ID"
   ssh_keys = ["$PUB_KEY"]
 
-  asset_dir = pathexpand("~/assets")
+  asset_dir = "./assets"
 
   worker_count = 2
   worker_type  = "t3.small"

--- a/ci/packet/packet-cluster.tf.envsubst
+++ b/ci/packet/packet-cluster.tf.envsubst
@@ -5,7 +5,7 @@ module "controller" {
 
   ssh_keys = ["$PUB_KEY"]
 
-  asset_dir = pathexpand("~/assets")
+  asset_dir = "./assets"
   cluster_name = "$CLUSTER_ID"
   project_id = "$PACKET_PROJECT_ID"
 

--- a/ci/packet/packet-cluster.tf.envsubst
+++ b/ci/packet/packet-cluster.tf.envsubst
@@ -5,16 +5,16 @@ module "controller" {
 
   ssh_keys = ["$PUB_KEY"]
 
-  asset_dir = "./assets"
+  asset_dir    = "./assets"
   cluster_name = "$CLUSTER_ID"
-  project_id = "$PACKET_PROJECT_ID"
+  project_id   = "$PACKET_PROJECT_ID"
 
   facility = "ams1"
 
   controller_count = 1
 
   management_cidrs = [
-    "0.0.0.0/0",       # Instances can be SSH-ed into from anywhere on the internet.
+    "0.0.0.0/0", # Instances can be SSH-ed into from anywhere on the internet.
   ]
 
   node_private_cidr = "10.0.0.0/8"
@@ -34,13 +34,13 @@ module "worker-pool-1" {
   ssh_keys = ["$PUB_KEY"]
 
   cluster_name = "$CLUSTER_ID"
-  project_id = "$PACKET_PROJECT_ID"
+  project_id   = "$PACKET_PROJECT_ID"
 
-  facility     = "ams1"
-  pool_name    = "pool-1"
+  facility  = "ams1"
+  pool_name = "pool-1"
 
   worker_count = 2
-  type  = "c2.medium.x86"
+  type         = "c2.medium.x86"
 
   kubeconfig = module.controller.kubeconfig
 

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -80,7 +80,7 @@ module "aws-tempest" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "./assets"
+  asset_dir = "./assets"
 
   # optional
   worker_count = 2

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -80,7 +80,7 @@ module "aws-tempest" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "/home/user/.secrets/clusters/tempest"
+  asset_dir          = "./assets"
 
   # optional
   worker_count = 2
@@ -133,7 +133,7 @@ In 4-8 minutes, the Kubernetes cluster will be ready.
 [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your system. Use the generated `kubeconfig` credentials to access the Kubernetes cluster and list nodes.
 
 ```
-$ export KUBECONFIG=/home/user/.secrets/clusters/tempest/auth/kubeconfig
+$ export KUBECONFIG=$PWD/assets/auth/kubeconfig
 $ kubectl get nodes
 NAME           STATUS  ROLES              AGE  VERSION
 ip-10-0-3-155  Ready   controller,master  10m  v1.14.1
@@ -179,7 +179,7 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | dns_zone | AWS Route53 DNS zone | "aws.example.com" |
 | dns_zone_id | AWS Route53 DNS zone id | "Z3PAABBCFAKEC0" |
 | ssh_keys | List of SSH public keys for user 'core' | ["ssh-rsa AAAAB3NZ..."] |
-| asset_dir | Path to a directory where generated assets should be placed (contains secrets, used to destroy the cluster), cannot be a relative path | "/home/user/.secrets/clusters/tempest" |
+| asset_dir | Path to a directory where generated assets should be placed (contains secrets, used to destroy the cluster). | "./assets" |
 
 #### DNS Zone
 
@@ -235,4 +235,3 @@ Check the list of valid [instance types](https://aws.amazon.com/ec2/instance-typ
 #### Spot
 
 Add `worker_price = "0.10"` to use spot instance workers (instead of "on-demand") and set a maximum spot price in USD. Clusters can tolerate spot market interuptions fairly well (reschedules pods, but cannot drain) to save money, with the tradeoff that requests for workers may go unfulfilled.
-

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -109,11 +109,11 @@ module "azure-ramius" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "./assets"
+  asset_dir = "./assets"
 
   # optional
-  worker_count    = 2
-  host_cidr       = "10.0.0.0/20"
+  worker_count = 2
+  host_cidr    = "10.0.0.0/20"
 }
 ```
 

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -109,7 +109,7 @@ module "azure-ramius" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "/home/user/.secrets/clusters/ramius"
+  asset_dir          = "./assets"
 
   # optional
   worker_count    = 2
@@ -162,7 +162,7 @@ In 4-8 minutes, the Kubernetes cluster will be ready.
 [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your system. Use the generated `kubeconfig` credentials to access the Kubernetes cluster and list nodes.
 
 ```
-$ export KUBECONFIG=/home/user/.secrets/clusters/ramius/auth/kubeconfig
+$ export KUBECONFIG=$PWD/assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                  STATUS  ROLES              AGE  VERSION
 ramius-controller-0   Ready   controller,master  24m  v1.14.1
@@ -212,7 +212,7 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | dns_zone | Azure DNS zone | "azure.example.com" |
 | dns_zone_group | Resource group where the Azure DNS zone resides | "global" |
 | ssh_keys | List of SSH public keys for user 'core' | ["ssh-rsa AAAAB3NZ..."] |
-| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "/home/user/.secrets/clusters/ramius" |
+| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "./assets" |
 
 !!! tip
     Regions are shown in [docs](https://azure.microsoft.com/en-us/global-infrastructure/regions/) or with `az account list-locations --output table`.

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -159,20 +159,20 @@ module "bare-metal-mercury" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//bare-metal/flatcar-linux/kubernetes?ref=<hash>"
 
   # bare-metal
-  cluster_name            = "mercury"
-  matchbox_http_endpoint  = "http://matchbox.example.com"
-  os_channel              = "flatcar-stable"
-  os_version              = "1632.3.0"
+  cluster_name           = "mercury"
+  matchbox_http_endpoint = "http://matchbox.example.com"
+  os_channel             = "flatcar-stable"
+  os_version             = "1632.3.0"
 
   # configuration
-  k8s_domain_name    = "node1.example.com"
+  k8s_domain_name = "node1.example.com"
 
   ssh_keys = [
     "ssh-rsa AAAAB3Nz...",
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "./assets"
+  asset_dir = "./assets"
 
   # machines
   controller_names   = ["node1"]

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -172,7 +172,7 @@ module "bare-metal-mercury" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "/home/user/.secrets/clusters/mercury"
+  asset_dir          = "./assets"
 
   # machines
   controller_names   = ["node1"]
@@ -290,7 +290,7 @@ bootkube[5]: Tearing down temporary bootstrap control plane...
 [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your system. Use the generated `kubeconfig` credentials to access the Kubernetes cluster and list nodes.
 
 ```
-$ export KUBECONFIG=/home/user/.secrets/clusters/mercury/auth/kubeconfig
+$ export KUBECONFIG=$PWD/assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                STATUS  ROLES              AGE  VERSION
 node1.example.com   Ready   controller,master  10m  v1.14.1
@@ -338,7 +338,7 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | os_version | Version of Flatcar Container Linux to PXE and install | "1632.3.0" |
 | k8s_domain_name | FQDN resolving to the controller(s) nodes. Workers and kubectl will communicate with this endpoint | "myk8s.example.com" |
 | ssh_keys | List of SSH public keys for user 'core' | ["ssh-rsa AAAAB3NZ..."] |
-| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "/home/user/.secrets/clusters/mercury" |
+| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "./assets" |
 | controller_names | Ordered list of controller short names | ["node1"] |
 | controller_macs | Ordered list of controller identifying MAC addresses | ["52:54:00:a1:9c:ae"] |
 | controller_domains | Ordered list of controller FQDNs | ["node1.example.com"] |
@@ -362,4 +362,3 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | kernel_args | Additional kernel args to provide at PXE boot | [] | "kvm-intel.nested=1" |
 | certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |
-

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -115,7 +115,7 @@ module "google-cloud-yavin" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "/home/user/.secrets/clusters/yavin"
+  asset_dir          = "./assets"
 
   # optional
   worker_count = 2
@@ -169,7 +169,7 @@ In 4-8 minutes, the Kubernetes cluster will be ready.
 [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your system. Use the generated `kubeconfig` credentials to access the Kubernetes cluster and list nodes.
 
 ```
-$ export KUBECONFIG=/home/user/.secrets/clusters/yavin/auth/kubeconfig
+$ export KUBECONFIG=$PWD/assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                                       ROLES              STATUS  AGE  VERSION
 yavin-controller-0.c.example-com.internal  controller,master  Ready   6m   v1.14.1
@@ -218,7 +218,8 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | dns_zone | Google Cloud DNS zone | "google-cloud.example.com" |
 | dns_zone_name | Google Cloud DNS zone name | "example-zone" |
 | ssh_keys | List of SSH public keys for user 'core' | ["ssh-rsa AAAAB3NZ..."] |
-| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "/home/user/.secrets/clusters/yavin" |
+| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "./assets" |
+
 
 Check the list of valid [regions](https://cloud.google.com/compute/docs/regions-zones/regions-zones) and list Flatcar Container Linux [images](https://cloud.google.com/compute/docs/images) with `gcloud compute images list | grep flatcar`.
 
@@ -263,4 +264,3 @@ Check the list of valid [machine types](https://cloud.google.com/compute/docs/ma
 #### Preemption
 
 Add `worker_preemeptible = true` to allow worker nodes to be [preempted](https://cloud.google.com/compute/docs/instances/preemptible) at random, but pay [significantly](https://cloud.google.com/compute/pricing) less. Clusters tolerate stopping instances fairly well (reschedules pods, but cannot drain) and preemption provides a nice reward for running fault-tolerant cluster systems.`
-

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -115,7 +115,7 @@ module "google-cloud-yavin" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "./assets"
+  asset_dir = "./assets"
 
   # optional
   worker_count = 2

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -139,8 +139,8 @@ module "controller" {
   asset_dir = "./assets"
 
   machine_domain = "vmcluster.k8s"
-  cluster_name = "vmcluster"
-  node_ip_pool = "192.168.192.0/24"
+  cluster_name   = "vmcluster"
+  node_ip_pool   = "192.168.192.0/24"
 
   controller_count = 1
 }
@@ -151,9 +151,9 @@ module "worker-pool-one" {
   ssh_keys = module.controller.ssh_keys
 
   machine_domain = module.controller.machine_domain
-  cluster_name = module.controller.cluster_name
-  libvirtpool = module.controller.libvirtpool
-  libvirtbaseid = module.controller.libvirtbaseid
+  cluster_name   = module.controller.cluster_name
+  libvirtpool    = module.controller.libvirtpool
+  libvirtbaseid  = module.controller.libvirtbaseid
 
   pool_name = "one"
 

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -136,7 +136,7 @@ module "controller" {
   ]
 
   # Where you want the terraform assets to be saved for KUBECONFIG
-  asset_dir = "/path/to/clusters/asset"
+  asset_dir = "./assets"
 
   machine_domain = "vmcluster.k8s"
   cluster_name = "vmcluster"
@@ -223,7 +223,7 @@ In 3-6 minutes, the Kubernetes cluster will be ready, depending on your downlink
 Use the generated `kubeconfig` credentials to access the Kubernetes cluster and list nodes.
 
 ```
-$ export KUBECONFIG=/path/to/clusters/asset/auth/kubeconfig  # matching the asset_dir from the config file
+$ export KUBECONFIG=$PWD/assets/auth/kubeconfig  # matching the asset_dir from the config file
 $ kubectl get nodes
 NAME                                   STATUS   ROLES               AGE     VERSION
 vmcluster-controller-0.vmcluster.k8s   Ready    controller,master   5h28m   v1.14.1
@@ -260,7 +260,7 @@ source.
 
 | Name | Description | Example |
 |:-----|:------------|:--------|
-| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "/home/user/infra/assets" |
+| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "./assets" |
 | cluster_name | Unique cluster name | "vmcluster" |
 | machine_domain | DNS zone | "vmcluster.k8s" |
 | os_image_unpacked | Path to unpacked Flatcar Container Linux image (probably after a qemu-img resize IMG +5G) | "file:///home/user/infra/flatcar_production_qemu_image.img" |

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -83,7 +83,7 @@ module "controller" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes?ref=<hash>"
 
   # DNS configuration
-  dns_zone    = "myclusters.example.com"
+  dns_zone = "myclusters.example.com"
 
   # configuration
   ssh_keys = [
@@ -103,7 +103,7 @@ module "controller" {
   controller_type  = "t1.small.x86"
 
   management_cidrs = [
-    "0.0.0.0/0",       # Instances can be SSH-ed into from anywhere on the internet.
+    "0.0.0.0/0", # Instances can be SSH-ed into from anywhere on the internet.
   ]
 
   # This is different for each project on Packet and depends on the packet facility/region.
@@ -118,7 +118,7 @@ module "controller" {
 module "dns" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//dns/route53?ref=<hash>"
 
-  entries = module.controller.dns_entries
+  entries     = module.controller.dns_entries
   aws_zone_id = "Z1_FAKE" # Z23ABC4XYZL05B for instance
 }
 
@@ -136,7 +136,7 @@ module "worker-pool-helium" {
   pool_name    = "helium"
 
   worker_count = 2
-  type  = "t1.small.x86"
+  type         = "t1.small.x86"
 
   kubeconfig = module.controller.kubeconfig
 

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -91,7 +91,7 @@ module "controller" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir = "/home/user/.secrets/clusters/packet"
+  asset_dir = "./assets"
 
   # Packet
   cluster_name = local.cluster_name
@@ -189,7 +189,7 @@ In 5-10 minutes, the Kubernetes cluster will be ready.
 [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your system. Use the generated `kubeconfig` credentials to access the Kubernetes cluster and list nodes.
 
 ```
-$ export KUBECONFIG=/home/user/.secrets/clusters/packet/auth/kubeconfig
+$ export KUBECONFIG=$PWD/assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                       STATUS  ROLES              AGE  VERSION
 supernova-controller-0     Ready   controller,master  10m  v1.14.1
@@ -243,7 +243,7 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | cluster_name | Unique cluster name (prepended to dns_zone) | "tempest" |
 | dns_zone | DNS zone | "myclusters.example.com" |
 | ssh_keys | List of SSH public keys for user 'core' | ["ssh-rsa AAAAB3NZ..."] |
-| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "/home/user/.secrets/clusters/tempest" |
+| asset_dir | Path to a directory where generated assets should be placed (contains secrets) | "./assets" |
 | project_id | Project ID obtained from the Packet account | "93fake81-0f3c1-..." |
 | facility | Packet Region in which the instance(s) should be deployed | https://www.packet.com/developers/api/#facilities. Eg: "ams1" |
 | management_cidrs | List of CIDRs to allow SSH access to the nodes | ["153.79.80.1/16", "59.60.10.1/32"] |

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ module "google-cloud-yavin" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "/home/user/.secrets/clusters/yavin"
+  asset_dir          = "./assets"
 
   # optional
   worker_count = 2
@@ -80,7 +80,7 @@ Apply complete! Resources: 64 added, 0 changed, 0 destroyed.
 In 4-8 minutes (varies by platform), the cluster will be ready. This Google Cloud example creates a `yavin.example.com` DNS record to resolve to a network load balancer across controller nodes.
 
 ```
-$ export KUBECONFIG=/home/user/.secrets/clusters/yavin/auth/kubeconfig
+$ export KUBECONFIG=$PWD/assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                                       ROLES              STATUS  AGE  VERSION
 yavin-controller-0.c.example-com.internal  controller,master  Ready   6m   v1.14.1

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ module "google-cloud-yavin" {
     "ssh-rsa AAAAB3Nz...",
   ]
 
-  asset_dir          = "./assets"
+  asset_dir = "./assets"
 
   # optional
   worker_count = 2


### PR DESCRIPTION
The docs currently have absolute path which is always erroneous. This
commit changes that to the relative path which can be just copy pasted
and things work fine.