### PR TITLE
Add kubelet-wrapper and etcd-wrapper

### DIFF
--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -25,7 +25,20 @@ systemd:
             Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt"
             Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
             Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
+
             ExecStopPost=-/opt/etcd-rejoin
+
+            ExecStartPre=
+            ExecStartPre=/usr/bin/mkdir --parents /var/lib/flatcar
+            ExecStartPre=-/usr/bin/docker stop %n
+            ExecStartPre=-/usr/bin/docker rm %n
+
+            ExecStart=
+            ExecStart=/etc/kubernetes/etcd-wrapper %n
+
+            ExecStop=
+            ExecStop=-/usr/bin/docker stop %n
+
     - name: docker.service
       enable: true
     - name: locksmithd.service
@@ -53,18 +66,7 @@ systemd:
         [Service]
         ConditionPathExists=/etc/kubernetes/kubeconfig
         EnvironmentFile=/etc/kubernetes/kubelet.env
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume var-lib-cni,kind=host,source=/var/lib/cni \
-          --mount volume=var-lib-cni,target=/var/lib/cni \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico \
-          --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=opt-cni-bin,target=/opt/cni/bin \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --insecure-options=image"
+        Environment="KUBELET_MOUNT_RW=/dev/kmsg"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
@@ -75,27 +77,10 @@ systemd:
         ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins
         ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
         ExecStartPre=/etc/kubernetes/configure-kubelet-cgroup-driver
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
-          --anonymous-auth=false \
-          --authentication-token-webhook \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/ca.crt \
-          --cluster_dns=${cluster_dns_service_ip} \
-          --cluster_domain=${cluster_domain_suffix} \
-          --cni-conf-dir=/etc/kubernetes/cni/net.d \
-          --config=/etc/kubernetes/kubelet.config \
-          --exit-on-lock-contention \
-          --kubeconfig=/etc/kubernetes/kubeconfig \
-          --lock-file=/var/run/lock/kubelet.lock \
-          --network-plugin=cni \
-          --node-labels=node.kubernetes.io/master \
-          --node-labels=node.kubernetes.io/controller="true" \
-          --pod-manifest-path=/etc/kubernetes/manifests \
-          --read-only-port=0 \
-          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
+        ExecStartPre=-/usr/bin/docker stop %n
+        ExecStartPre=-/usr/bin/docker rm %n
+        ExecStart=/etc/kubernetes/kubelet-wrapper %n
+        ExecStop=/usr/bin/docker stop %n
         Restart=always
         RestartSec=10
         [Install]
@@ -120,8 +105,10 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.2
+          KUBELET_IMAGE=k8s.gcr.io/hyperkube:v1.16.2
+          CLUSTER_DNS_SERVICE_IP=${cluster_dns_service_ip}
+          CLUSTER_DOMAIN_SUFFIX=${cluster_domain_suffix}
+          NODE_ROLE=controller
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -147,7 +134,6 @@ storage:
             --mount volume=assets,target=/assets \
             --volume bootstrap,kind=host,source=/etc/kubernetes \
             --mount volume=bootstrap,target=/etc/kubernetes \
-            $${RKT_OPTS} \
             quay.io/coreos/bootkube:v0.14.0 \
             --net=host \
             --dns=host \
@@ -214,6 +200,16 @@ storage:
           kind: KubeletConfiguration
           cgroupDriver: "$${docker_cgroup_driver}"
           EOF
+    - path: /etc/kubernetes/kubelet-wrapper
+      filesystem: root
+      mode: 0744
+      contents:
+        inline: ${kubelet_wrapper_inline}
+    - path: /etc/kubernetes/etcd-wrapper
+      filesystem: root
+      mode: 0744
+      contents:
+        inline: ${etcd_wrapper_inline}
 passwd:
   users:
     - name: core

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -71,6 +71,10 @@ data "template_file" "controller-configs" {
     ssh_authorized_key     = "${var.ssh_authorized_key}"
     cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
     cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+
+    kubelet_wrapper_inline = "${jsonencode(file("${path.module}/kubelet-wrapper"))}"
+
+    etcd_wrapper_inline = "${jsonencode(file("${path.module}/etcd-wrapper"))}"
   }
 }
 

