### PR TITLE
packet: Fix node local storage on new kernels

### DIFF
--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -126,7 +126,36 @@ systemd:
       enabled: true
       enable: true
 storage:
+  filesystems:
+    - name: "OEM"
+      mount:
+        device: "/dev/disk/by-label/OEM"
+        format: "ext4"
   files:
+    # XXX: We need to manually specify the RAID0 layout because of a kernel bug.
+    # We use default_layout=2 as **we assume all installations from now on are
+    # using a kernel >= 3.14** (released on 2014-03-30).
+    # For more info on this kernel bug, see:
+    # https://github.com/torvalds/linux/commit/c84a1372df929033cb1a0441fb57bd3932f39ac9
+    # It is needed as kernel cmdline and modprobe config for some bug, see
+    # commit msg for details
+    - path: /etc/modprobe.d/raid0.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: options raid0 default_layout=2
+    - path: /etc/modules-load.d/raid0.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: raid0
+    - filesystem: "OEM"
+      path: "/grub.cfg"
+      mode: 0644
+      append: true
+      contents:
+        inline: |
+          set linux_append="$linux_append raid0.default_layout=2"
     - path: /opt/persist-data-raid
       filesystem: root
       mode: 0700


### PR DESCRIPTION
This patch uses the new kernel module option `default_layout=2` to
fix a kernel bug that may cause data corruption when booted with kernels
pre and post 3.14. See:
https://github.com/torvalds/linux/commit/c84a1372df929033cb1a0441fb57bd3932f39ac9

Linux 3.14 (20d0189b101) made an unintended change to the RAID0 layout
for multi-zone arrays (where devices aren't all the same size), this
forced to add some one param to the kernel raid0 module (mandatory,
kernel will throw an error if one is not set and can't guess):

	1 restores the original layout
	2 uses the altered layout

The kernel, therefore, forces to choose a layout as there is no way the
kernel can detect which one is the right to use. In our case, it is
simple: we assume we are using a kernel older than 3.14 (released on
2014-03-30), way before Lokomotive existed.

We specify this in two different parts:
 * As modprobe configuration
 * As kernel cmdline

As ignition runs after grub, [the first boot is not affected](https://coreos.com/os/docs/latest/other-settings.html). Therefore, doing it only at kernel cmdline with ignition is not enough
for the first boot.

For the first boot the modprobe config files are created. It works fine,
those options are used when the node local storage script creates the
array (and therefore the raid0 module is loaded).

But those are not enough on their own, though, as on reboot the raid0
module seems to be loaded very early, before reading modprobe config
files. Therefore, if you only set the modprobe config files
(/etc/modprobe.d/ and /etc/modules-load.d), *after* a reboot you will see:

	$ cat /sys/module/raid0/parameters/default_layout
	0

And the RAID0 array will not work. But, if you run:

	rmmod raid0; modprobe raid0

Then you will see:

	$ cat /sys/module/raid0/parameters/default_layout
	2

So, it really seems like the module is loaded very early on and that
option is not activated. We need to investigate this.

To make this work in all cases (first boot and after the second
boot), we add modprobe config files (for the first boot) and the kernel
cmdline so it takes effect from the second boot on (no matter how early
the raid0 module is loaded).

Hopefully, we will find a better workaround in the future. But this
seems to do the trick for now.

Also, it's worth noting that this should not cause any issue on kernels
that don't have the module param as it works fine if the module doesn't
know that param.

