### PR TITLE
Update hostendpoint controller to v0.0.3

### DIFF
--- a/packet/flatcar-linux/kubernetes/calico/host-endpoint-controller.yaml
+++ b/packet/flatcar-linux/kubernetes/calico/host-endpoint-controller.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       serviceAccountName: calico-hostendpoint-controller
       containers:
-      - image: kinvolk/calico-hostendpoint-controller:v0.0.2
+      - image: kinvolk/calico-hostendpoint-controller:v0.0.3
         name: calico-hostendpoint-controller
         volumeMounts:
         - mountPath: /tmp/


### PR DESCRIPTION
Following https://github.com/kinvolk/lokomotive-kubernetes/pull/80 the controller no longer fetches the workers due to label renames which results in workers not having host endpoints. v0.0.3 fixes this.