### PR TITLE
calico: Upgrade to 3.10.1

### DIFF
--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=a8c27deb0e2390c632a82512657310b9c4eb7782"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/azure/flatcar-linux/kubernetes/bootkube.tf
+++ b/azure/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=a8c27deb0e2390c632a82512657310b9c4eb7782"
 
   cluster_name = "${var.cluster_name}"
   api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=a8c27deb0e2390c632a82512657310b9c4eb7782"
 
   cluster_name                    = "${var.cluster_name}"
   api_servers                     = ["${var.k8s_domain_name}"]

--- a/digital-ocean/container-linux/kubernetes/bootkube.tf
+++ b/digital-ocean/container-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=a8c27deb0e2390c632a82512657310b9c4eb7782"
 
   cluster_name = "${var.cluster_name}"
   api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/google-cloud/flatcar-linux/kubernetes/bootkube.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=a8c27deb0e2390c632a82512657310b9c4eb7782"
 
   cluster_name          = "${var.cluster_name}"
   api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]

--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
+  source = "git::https://github.com/kinvolk/terraform-render-bootkube//?ref=a8c27deb0e2390c632a82512657310b9c4eb7782"
 
   cluster_name = "${var.cluster_name}"
 

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=7e9cf2460a3f01703f2edbfde463c1843fbf8d49"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=a8c27deb0e2390c632a82512657310b9c4eb7782"
 
   cluster_name = "${var.cluster_name}"
 


### PR DESCRIPTION
* Corresponding change commit in terraform-render-bootkube
https://github.com/kinvolk/terraform-render-bootkube/commit/fb0e539092f68fd1adadacb938108ae1b503d299

* Release Notes: https://docs.projectcalico.org/v3.10/release-notes#v3.10.1
