### PR TITLE
[WIP] packet: create a symlink /dev/kmsg for starting kubelet

### DIFF
--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -88,6 +88,7 @@ systemd:
         ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
         ExecStartPre=/etc/kubernetes/configure-kubelet-cgroup-driver
+        ExecStartPre=/bin/ln -sf /dev/console /dev/kmsg
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --node-ip=$${COREOS_PACKET_IPV4_PRIVATE_0} \
           --anonymous-auth=false \


### PR DESCRIPTION
Since k8s v1.15, kubelet cannot start without `/dev/kmsg` being available inside the container, because the OOM parser cannot open the file.

```
Failed to start OOM watcher open /dev/kmsg: no such file or directory
```

This happens only with flatcar-edge, where docker is used as container runtime in `kubelet-wrapper`.

See also https://github.com/kubernetes-sigs/kind/pull/664,
https://github.com/kubernetes/kubernetes/pull/74942

_not tested yet, please do not merge_
This PR should be merged together with https://github.com/flatcar-linux/coreos-overlay/pull/114.