### PR TITLE
packet: Remove temporary ARM signature key

### DIFF
--- a/packet/flatcar-linux/kubernetes/cl/controller-install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller-install.yaml.tmpl
@@ -40,20 +40,12 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          if [ "${os_arch}" = arm64 ]; then
-            curl -o /tmp/Flatcar_ARM_Testing_Key.asc \
-              https://www.flatcar-linux.org/security/image-signing-key/Flatcar_ARM_Testing_Key.asc
-            ARG="-d /dev/sda -k /tmp/Flatcar_ARM_Testing_Key.asc"
-          else
-            ARG="-s"
-          fi
-
           flatcar-install \
             -C "${os_channel}" \
             -V "${os_version}" \
             -o "${flatcar_linux_oem}" \
             -i /opt/postinstall-ignition.json \
-            $ARG
+            -s
           udevadm settle
           systemctl reboot
 passwd:

--- a/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/install.yaml.tmpl
@@ -40,20 +40,12 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          if [ "${os_arch}" = arm64 ]; then
-            curl -o /tmp/Flatcar_ARM_Testing_Key.asc \
-              https://www.flatcar-linux.org/security/image-signing-key/Flatcar_ARM_Testing_Key.asc
-            ARG="-d /dev/sda -k /tmp/Flatcar_ARM_Testing_Key.asc"
-          else
-            ARG="-s"
-          fi
-
           flatcar-install \
             -C "${os_channel}" \
             -V "${os_version}" \
             -o "${flatcar_linux_oem}" \
             -i /opt/postinstall-ignition.json \
-            $ARG
+            -s
 
           udevadm settle
           systemctl reboot


### PR DESCRIPTION
Since Flatcar Container Linux now has official
ARM64 releases, the developer signature workaround
is not needed anymore and hinders accepting offically
signed images.