--- a/aws/flatcar-linux/kubernetes/etcd-wrapper
+++ b/aws/flatcar-linux/kubernetes/etcd-wrapper
@@ -1,0 +1,1 @@
+../../../common/etcd-wrapper

--- a/aws/flatcar-linux/kubernetes/kubelet-wrapper
+++ b/aws/flatcar-linux/kubernetes/kubelet-wrapper
@@ -1,0 +1,1 @@
+../../../common/kubelet-wrapper

--- a/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -29,20 +29,7 @@ systemd:
         Wants=rpc-statd.service
         [Service]
         EnvironmentFile=/etc/kubernetes/kubelet.env
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume var-lib-cni,kind=host,source=/var/lib/cni \
-          --mount volume=var-lib-cni,target=/var/lib/cni \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico \
-          --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=opt-cni-bin,target=/opt/cni/bin \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume iscsiadm,kind=host,source=/usr/sbin/iscsiadm \
-          --mount volume=iscsiadm,target=/usr/sbin/iscsiadm \
-          --insecure-options=image"
+        Environment="KUBELET_MOUNT_RW=/usr/sbin/iscsiadm /dev/kmsg"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
@@ -51,25 +38,10 @@ systemd:
         ExecStartPre=/bin/mkdir -p /var/lib/kubelet/volumeplugins
         ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
         ExecStartPre=/etc/kubernetes/configure-kubelet-cgroup-driver
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
-          --anonymous-auth=false \
-          --authentication-token-webhook \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/ca.crt \
-          --cluster_dns=${cluster_dns_service_ip} \
-          --cluster_domain=${cluster_domain_suffix} \
-          --cni-conf-dir=/etc/kubernetes/cni/net.d \
-          --config=/etc/kubernetes/kubelet.config \
-          --exit-on-lock-contention \
-          --kubeconfig=/etc/kubernetes/kubeconfig \
-          --lock-file=/var/run/lock/kubelet.lock \
-          --network-plugin=cni \
-          --node-labels=node.kubernetes.io/node \
-          --pod-manifest-path=/etc/kubernetes/manifests \
-          --read-only-port=0 \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
+        ExecStartPre=-/usr/bin/docker stop %n
+        ExecStartPre=-/usr/bin/docker rm %n
+        ExecStart=/etc/kubernetes/kubelet-wrapper %n
+        ExecStop=/usr/bin/docker stop %n
         Restart=always
         RestartSec=5
         [Install]
@@ -99,8 +71,10 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube
-          KUBELET_IMAGE_TAG=v1.16.2
+          KUBELET_IMAGE=k8s.gcr.io/hyperkube:v1.16.2
+          CLUSTER_DNS_SERVICE_IP=${cluster_dns_service_ip}
+          CLUSTER_DOMAIN_SUFFIX=${cluster_domain_suffix}
+          NODE_ROLE=worker
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root
       contents:
@@ -135,6 +109,11 @@ storage:
             --net=host \
             --dns=host \
             --exec=/kubectl -- --kubeconfig=/etc/kubernetes/kubeconfig delete node $(hostname)
+    - path: /etc/kubernetes/kubelet-wrapper
+      filesystem: root
+      mode: 0744
+      contents:
+        inline: ${kubelet_wrapper_inline}
 passwd:
   users:
     - name: core

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -83,5 +83,6 @@ data "template_file" "worker-config" {
     ssh_authorized_key     = "${var.ssh_authorized_key}"
     cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
     cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    kubelet_wrapper_inline = "${jsonencode(file("${path.module}/../kubelet-wrapper"))}"
   }
 }

