### PR TITLE
docs: Rephrase the current state of arm64 until it's stable

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -241,7 +241,7 @@ Learn about [maintenance](../topics/maintenance.md).
 
 ## ARM Support and Hybrid Clusters
 
-Lokomotive and Flatcar support the Packet arm64 server types `c1.large.arm` and `c2.large.arm`.
+Lokomotive and Flatcar currently include an alpha-quality preview for the Packet arm64 server types `c1.large.arm` and `c2.large.arm`.
 They can be used for both worker and controller nodes.
 Besides specifying them in `controller_type`/`type` you need to configure some additional variables
 in the respective controller/worker module:


### PR DESCRIPTION
Rephrase the support of arm64 until the Flatcar stable arm64 release is done, official Packet installation is there, and all components support arm64.