### PR TITLE
ci: Add Packet ARM cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,17 @@ kubeconfig := $(KUBECONFIG)
 ifeq ($(RUN_FROM_CI),"true")
 	kubeconfig := "${HOME}/assets/auth/kubeconfig"
 endif
+kubehunter := ./scripts/kube-hunter.sh
+ifeq ($(SKIP_KUBE_HUNTER),"true")
+	kubehunter := echo
+endif
 
 .PHONY: run-e2e-tests
 run-e2e-tests: kube-hunter
 	KUBECONFIG=${kubeconfig} ./scripts/check-version-skew.sh
 
 kube-hunter:
-	KUBECONFIG=${kubeconfig} ./scripts/kube-hunter.sh
+	KUBECONFIG=${kubeconfig} ${kubehunter}
 
 .PHONY: update-terraform-render-bootkube
 update-terraform-render-bootkube:

--- a/ci/packet-arm/packet-arm-cluster.tf.envsubst
+++ b/ci/packet-arm/packet-arm-cluster.tf.envsubst
@@ -1,0 +1,65 @@
+module "controller" {
+  source = "../../packet/flatcar-linux/kubernetes"
+
+  providers = {
+    aws      = aws.default
+    local    = local.default
+    null     = null.default
+    template = template.default
+    tls      = tls.default
+    packet   = packet.default
+  }
+
+  dns_zone = "$AWS_DNS_ZONE"
+  dns_zone_id = "$AWS_DNS_ZONE_ID"
+
+  ssh_keys = ["$PUB_KEY"]
+
+  asset_dir = pathexpand("~/assets")
+  cluster_name = "$CLUSTER_ID"
+  project_id = "$PACKET_PROJECT_ID"
+
+  facility = "sjc1"
+
+  controller_count = 1
+  controller_type  = "c2.large.arm"
+  os_arch = "arm64"
+  os_channel = "alpha"
+  ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/arm64-usr/packet.ipxe"
+
+  management_cidrs = [
+    "0.0.0.0/0",       # Instances can be SSH-ed into from anywhere on the internet.
+  ]
+
+  node_private_cidr = "10.0.0.0/8"
+}
+
+module "worker-pool-1" {
+  source = "../../packet/flatcar-linux/kubernetes/workers"
+
+  providers = {
+    local    = local.default
+    template = template.default
+    tls      = tls.default
+    packet   = packet.default
+  }
+
+
+  ssh_keys = ["$PUB_KEY"]
+
+  cluster_name = "$CLUSTER_ID"
+  project_id = "$PACKET_PROJECT_ID"
+
+  facility     = "sjc1"
+  pool_name    = "pool-1"
+
+  worker_count = 1
+  type  = "c1.large.arm"
+  os_arch = "arm64"
+  os_channel = "alpha"
+  ipxe_script_url = "https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/arm64-usr/packet.ipxe"
+
+  kubeconfig = module.controller.kubeconfig
+
+  labels = "node.supernova.io/role=backend"
+}

--- a/ci/packet-arm/provider.tf
+++ b/ci/packet-arm/provider.tf
@@ -1,0 +1,33 @@
+provider "aws" {
+  version = "2.31.0"
+  alias   = "default"
+}
+
+provider "ct" {
+  version = "0.4.0"
+}
+
+provider "local" {
+  version = "~> 1.2"
+  alias   = "default"
+}
+
+provider "null" {
+  version = "~> 2.1"
+  alias   = "default"
+}
+
+provider "template" {
+  version = "~> 2.1"
+  alias   = "default"
+}
+
+provider "tls" {
+  version = "~> 2.0"
+  alias   = "default"
+}
+
+provider "packet" {
+  version = "~> 2.7.3"
+  alias   = "default"
+}


### PR DESCRIPTION
The cluster configuration is the same as for the existing
Packet cluster. The only difference is the server type
`c2.large.arm` (controller) and `c1.large.arm` (worker), the added variables `os_arch`/`os_channel`/`ipxe_script_url`,
and the worker count set to 1 instead of 2.