### PR TITLE
packet: Use Route53 FQDN attribute instead of name

### DIFF
--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -6,7 +6,7 @@ module "bootkube" {
   # Cannot use cyclic dependencies on controllers or their DNS records
   api_servers          = ["${format("%s-private.%s", var.cluster_name, var.dns_zone)}"]
   api_servers_external = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers         = "${aws_route53_record.etcds.*.name}"
+  etcd_servers         = "${aws_route53_record.etcds.*.fqdn}"
   asset_dir            = "${var.asset_dir}"
   networking           = "${var.networking}"
   network_mtu          = "${var.network_mtu}"


### PR DESCRIPTION
The name attribute only refers to the name used to create the DNS record. The values accepted are either the subdomain to be created on the dns_zone or the FQDN.

For example, if you do something like:

        resource "aws_route53_record" "example" {
          zone_id = "xxx" # let's say it is the zone id for awesome.lokomotive-k8s.com

          name = "deleteme"
          type = "A" 
          ttl  = 300 

          # private IPv4 address for etcd
          records = ["10.0.0.1"]
        }   

        output "name" {
          value = "${aws_route53_record.example.name}"
        }   

        output "fqdn" {
          value = "${aws_route53_record.example.fqdn}"
        }

You will see:

        fqdn = deleteme.awesome.lokomotive-k8s.com
        name = deleteme

If you use the FQDN for the name attribute in the example resource, however, the name and fqdn will match. This is what we are currently doing, for example here:
        https://github.com/kinvolk/lokomotive-kubernetes/blob/da1cdcfaec23acd727193f53b45ef40753960534/packet/flatcar-linux/kubernetes/controllers.tf#L8

However, the correct and reliable way to get the FQDN of a domain is to get the `fqdn` attribute, and not the name.

This patch just simply changes to that, so we use what we really want and not depend on how the record was created. Although in this case it is a no-op.