### PR TITLE
Makefile: Add a make target to run kube-hunter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+kubeconfig := $(KUBECONFIG)
+## Following kubeconfig path is only valid from CI
+ifeq ($(RUN_FROM_CI),"true")
+	kubeconfig := "${HOME}/assets/auth/kubeconfig"
+endif
+
+.PHONY: run-e2e-tests
+run-e2e-tests: kube-hunter
+
+kube-hunter:
+	KUBECONFIG=${kubeconfig} ./scripts/kube-hunter.sh

--- a/scripts/kube-hunter.sh
+++ b/scripts/kube-hunter.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 0


### PR DESCRIPTION
* This commit is just a preparation for enabling the CI code to run
these end to end tests, which run kube-hunter.
 
* Running kube-hunter with each change on lokomotive helps us get the
security impacts of the change. Security violations from any PR change
can be obviated, with these results.
---
This endpoint can be called from the CI. Once this PR is merged we can make changes to the CI code and run this make command.