--- a/common/etcd-wrapper
+++ b/common/etcd-wrapper
@@ -1,0 +1,63 @@
+#!/usr/bin/bash -e
+# Wrapper for launching etcd via docker.
+
+SYSTEMD_SERVICE_NAME="$1"; shift
+
+function require_ev_all() {
+	for rev in $@ ; do
+		if [[ -z "${!rev}" ]]; then
+			echo ${rev} is not set
+			exit 1
+		fi
+	done
+}
+
+function require_ev_one() {
+	for rev in $@ ; do
+		if [[ ! -z "${!rev}" ]]; then
+			return
+		fi
+	done
+	echo One of $@ must be set
+	exit 1
+}
+
+require_ev_one ETCD_IMAGE ETCD_IMAGE_TAG
+require_ev_all SYSTEMD_SERVICE_NAME ETCD_USER ETCD_DATA_DIR
+
+ETCD_IMAGE_URL="${ETCD_IMAGE_URL:-quay.io/coreos/etcd}"
+ETCD_IMAGE="${ETCD_IMAGE:-${ETCD_IMAGE_URL}:${ETCD_IMAGE_TAG}}"
+
+if [[ ! -e "${ETCD_DATA_DIR}" ]]; then
+	mkdir --parents "${ETCD_DATA_DIR}"
+	chown "${ETCD_USER}" "${ETCD_DATA_DIR}"
+fi
+
+# Do not pass ETCD_DATA_DIR through to the container. The default path,
+# /var/lib/etcd is always used inside the container.
+etcd_data_dir="${ETCD_DATA_DIR}"
+unset ETCD_DATA_DIR
+
+ETCD_SSL_DIR="${ETCD_SSL_DIR:-/etc/ssl/certs}"
+
+for i in $(env|grep ^ETCD_) ; do
+	DOCKER_ENV="${DOCKER_ENV} -e $i"
+done
+
+# TODO: systemd notify does not work with Docker
+DOCKER="${DOCKER:-/usr/bin/docker}"
+set -x
+exec ${DOCKER} ${DOCKER_GLOBAL_ARGS} \
+	run \
+	--name $SYSTEMD_SERVICE_NAME \
+	--entrypoint=/usr/local/bin/etcd \
+	--net=host \
+	--mount type=bind,bind-propagation=rshared,source=${etcd_data_dir},target=/var/lib/etcd \
+	--mount type=bind,bind-propagation=rprivate,source=${ETCD_SSL_DIR},target=/etc/ssl/certs,readonly \
+	--mount type=bind,bind-propagation=rprivate,source=/usr/share/ca-certificates,target=/usr/share/ca-certificates,readonly \
+	--mount type=bind,bind-propagation=rprivate,source=/etc/hosts,target=/etc/hosts,readonly \
+	--mount type=bind,bind-propagation=rprivate,source=/etc/resolv.conf,target=/etc/resolv.conf,readonly \
+	--user=$(id -u "${ETCD_USER}") \
+	${DOCKER_ENV} \
+	${ETCD_IMAGE} ${ETCD_IMAGE_ARGS} \
+	--data-dir=/var/lib/etcd "$@"

