### PR TITLE
ci: Add baremetal cluster configuration

### DIFF
--- a/ci/baremetal/baremetal-cluster.tf.envsubst
+++ b/ci/baremetal/baremetal-cluster.tf.envsubst
@@ -1,0 +1,46 @@
+module "baremetal" {
+  source = "../../bare-metal/flatcar-linux/kubernetes"
+
+  providers = {
+    local = "local.default"
+    null = "null.default"
+    template = "template.default"
+    tls = "tls.default"
+  }
+
+  cached_install = "true"
+  matchbox_http_endpoint = "http://matchbox.example.com:8080"
+
+  cluster_name = "mercury"
+  k8s_domain_name = "node1.example.com"
+
+  ssh_keys = [
+    "$PUB_KEY",
+  ]
+
+  asset_dir = "${pathexpand("~/assets")}"
+
+  controller_domains = [
+    "node1.example.com",
+  ]
+  controller_macs = [
+    "52:54:00:a1:9c:ae",
+  ]
+  controller_names = [
+    "node1",
+  ]
+  worker_domains = [
+    "node2.example.com",
+    "node3.example.com",
+  ]
+  worker_macs = [
+    "52:54:00:b2:2f:86",
+    "52:54:00:c3:61:77",
+  ]
+  worker_names = [
+    "node2",
+    "node3",
+  ]
+  os_channel = "flatcar-stable"
+  os_version = "current"
+}

--- a/ci/baremetal/provider.tf
+++ b/ci/baremetal/provider.tf
@@ -1,0 +1,31 @@
+provider "matchbox" {
+  version     = "0.2.3"
+  ca          = "${file(pathexpand("~/pxe-testbed/.matchbox/ca.crt"))}"
+  client_cert = "${file(pathexpand("~/pxe-testbed/.matchbox/client.crt"))}"
+  client_key  = "${file(pathexpand("~/pxe-testbed/.matchbox/client.key"))}"
+  endpoint    = "matchbox.example.com:8081"
+}
+
+provider "ct" {
+  version = "0.4.0"
+}
+
+provider "local" {
+  version = "~> 1.2"
+  alias   = "default"
+}
+
+provider "null" {
+  version = "~> 2.1"
+  alias   = "default"
+}
+
+provider "template" {
+  version = "~> 2.1"
+  alias   = "default"
+}
+
+provider "tls" {
+  version = "~> 2.0"
+  alias   = "default"
+}


### PR DESCRIPTION
Include the baremetal PXE cluster configuration in the repository to be able to update it together with code changes

_Note: Test as described in https://github.com/kinvolk/lokomotive-ci/pull/57_