### PR TITLE
packet/flatcar-linux: add support for CLC snippets

### DIFF
--- a/docs/advanced/customization.md
+++ b/docs/advanced/customization.md
@@ -65,7 +65,7 @@ View the Container Linux Config [format](https://coreos.com/os/docs/1576.4.0/con
 
 Write Container Linux Configs *snippets* as files in the repository where you keep Terraform configs for clusters (perhaps in a `clc` or `snippets` subdirectory). You may organize snippets in multiple files as desired, provided they are each valid.
 
-[AWS](../flatcar-linux/aws.md#cluster) and [Azure](../flatcar-linux/azure.md#cluster) clusters allow populating a list of `controller_clc_snippets` or `worker_clc_snippets`.
+[AWS](../flatcar-linux/aws.md#cluster), [Azure](../flatcar-linux/azure.md#cluster) and [Packet](../flatcar-linux/packet.md#cluster) clusters allow populating a list of `controller_clc_snippets` or `worker_clc_snippets`.
 
 ```
 module "aws-nemo" {

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -258,6 +258,7 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | facility | Packet Region in which the instance(s) should be deployed | https://www.packet.com/developers/api/#facilities. Eg: "ams1" |
 | management_cidrs | List of CIDRs to allow SSH access to the nodes | ["153.79.80.1/16", "59.60.10.1/32"] |
 | node_private_cidr | Private CIDR obtained from Packet for the project and facility | 10.128.16.32/25 |
+| controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
 
 #### Worker module
 
@@ -269,6 +270,7 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | facility | Packet Region in which the instance(s) should be deployed | https://www.packet.com/developers/api/#facilities. Eg: "ams1" |
 | pool_name | Name of the worker pool. Used in setting hostname | "helium" |
 | kubeconfig | Kubeconfig to be used in worker pools | "${module.controller.kubeconfig} |
+| clc_snippets | Worker Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
 
 #### DNS Zone
 

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -76,6 +76,7 @@ data "ct_config" "controller-ignitions" {
   count    = "${var.controller_count}"
   platform = "packet"
   content  = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  snippets     = ["${var.controller_clc_snippets}"]
 }
 
 data "template_file" "controller-configs" {

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -72,6 +72,12 @@ variable "facility" {
   description = "Packet facility to deploy the cluster in"
 }
 
+variable "controller_clc_snippets" {
+  type        = "list"
+  description = "Controller Container Linux Config snippets"
+  default     = []
+}
+
 # Configuration
 
 variable "ssh_keys" {

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -28,6 +28,12 @@ variable "type" {
   description = "Packet instance type for workers, can be changed afterwards to recreate the nodes"
 }
 
+variable "clc_snippets" {
+  type        = "list"
+  description = "Container Linux Config snippets"
+  default     = []
+}
+
 # TODO: migrate to `templatefile` when Terraform `0.12` is out and use `{% for ~}`
 # to avoid specifying `--node-labels` again when the var is empty.
 variable "labels" {

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -41,6 +41,7 @@ resource "packet_bgp_session" "bgp" {
 data "ct_config" "ignitions" {
   content  = "${data.template_file.configs.rendered}"
   platform = "packet"
+  snippets     = ["${var.clc_snippets}"]
 }
 
 data "template_file" "configs" {


### PR DESCRIPTION
Both kubernetes and kubernetes/workers module in Packet lack the
ability to specify CLC (Container Linux Configuration) snippets that
are used to modify the instances (or devices in Packet).

We can solve that by following the pattern set by code in other
cloud providers, only adapting it to Packet's structure. The variable
names remain consistent.

Signed-off-by: Martin Polednik <m.polednik@gmail.com>