### PR TITLE
bare-metal: use ignition.config.url instead of flatcar.config.url

### DIFF
--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -104,7 +104,7 @@ resource "matchbox_profile" "flatcar-install" {
 
   args = [
     "initrd=flatcar_production_pxe_image.cpio.gz",
-    "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "ignition.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "flatcar.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
@@ -128,7 +128,7 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
 
   args = [
     "initrd=flatcar_production_pxe_image.cpio.gz",
-    "flatcar.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
+    "ignition.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "flatcar.first_boot=yes",
     "console=tty0",
     "console=ttyS0",


### PR DESCRIPTION
Since upstream Container Linux changed the config URL to `ignition.config.url`, we should also replace `flatcar.config.url` with `ignition.config.url`.

Replaces https://github.com/kinvolk/lokomotive-kubernetes/pull/70