### PR TITLE
packet: Improve BGP support on workers

### DIFF
--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -121,3 +121,9 @@ EOD
   type    = "string"
   default = ""
 }
+
+variable "disable_bgp" {
+  description = "Disable BGP on nodes. Nodes won't be able to connect to Packet BGP peers. Note that BGP is used to receive internet traffic directed to Packet elastic IPs"
+  type        = "string"
+  default     = "false"
+}

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -13,7 +13,7 @@ resource "packet_device" "nodes" {
 }
 
 resource "packet_bgp_session" "bgp" {
-  count          = "${var.count}"
+  count          = "${var.disable_bgp == "true" ? 0 : var.count}"
   device_id      = "${element(packet_device.nodes.*.id, count.index)}"
   address_family = "ipv4"
 }

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -14,7 +14,7 @@ resource "packet_device" "nodes" {
 
 resource "packet_bgp_session" "bgp" {
   count          = "${var.disable_bgp == "true" ? 0 : var.count}"
-  device_id      = "${element(packet_device.nodes.*.id, count.index)}"
+  device_id      = "${packet_device.nodes.*.id[count.index]}"
   address_family = "ipv4"
 }
 


### PR DESCRIPTION
This patch series just improves the usage of BGP on worker nodes:

 * It is possible to disable BGP on worker pools that don't need it (default is false, so no backwards incompatible change is done)
 * There was an interpolation issue causing BGP sessions from all nodes to be deleted when a node was added/removed from the pool

The commits explain this in more detail.