--- a/common/kubelet-wrapper
+++ b/common/kubelet-wrapper
@@ -1,0 +1,67 @@
+#!/bin/bash -e
+# Wrapper for launching kubelet via docker.
+
+SYSTEMD_SERVICE_NAME="$1"; shift
+
+function require_ev_all() {
+	for rev in $@ ; do
+		if [[ -z "${!rev}" ]]; then
+			echo "${rev}" is not set
+			exit 1
+		fi
+	done
+}
+
+require_ev_all SYSTEMD_SERVICE_NAME KUBELET_IMAGE CLUSTER_DOMAIN_SUFFIX CLUSTER_DNS_SERVICE_IP
+
+mkdir -p /etc/kubernetes /var/lib/docker /var/lib/kubelet /run/kubelet
+
+readonly docker_cgroup_driver="$(docker info -f '{{.CgroupDriver}}')"
+if [[ "$docker_cgroup_driver" = "systemd" ]] ; then
+	for i in $(cat /proc/cgroups |awk '{print $1}'|grep -v subsys_name) ; do
+		# systemd does not create the entries for all cgroup controllers (e.g. hugetlb)
+		mkdir --parents /sys/fs/cgroup/$i/kubepods.slice
+	done
+fi
+
+KUBELET_MOUNT_RW="${KUBELET_MOUNT_RW:-} /sys/fs/cgroup /var/lib/calico /opt/cni/bin /var/lib/cni /etc/kubernetes /var/log /run /sys"
+for m in $KUBELET_MOUNT_RW ; do
+	KUBELET_MOUNT_ARGS="$KUBELET_MOUNT_ARGS --mount type=bind,bind-propagation=rprivate,source=$m,target=$m"
+done
+
+KUBELET_MOUNT_RO="${KUBELET_MOUNT_RO:-} /etc/ssl/certs /usr/share/ca-certificates /usr/lib/os-release /lib/modules /etc/machine-id"
+for m in $KUBELET_MOUNT_RO ; do
+	KUBELET_MOUNT_ARGS="$KUBELET_MOUNT_ARGS --mount type=bind,bind-propagation=rprivate,source=$m,target=$m,readonly"
+done
+
+if [[ "$NODE_ROLE" = "controller" ]] ; then
+	KUBELET_ARGS='
+		--register-with-taints=node-role.kubernetes.io/master=:NoSchedule
+		--node-labels=node.kubernetes.io/master
+		--node-labels=node.kubernetes.io/controller=true
+	'
+fi
+
+if [[ "$NODE_ROLE" = "worker" ]] ; then
+	KUBELET_ARGS='
+		--node-labels=node.kubernetes.io/node
+	'
+fi
+
+set -x
+exec /usr/bin/docker \
+	run --name $SYSTEMD_SERVICE_NAME \
+	--privileged --net=host --pid=host \
+	$KUBELET_MOUNT_ARGS \
+	--mount type=bind,bind-propagation=rslave,source=/var/lib/docker,target=/var/lib/docker \
+	--mount type=bind,bind-propagation=shared,source=/var/lib/kubelet,target=/var/lib/kubelet \
+	${KUBELET_IMAGE} /kubelet ${KUBELET_ARGS} \
+	--anonymous-auth=false --authentication-token-webhook --authorization-mode=Webhook \
+	--client-ca-file=/etc/kubernetes/ca.crt \
+	--cluster_dns=${CLUSTER_DNS_SERVICE_IP} --cluster_domain=${CLUSTER_DOMAIN_SUFFIX} \
+	--cni-conf-dir=/etc/kubernetes/cni/net.d --network-plugin=cni \
+	--config=/etc/kubernetes/kubelet.config --kubeconfig=/etc/kubernetes/kubeconfig \
+	--exit-on-lock-contention --lock-file=/var/run/lock/kubelet.lock \
+	--pod-manifest-path=/etc/kubernetes/manifests \
+	--read-only-port=0 \
+	--volume-plugin-dir=/var/lib/kubelet/volumeplugins


### PR DESCRIPTION
The kubelet-wrapper and etcd-wrapper scripts are part of Flatcar
Container Linux. They are tightly coupled with the service files
kubelet.service and etcd-member.service, respectively. The service files
are part of Lokomotive.

This coupling consists of environment variables and container runtime
parameters. This causes problem because any change (e.g. moving from rkt
to Docker) requires synchronisation between Flatcar and Lokomotive
releases.

This patch makes Lokomotive provide its own kubelet-wrapper and
etcd-wrapper scripts so that it is not dependent on the a specific
channel of Flatcar.

This patch also changes the container runtime to Docker.

Since Docker does not support sd_notify, I remove the related code.
To fix this, we could use sdnotify-proxy. See links:
https://www.freedesktop.org/software/systemd/man/sd_notify.html
https://github.com/coreos/sdnotify-proxy

In practice, Lokomotive works without sd_notify, but other services that
have a dependency on etcd-member might have not run in the correct
order. I found only one service in this case: flanneld:

```
/usr/lib/systemd/system/flanneld.service:4:After=etcd.service etcd2.service etcd-member.service
```

This patch only fixes AWS: packet and others are left as TODO.

I expect that kubelet-wrapper and etcd-wrapper can be shared for all
cloud providers, so I've put them in the 'common' directory. This will
make future changes easier to manage.

To make terraform modules self-sufficient (e.g.
aws/flatcar-linux/kubernetes), required files should normally not be
outside of the root directory of the terraform module (e.g. no access
via ../../../). I've added symbolic links to the common directory. If
you create assets with vfsgen, the symbolic links are read as regular
files so they get added several times in the assets, making the
terraform module self-sufficient.

Note: with this patch, we are dangerously close to the 16384 size limit
on AWS user_data. In my tests, we're around 15860.

TODO:
- [ ] Fix sd_notify for Flannel
- [ ] Other cloud providers
- [ ] Longer-term solution for the 16384 size limit on AWS user_data
- [ ] Remove rkt from other parts of Terraform scripts