### PR TITLE
Migrate to Terraform 0.12

### DIFF
--- a/aws/flatcar-linux/kubernetes/ami.tf
+++ b/aws/flatcar-linux/kubernetes/ami.tf
@@ -47,4 +47,3 @@ data "aws_ami" "flatcar" {
     values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-*"]
   }
 }
-

--- a/aws/flatcar-linux/kubernetes/ami.tf
+++ b/aws/flatcar-linux/kubernetes/ami.tf
@@ -2,10 +2,10 @@ locals {
   # Pick a CoreOS Container Linux derivative
   # coreos-stable -> CoreOS Container Linux AMI
   # flatcar-stable -> Flatcar Container Linux AMI
-  ami_id = "${local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id}"
+  ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
 
-  flavor  = "${element(split("-", var.os_image), 0)}"
-  channel = "${element(split("-", var.os_image), 1)}"
+  flavor  = element(split("-", var.os_image), 0)
+  channel = element(split("-", var.os_image), 1)
 }
 
 data "aws_ami" "coreos" {
@@ -47,3 +47,4 @@ data "aws_ami" "flatcar" {
     values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-*"]
   }
 }
+

--- a/aws/flatcar-linux/kubernetes/ami.tf
+++ b/aws/flatcar-linux/kubernetes/ami.tf
@@ -4,8 +4,8 @@ locals {
   # flatcar-stable -> Flatcar Container Linux AMI
   ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
 
-  flavor  = element(split("-", var.os_image), 0)
-  channel = element(split("-", var.os_image), 1)
+  flavor  = split("-", var.os_image)[0]
+  channel = split("-", var.os_image)[1]
 }
 
 data "aws_ami" "coreos" {

--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -4,7 +4,7 @@ module "bootkube" {
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers          = [aws_route53_record.etcds.*.fqdn]
+  etcd_servers          = aws_route53_record.etcds.*.fqdn
   asset_dir             = var.asset_dir
   networking            = var.networking
   network_mtu           = var.network_mtu

--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -16,4 +16,3 @@ module "bootkube" {
 
   certs_validity_period_hours = var.certs_validity_period_hours
 }
-

--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=0f3156c73b846bf1bc5dd4681879048c37fb2f25"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/aws/flatcar-linux/kubernetes/bootkube.tf
+++ b/aws/flatcar-linux/kubernetes/bootkube.tf
@@ -2,17 +2,18 @@
 module "bootkube" {
   source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
 
-  cluster_name          = "${var.cluster_name}"
-  api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers          = ["${aws_route53_record.etcds.*.fqdn}"]
-  asset_dir             = "${var.asset_dir}"
-  networking            = "${var.networking}"
-  network_mtu           = "${var.network_mtu}"
-  pod_cidr              = "${var.pod_cidr}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  enable_reporting      = "${var.enable_reporting}"
-  enable_aggregation    = "${var.enable_aggregation}"
+  cluster_name          = var.cluster_name
+  api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  etcd_servers          = [aws_route53_record.etcds.*.fqdn]
+  asset_dir             = var.asset_dir
+  networking            = var.networking
+  network_mtu           = var.network_mtu
+  pod_cidr              = var.pod_cidr
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  enable_reporting      = var.enable_reporting
+  enable_aggregation    = var.enable_aggregation
 
-  certs_validity_period_hours = "${var.certs_validity_period_hours}"
+  certs_validity_period_hours = var.certs_validity_period_hours
 }
+

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -86,4 +86,3 @@ data "template_file" "etcds" {
     dns_zone     = var.dns_zone
   }
 }
-

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -10,7 +10,7 @@ resource "aws_route53_record" "etcds" {
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = [element(aws_instance.controllers.*.private_ip, count.index)]
+  records = [aws_instance.controllers[count.index].private_ip]
 }
 
 # Controller instances
@@ -24,7 +24,7 @@ resource "aws_instance" "controllers" {
   instance_type = var.controller_type
 
   ami       = local.ami_id
-  user_data = element(data.ct_config.controller-ignitions.*.rendered, count.index)
+  user_data = data.ct_config.controller-ignitions[count.index].rendered
 
   # storage
   root_block_device {
@@ -36,7 +36,7 @@ resource "aws_instance" "controllers" {
 
   # network
   associate_public_ip_address = true
-  subnet_id                   = element(aws_subnet.public.*.id, count.index)
+  subnet_id                   = aws_subnet.public[count.index].id
   vpc_security_group_ids      = [aws_security_group.controller.id]
 
   lifecycle {
@@ -49,11 +49,8 @@ resource "aws_instance" "controllers" {
 
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
-  count = var.controller_count
-  content = element(
-    data.template_file.controller-configs.*.rendered,
-    count.index,
-  )
+  count        = var.controller_count
+  content      = data.template_file.controller-configs[count.index].rendered
   pretty_print = false
   snippets     = var.controller_clc_snippets
 }

--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -1,86 +1,89 @@
 # Discrete DNS records for each controller's private IPv4 for etcd usage
 resource "aws_route53_record" "etcds" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   # DNS Zone where record should be created
-  zone_id = "${var.dns_zone_id}"
+  zone_id = var.dns_zone_id
 
-  name = "${format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)}"
+  name = format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)
   type = "A"
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = ["${element(aws_instance.controllers.*.private_ip, count.index)}"]
+  records = [element(aws_instance.controllers.*.private_ip, count.index)]
 }
 
 # Controller instances
 resource "aws_instance" "controllers" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   tags = {
     Name = "${var.cluster_name}-controller-${count.index}"
   }
 
-  instance_type = "${var.controller_type}"
+  instance_type = var.controller_type
 
-  ami       = "${local.ami_id}"
-  user_data = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+  ami       = local.ami_id
+  user_data = element(data.ct_config.controller-ignitions.*.rendered, count.index)
 
   # storage
   root_block_device {
-    volume_type = "${var.disk_type}"
-    volume_size = "${var.disk_size}"
-    iops        = "${var.disk_iops}"
+    volume_type = var.disk_type
+    volume_size = var.disk_size
+    iops        = var.disk_iops
     encrypted   = true
   }
 
   # network
   associate_public_ip_address = true
-  subnet_id                   = "${element(aws_subnet.public.*.id, count.index)}"
-  vpc_security_group_ids      = ["${aws_security_group.controller.id}"]
+  subnet_id                   = element(aws_subnet.public.*.id, count.index)
+  vpc_security_group_ids      = [aws_security_group.controller.id]
 
   lifecycle {
     ignore_changes = [
-      "ami",
-      "user_data",
+      ami,
+      user_data,
     ]
   }
 }
 
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
-  count        = "${var.controller_count}"
-  content      = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  count = var.controller_count
+  content = element(
+    data.template_file.controller-configs.*.rendered,
+    count.index,
+  )
   pretty_print = false
-  snippets     = ["${var.controller_clc_snippets}"]
+  snippets     = var.controller_clc_snippets
 }
 
 # Controller Container Linux configs
 data "template_file" "controller-configs" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
-  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+  template = file("${path.module}/cl/controller.yaml.tmpl")
 
   vars = {
     # Cannot use cyclic dependencies on controllers or their DNS records
     etcd_name   = "etcd${count.index}"
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
-
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster   = "${join(",", data.template_file.etcds.*.rendered)}"
-    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    etcd_initial_cluster   = join(",", data.template_file.etcds.*.rendered)
+    ssh_keys               = jsonencode(var.ssh_keys)
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
 
 data "template_file" "etcds" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
   vars = {
-    index        = "${count.index}"
-    cluster_name = "${var.cluster_name}"
-    dns_zone     = "${var.dns_zone}"
+    index        = count.index
+    cluster_name = var.cluster_name
+    dns_zone     = var.dns_zone
   }
 }
+

--- a/aws/flatcar-linux/kubernetes/dns.tf
+++ b/aws/flatcar-linux/kubernetes/dns.tf
@@ -1,10 +1,11 @@
 # Wildcard DNS Record for ingress
 resource "aws_route53_record" "ingress-wildcard" {
-  zone_id = "${var.dns_zone_id}"
-  name    = "${format("*.%s.%s.", var.cluster_name, var.dns_zone)}"
+  zone_id = var.dns_zone_id
+  name    = format("*.%s.%s.", var.cluster_name, var.dns_zone)
   type    = "CNAME"
   ttl     = 60
   records = [
-    "${format("%s.%s.", var.cluster_name, var.dns_zone)}",
+    format("%s.%s.", var.cluster_name, var.dns_zone),
   ]
 }
+

--- a/aws/flatcar-linux/kubernetes/dns.tf
+++ b/aws/flatcar-linux/kubernetes/dns.tf
@@ -8,4 +8,3 @@ resource "aws_route53_record" "ingress-wildcard" {
     format("%s.%s.", var.cluster_name, var.dns_zone),
   ]
 }
-

--- a/aws/flatcar-linux/kubernetes/network.tf
+++ b/aws/flatcar-linux/kubernetes/network.tf
@@ -1,57 +1,67 @@
-data "aws_availability_zones" "all" {}
+data "aws_availability_zones" "all" {
+}
 
 # Network VPC, gateway, and routes
 
 resource "aws_vpc" "network" {
-  cidr_block                       = "${var.host_cidr}"
+  cidr_block                       = var.host_cidr
   assign_generated_ipv6_cidr_block = true
   enable_dns_support               = true
   enable_dns_hostnames             = true
 
-  tags = "${map("Name", "${var.cluster_name}")}"
+  tags = {
+    "Name" = var.cluster_name
+  }
 }
 
 resource "aws_internet_gateway" "gateway" {
-  vpc_id = "${aws_vpc.network.id}"
+  vpc_id = aws_vpc.network.id
 
-  tags = "${map("Name", "${var.cluster_name}")}"
+  tags = {
+    "Name" = var.cluster_name
+  }
 }
 
 resource "aws_route_table" "default" {
-  vpc_id = "${aws_vpc.network.id}"
+  vpc_id = aws_vpc.network.id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.gateway.id}"
+    gateway_id = aws_internet_gateway.gateway.id
   }
 
   route {
     ipv6_cidr_block = "::/0"
-    gateway_id      = "${aws_internet_gateway.gateway.id}"
+    gateway_id      = aws_internet_gateway.gateway.id
   }
 
-  tags = "${map("Name", "${var.cluster_name}")}"
+  tags = {
+    "Name" = var.cluster_name
+  }
 }
 
 # Subnets (one per availability zone)
 
 resource "aws_subnet" "public" {
-  count = "${length(data.aws_availability_zones.all.names)}"
+  count = length(data.aws_availability_zones.all.names)
 
-  vpc_id            = "${aws_vpc.network.id}"
-  availability_zone = "${data.aws_availability_zones.all.names[count.index]}"
+  vpc_id            = aws_vpc.network.id
+  availability_zone = data.aws_availability_zones.all.names[count.index]
 
-  cidr_block                      = "${cidrsubnet(var.host_cidr, 4, count.index)}"
-  ipv6_cidr_block                 = "${cidrsubnet(aws_vpc.network.ipv6_cidr_block, 8, count.index)}"
+  cidr_block                      = cidrsubnet(var.host_cidr, 4, count.index)
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.network.ipv6_cidr_block, 8, count.index)
   map_public_ip_on_launch         = true
   assign_ipv6_address_on_creation = true
 
-  tags = "${map("Name", "${var.cluster_name}-public-${count.index}")}"
+  tags = {
+    "Name" = "${var.cluster_name}-public-${count.index}"
+  }
 }
 
 resource "aws_route_table_association" "public" {
-  count = "${length(data.aws_availability_zones.all.names)}"
+  count = length(data.aws_availability_zones.all.names)
 
-  route_table_id = "${aws_route_table.default.id}"
-  subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
+  route_table_id = aws_route_table.default.id
+  subnet_id      = element(aws_subnet.public.*.id, count.index)
 }
+

--- a/aws/flatcar-linux/kubernetes/network.tf
+++ b/aws/flatcar-linux/kubernetes/network.tf
@@ -62,5 +62,5 @@ resource "aws_route_table_association" "public" {
   count = length(data.aws_availability_zones.all.names)
 
   route_table_id = aws_route_table.default.id
-  subnet_id      = element(aws_subnet.public.*.id, count.index)
+  subnet_id      = aws_subnet.public[count.index].id
 }

--- a/aws/flatcar-linux/kubernetes/network.tf
+++ b/aws/flatcar-linux/kubernetes/network.tf
@@ -64,4 +64,3 @@ resource "aws_route_table_association" "public" {
   route_table_id = aws_route_table.default.id
   subnet_id      = element(aws_subnet.public.*.id, count.index)
 }
-

--- a/aws/flatcar-linux/kubernetes/nlb.tf
+++ b/aws/flatcar-linux/kubernetes/nlb.tf
@@ -1,14 +1,14 @@
 # Network Load Balancer DNS Record
 resource "aws_route53_record" "apiserver" {
-  zone_id = "${var.dns_zone_id}"
+  zone_id = var.dns_zone_id
 
-  name = "${format("%s.%s.", var.cluster_name, var.dns_zone)}"
+  name = format("%s.%s.", var.cluster_name, var.dns_zone)
   type = "A"
 
   # AWS recommends their special "alias" records for NLBs
   alias {
-    name                   = "${aws_lb.nlb.dns_name}"
-    zone_id                = "${aws_lb.nlb.zone_id}"
+    name                   = aws_lb.nlb.dns_name
+    zone_id                = aws_lb.nlb.zone_id
     evaluate_target_health = true
   }
 }
@@ -19,51 +19,51 @@ resource "aws_lb" "nlb" {
   load_balancer_type = "network"
   internal           = false
 
-  subnets = ["${aws_subnet.public.*.id}"]
+  subnets = aws_subnet.public.*.id
 
   enable_cross_zone_load_balancing = true
 }
 
 # Forward TCP apiserver traffic to controllers
 resource "aws_lb_listener" "apiserver-https" {
-  load_balancer_arn = "${aws_lb.nlb.arn}"
+  load_balancer_arn = aws_lb.nlb.arn
   protocol          = "TCP"
   port              = "6443"
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.controllers.arn}"
+    target_group_arn = aws_lb_target_group.controllers.arn
   }
 }
 
 # Forward HTTP ingress traffic to workers
 resource "aws_lb_listener" "ingress-http" {
-  load_balancer_arn = "${aws_lb.nlb.arn}"
+  load_balancer_arn = aws_lb.nlb.arn
   protocol          = "TCP"
   port              = 80
 
   default_action {
     type             = "forward"
-    target_group_arn = "${module.workers.target_group_http}"
+    target_group_arn = module.workers.target_group_http
   }
 }
 
 # Forward HTTPS ingress traffic to workers
 resource "aws_lb_listener" "ingress-https" {
-  load_balancer_arn = "${aws_lb.nlb.arn}"
+  load_balancer_arn = aws_lb.nlb.arn
   protocol          = "TCP"
   port              = 443
 
   default_action {
     type             = "forward"
-    target_group_arn = "${module.workers.target_group_https}"
+    target_group_arn = module.workers.target_group_https
   }
 }
 
 # Target group of controllers
 resource "aws_lb_target_group" "controllers" {
   name        = "${var.cluster_name}-controllers"
-  vpc_id      = "${aws_vpc.network.id}"
+  vpc_id      = aws_vpc.network.id
   target_type = "instance"
 
   protocol = "TCP"
@@ -85,9 +85,10 @@ resource "aws_lb_target_group" "controllers" {
 
 # Attach controller instances to apiserver NLB
 resource "aws_lb_target_group_attachment" "controllers" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
-  target_group_arn = "${aws_lb_target_group.controllers.arn}"
-  target_id        = "${element(aws_instance.controllers.*.id, count.index)}"
+  target_group_arn = aws_lb_target_group.controllers.arn
+  target_id        = element(aws_instance.controllers.*.id, count.index)
   port             = 6443
 }
+

--- a/aws/flatcar-linux/kubernetes/nlb.tf
+++ b/aws/flatcar-linux/kubernetes/nlb.tf
@@ -91,4 +91,3 @@ resource "aws_lb_target_group_attachment" "controllers" {
   target_id        = element(aws_instance.controllers.*.id, count.index)
   port             = 6443
 }
-

--- a/aws/flatcar-linux/kubernetes/nlb.tf
+++ b/aws/flatcar-linux/kubernetes/nlb.tf
@@ -88,6 +88,6 @@ resource "aws_lb_target_group_attachment" "controllers" {
   count = var.controller_count
 
   target_group_arn = aws_lb_target_group.controllers.arn
-  target_id        = element(aws_instance.controllers.*.id, count.index)
+  target_id        = aws_instance.controllers[count.index].id
   port             = 6443
 }

--- a/aws/flatcar-linux/kubernetes/outputs.tf
+++ b/aws/flatcar-linux/kubernetes/outputs.tf
@@ -1,53 +1,54 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin}"
+  value = module.bootkube.kubeconfig-admin
 }
 
 # Outputs for Kubernetes Ingress
 
 output "ingress_dns_name" {
-  value       = "${aws_lb.nlb.dns_name}"
+  value       = aws_lb.nlb.dns_name
   description = "DNS name of the network load balancer for distributing traffic to Ingress controllers"
 }
 
 output "ingress_zone_id" {
-  value       = "${aws_lb.nlb.zone_id}"
+  value       = aws_lb.nlb.zone_id
   description = "Route53 zone id of the network load balancer DNS name that can be used in Route53 alias records"
 }
 
 # Outputs for worker pools
 
 output "vpc_id" {
-  value       = "${aws_vpc.network.id}"
+  value       = aws_vpc.network.id
   description = "ID of the VPC for creating worker instances"
 }
 
 output "subnet_ids" {
-  value       = ["${aws_subnet.public.*.id}"]
+  value       = [aws_subnet.public.*.id]
   description = "List of subnet IDs for creating worker instances"
 }
 
 output "worker_security_groups" {
-  value       = ["${aws_security_group.worker.id}"]
+  value       = [aws_security_group.worker.id]
   description = "List of worker security group IDs"
 }
 
 output "kubeconfig" {
-  value = "${module.bootkube.kubeconfig-kubelet}"
+  value = module.bootkube.kubeconfig-kubelet
 }
 
 # Outputs for custom load balancing
 
 output "nlb_id" {
   description = "ARN of the Network Load Balancer"
-  value       = "${aws_lb.nlb.id}"
+  value       = aws_lb.nlb.id
 }
 
 output "worker_target_group_http" {
   description = "ARN of a target group of workers for HTTP traffic"
-  value       = "${module.workers.target_group_http}"
+  value       = module.workers.target_group_http
 }
 
 output "worker_target_group_https" {
   description = "ARN of a target group of workers for HTTPS traffic"
-  value       = "${module.workers.target_group_https}"
+  value       = module.workers.target_group_https
 }
+

--- a/aws/flatcar-linux/kubernetes/outputs.tf
+++ b/aws/flatcar-linux/kubernetes/outputs.tf
@@ -51,4 +51,3 @@ output "worker_target_group_https" {
   description = "ARN of a target group of workers for HTTPS traffic"
   value       = module.workers.target_group_https
 }
-

--- a/aws/flatcar-linux/kubernetes/require.tf
+++ b/aws/flatcar-linux/kubernetes/require.tf
@@ -23,4 +23,3 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0"
 }
-

--- a/aws/flatcar-linux/kubernetes/require.tf
+++ b/aws/flatcar-linux/kubernetes/require.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.11.0"
+  required_version = ">= 0.12.0"
 }
 
 provider "aws" {

--- a/aws/flatcar-linux/kubernetes/require.tf
+++ b/aws/flatcar-linux/kubernetes/require.tf
@@ -23,3 +23,4 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0"
 }
+

--- a/aws/flatcar-linux/kubernetes/security.tf
+++ b/aws/flatcar-linux/kubernetes/security.tf
@@ -361,4 +361,3 @@ resource "aws_security_group_rule" "worker-egress" {
   cidr_blocks      = ["0.0.0.0/0"]
   ipv6_cidr_blocks = ["::/0"]
 }
-

--- a/aws/flatcar-linux/kubernetes/security.tf
+++ b/aws/flatcar-linux/kubernetes/security.tf
@@ -6,13 +6,15 @@ resource "aws_security_group" "controller" {
   name        = "${var.cluster_name}-controller"
   description = "${var.cluster_name} controller security group"
 
-  vpc_id = "${aws_vpc.network.id}"
+  vpc_id = aws_vpc.network.id
 
-  tags = "${map("Name", "${var.cluster_name}-controller")}"
+  tags = {
+    "Name" = "${var.cluster_name}-controller"
+  }
 }
 
 resource "aws_security_group_rule" "controller-ssh" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -22,7 +24,7 @@ resource "aws_security_group_rule" "controller-ssh" {
 }
 
 resource "aws_security_group_rule" "controller-etcd" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -33,31 +35,31 @@ resource "aws_security_group_rule" "controller-etcd" {
 
 # Allow Prometheus to scrape etcd metrics
 resource "aws_security_group_rule" "controller-etcd-metrics" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 2381
   to_port                  = 2381
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-vxlan" {
-  count = "${var.networking == "flannel" ? 1 : 0}"
+  count = var.networking == "flannel" ? 1 : 0
 
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = "udp"
   from_port                = 4789
   to_port                  = 4789
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-vxlan-self" {
-  count = "${var.networking == "flannel" ? 1 : 0}"
+  count = var.networking == "flannel" ? 1 : 0
 
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = "udp"
@@ -67,7 +69,7 @@ resource "aws_security_group_rule" "controller-vxlan-self" {
 }
 
 resource "aws_security_group_rule" "controller-apiserver" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -78,28 +80,28 @@ resource "aws_security_group_rule" "controller-apiserver" {
 
 # Allow Prometheus to scrape node-exporter daemonset
 resource "aws_security_group_rule" "controller-node-exporter" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 9100
   to_port                  = 9100
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 # Allow apiserver to access kubelets for exec, log, port-forward
 resource "aws_security_group_rule" "controller-kubelet" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 10250
   to_port                  = 10250
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-kubelet-self" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -109,17 +111,17 @@ resource "aws_security_group_rule" "controller-kubelet-self" {
 }
 
 resource "aws_security_group_rule" "controller-bgp" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 179
   to_port                  = 179
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-bgp-self" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -129,17 +131,17 @@ resource "aws_security_group_rule" "controller-bgp-self" {
 }
 
 resource "aws_security_group_rule" "controller-ipip" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = 4
   from_port                = 0
   to_port                  = 0
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-ipip-self" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = 4
@@ -149,17 +151,17 @@ resource "aws_security_group_rule" "controller-ipip-self" {
 }
 
 resource "aws_security_group_rule" "controller-ipip-legacy" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type                     = "ingress"
   protocol                 = 94
   from_port                = 0
   to_port                  = 0
-  source_security_group_id = "${aws_security_group.worker.id}"
+  source_security_group_id = aws_security_group.worker.id
 }
 
 resource "aws_security_group_rule" "controller-ipip-legacy-self" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type      = "ingress"
   protocol  = 94
@@ -169,7 +171,7 @@ resource "aws_security_group_rule" "controller-ipip-legacy-self" {
 }
 
 resource "aws_security_group_rule" "controller-egress" {
-  security_group_id = "${aws_security_group.controller.id}"
+  security_group_id = aws_security_group.controller.id
 
   type             = "egress"
   protocol         = "-1"
@@ -185,13 +187,15 @@ resource "aws_security_group" "worker" {
   name        = "${var.cluster_name}-worker"
   description = "${var.cluster_name} worker security group"
 
-  vpc_id = "${aws_vpc.network.id}"
+  vpc_id = aws_vpc.network.id
 
-  tags = "${map("Name", "${var.cluster_name}-worker")}"
+  tags = {
+    "Name" = "${var.cluster_name}-worker"
+  }
 }
 
 resource "aws_security_group_rule" "worker-ssh" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -201,7 +205,7 @@ resource "aws_security_group_rule" "worker-ssh" {
 }
 
 resource "aws_security_group_rule" "worker-http" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -211,7 +215,7 @@ resource "aws_security_group_rule" "worker-http" {
 }
 
 resource "aws_security_group_rule" "worker-https" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -221,21 +225,21 @@ resource "aws_security_group_rule" "worker-https" {
 }
 
 resource "aws_security_group_rule" "worker-vxlan" {
-  count = "${var.networking == "flannel" ? 1 : 0}"
+  count = var.networking == "flannel" ? 1 : 0
 
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type                     = "ingress"
   protocol                 = "udp"
   from_port                = 4789
   to_port                  = 4789
-  source_security_group_id = "${aws_security_group.controller.id}"
+  source_security_group_id = aws_security_group.controller.id
 }
 
 resource "aws_security_group_rule" "worker-vxlan-self" {
-  count = "${var.networking == "flannel" ? 1 : 0}"
+  count = var.networking == "flannel" ? 1 : 0
 
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = "udp"
@@ -246,7 +250,7 @@ resource "aws_security_group_rule" "worker-vxlan-self" {
 
 # Allow Prometheus to scrape node-exporter daemonset
 resource "aws_security_group_rule" "worker-node-exporter" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -256,7 +260,7 @@ resource "aws_security_group_rule" "worker-node-exporter" {
 }
 
 resource "aws_security_group_rule" "ingress-health" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type        = "ingress"
   protocol    = "tcp"
@@ -267,18 +271,18 @@ resource "aws_security_group_rule" "ingress-health" {
 
 # Allow apiserver to access kubelets for exec, log, port-forward
 resource "aws_security_group_rule" "worker-kubelet" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 10250
   to_port                  = 10250
-  source_security_group_id = "${aws_security_group.controller.id}"
+  source_security_group_id = aws_security_group.controller.id
 }
 
 # Allow Prometheus to scrape kubelet metrics
 resource "aws_security_group_rule" "worker-kubelet-self" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -288,17 +292,17 @@ resource "aws_security_group_rule" "worker-kubelet-self" {
 }
 
 resource "aws_security_group_rule" "worker-bgp" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 179
   to_port                  = 179
-  source_security_group_id = "${aws_security_group.controller.id}"
+  source_security_group_id = aws_security_group.controller.id
 }
 
 resource "aws_security_group_rule" "worker-bgp-self" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = "tcp"
@@ -308,17 +312,17 @@ resource "aws_security_group_rule" "worker-bgp-self" {
 }
 
 resource "aws_security_group_rule" "worker-ipip" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type                     = "ingress"
   protocol                 = 4
   from_port                = 0
   to_port                  = 0
-  source_security_group_id = "${aws_security_group.controller.id}"
+  source_security_group_id = aws_security_group.controller.id
 }
 
 resource "aws_security_group_rule" "worker-ipip-self" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = 4
@@ -328,17 +332,17 @@ resource "aws_security_group_rule" "worker-ipip-self" {
 }
 
 resource "aws_security_group_rule" "worker-ipip-legacy" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type                     = "ingress"
   protocol                 = 94
   from_port                = 0
   to_port                  = 0
-  source_security_group_id = "${aws_security_group.controller.id}"
+  source_security_group_id = aws_security_group.controller.id
 }
 
 resource "aws_security_group_rule" "worker-ipip-legacy-self" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type      = "ingress"
   protocol  = 94
@@ -348,7 +352,7 @@ resource "aws_security_group_rule" "worker-ipip-legacy-self" {
 }
 
 resource "aws_security_group_rule" "worker-egress" {
-  security_group_id = "${aws_security_group.worker.id}"
+  security_group_id = aws_security_group.worker.id
 
   type             = "egress"
   protocol         = "-1"
@@ -357,3 +361,4 @@ resource "aws_security_group_rule" "worker-egress" {
   cidr_blocks      = ["0.0.0.0/0"]
   ipv6_cidr_blocks = ["::/0"]
 }
+

--- a/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/aws/flatcar-linux/kubernetes/ssh.tf
@@ -1,46 +1,46 @@
 # Secure copy etcd TLS assets to controllers.
 resource "null_resource" "copy-controller-secrets" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   connection {
     type    = "ssh"
-    host    = "${element(aws_instance.controllers.*.public_ip, count.index)}"
+    host    = element(aws_instance.controllers.*.public_ip, count.index)
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_ca_cert}"
+    content     = module.bootkube.etcd_ca_cert
     destination = "$HOME/etcd-client-ca.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_cert}"
+    content     = module.bootkube.etcd_client_cert
     destination = "$HOME/etcd-client.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_key}"
+    content     = module.bootkube.etcd_client_key
     destination = "$HOME/etcd-client.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_cert}"
+    content     = module.bootkube.etcd_server_cert
     destination = "$HOME/etcd-server.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_key}"
+    content     = module.bootkube.etcd_server_key
     destination = "$HOME/etcd-server.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_cert}"
+    content     = module.bootkube.etcd_peer_cert
     destination = "$HOME/etcd-peer.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_key}"
+    content     = module.bootkube.etcd_peer_key
     destination = "$HOME/etcd-peer.key"
   }
 
@@ -60,7 +60,7 @@ resource "null_resource" "copy-controller-secrets" {
   }
 
   triggers = {
-    controller_id = "${aws_instance.controllers.*.id[count.index]}"
+    controller_id = aws_instance.controllers[count.index].id
   }
 }
 
@@ -68,26 +68,26 @@ resource "null_resource" "copy-controller-secrets" {
 # one-time self-hosted cluster bootstrapping.
 resource "null_resource" "bootkube-start" {
   depends_on = [
-    "module.bootkube",
-    "module.workers",
-    "aws_route53_record.apiserver",
-    "null_resource.copy-controller-secrets",
+    module.bootkube,
+    module.workers,
+    aws_route53_record.apiserver,
+    null_resource.copy-controller-secrets,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${aws_instance.controllers.0.public_ip}"
+    host    = aws_instance.controllers[0].public_ip
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.kubeconfig-kubelet}"
+    content     = module.bootkube.kubeconfig-kubelet
     destination = "$HOME/kubeconfig"
   }
 
   provisioner "file" {
-    source      = "${var.asset_dir}"
+    source      = var.asset_dir
     destination = "$HOME/assets"
   }
 
@@ -101,3 +101,4 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
+

--- a/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/aws/flatcar-linux/kubernetes/ssh.tf
@@ -101,4 +101,3 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
-

--- a/aws/flatcar-linux/kubernetes/ssh.tf
+++ b/aws/flatcar-linux/kubernetes/ssh.tf
@@ -4,7 +4,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(aws_instance.controllers.*.public_ip, count.index)
+    host    = aws_instance.controllers[count.index].public_ip
     user    = "core"
     timeout = "15m"
   }

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -161,4 +161,3 @@ variable "certs_validity_period_hours" {
   type        = string
   default     = 8760
 }
-

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -18,14 +18,14 @@ variable "dns_zone_id" {
 # instances
 
 variable "controller_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of workers"
 }
 
@@ -48,8 +48,8 @@ variable "os_image" {
 }
 
 variable "disk_size" {
-  type        = string
-  default     = "40"
+  type        = number
+  default     = 40
   description = "Size of the EBS volume in GB"
 }
 
@@ -60,8 +60,8 @@ variable "disk_type" {
 }
 
 variable "disk_iops" {
-  type        = string
-  default     = "0"
+  type        = number
+  default     = 0
   description = "IOPS of the EBS volume (e.g. 100)"
 }
 
@@ -109,8 +109,8 @@ variable "networking" {
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only). Use 8981 if using instances types with Jumbo frames."
-  type        = string
-  default     = "1480"
+  type        = number
+  default     = 1480
 }
 
 variable "host_cidr" {
@@ -143,21 +143,21 @@ variable "cluster_domain_suffix" {
 }
 
 variable "enable_reporting" {
-  type        = string
+  type        = bool
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = "false"
+  default     = false
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 # Certificates
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = string
+  type        = number
   default     = 8760
 }

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -1,90 +1,90 @@
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
 # AWS
 
 variable "dns_zone" {
-  type        = "string"
+  type        = string
   description = "AWS Route53 DNS Zone (e.g. aws.example.com)"
 }
 
 variable "dns_zone_id" {
-  type        = "string"
+  type        = string
   description = "AWS Route53 DNS Zone ID (e.g. Z3PAABBCFAKEC0)"
 }
 
 # instances
 
 variable "controller_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of workers"
 }
 
 variable "controller_type" {
-  type        = "string"
+  type        = string
   default     = "t3.small"
   description = "EC2 instance type for controllers"
 }
 
 variable "worker_type" {
-  type        = "string"
+  type        = string
   default     = "t3.small"
   description = "EC2 instance type for workers"
 }
 
 variable "os_image" {
-  type        = "string"
+  type        = string
   default     = "flatcar-stable"
   description = "AMI channel for a CoreOS Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
 }
 
 variable "disk_size" {
-  type        = "string"
+  type        = string
   default     = "40"
   description = "Size of the EBS volume in GB"
 }
 
 variable "disk_type" {
-  type        = "string"
+  type        = string
   default     = "gp2"
   description = "Type of the EBS volume (e.g. standard, gp2, io1)"
 }
 
 variable "disk_iops" {
-  type        = "string"
+  type        = string
   default     = "0"
   description = "IOPS of the EBS volume (e.g. 100)"
 }
 
 variable "worker_price" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Spot price in USD for autoscaling group spot instances. Leave as default empty string for autoscaling group to use on-demand instances. Note, switching in-place from spot to on-demand is not possible: https://github.com/terraform-providers/terraform-provider-aws/issues/4320"
 }
 
 variable "worker_target_groups" {
-  type        = "list"
+  type        = list(string)
   description = "Additional target group ARNs to which worker instances should be added"
   default     = []
 }
 
 variable "controller_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
 
 variable "worker_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Worker Container Linux Config snippets"
   default     = []
 }
@@ -92,36 +92,36 @@ variable "worker_clc_snippets" {
 # configuration
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "networking" {
   description = "Choice of networking provider (calico or flannel)"
-  type        = "string"
+  type        = string
   default     = "calico"
 }
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only). Use 8981 if using instances types with Jumbo frames."
-  type        = "string"
+  type        = string
   default     = "1480"
 }
 
 variable "host_cidr" {
   description = "CIDR IPv4 range to assign to EC2 nodes"
-  type        = "string"
+  type        = string
   default     = "10.0.0.0/16"
 }
 
 variable "pod_cidr" {
   description = "CIDR IPv4 range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.2.0.0/16"
 }
 
@@ -131,25 +131,26 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type        = string
   description = "Enable usage or analytics reporting to upstreams (Calico)"
   default     = "false"
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
@@ -157,6 +158,7 @@ variable "enable_aggregation" {
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = "string"
+  type        = string
   default     = 8760
 }
+

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -1,22 +1,23 @@
 module "workers" {
   source = "./workers"
-  name   = "${var.cluster_name}"
+  name   = var.cluster_name
 
   # AWS
-  vpc_id          = "${aws_vpc.network.id}"
-  subnet_ids      = ["${aws_subnet.public.*.id}"]
-  security_groups = ["${aws_security_group.worker.id}"]
-  worker_count    = "${var.worker_count}"
-  instance_type   = "${var.worker_type}"
-  os_image        = "${var.os_image}"
-  disk_size       = "${var.disk_size}"
-  spot_price      = "${var.worker_price}"
-  target_groups   = ["${var.worker_target_groups}"]
+  vpc_id          = aws_vpc.network.id
+  subnet_ids      = [aws_subnet.public.*.id]
+  security_groups = [aws_security_group.worker.id]
+  worker_count    = var.worker_count
+  instance_type   = var.worker_type
+  os_image        = var.os_image
+  disk_size       = var.disk_size
+  spot_price      = var.worker_price
+  target_groups   = [var.worker_target_groups]
 
   # configuration
-  kubeconfig            = "${module.bootkube.kubeconfig-kubelet}"
-  ssh_keys              = "${var.ssh_keys}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  clc_snippets          = "${var.worker_clc_snippets}"
+  kubeconfig            = module.bootkube.kubeconfig-kubelet
+  ssh_keys              = var.ssh_keys
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  clc_snippets          = var.worker_clc_snippets
 }
+

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -20,4 +20,3 @@ module "workers" {
   cluster_domain_suffix = var.cluster_domain_suffix
   clc_snippets          = var.worker_clc_snippets
 }
-

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -4,14 +4,14 @@ module "workers" {
 
   # AWS
   vpc_id          = aws_vpc.network.id
-  subnet_ids      = [aws_subnet.public.*.id]
+  subnet_ids      = aws_subnet.public.*.id
   security_groups = [aws_security_group.worker.id]
   worker_count    = var.worker_count
   instance_type   = var.worker_type
   os_image        = var.os_image
   disk_size       = var.disk_size
   spot_price      = var.worker_price
-  target_groups   = [var.worker_target_groups]
+  target_groups   = var.worker_target_groups
 
   # configuration
   kubeconfig            = module.bootkube.kubeconfig-kubelet

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -6,7 +6,7 @@ module "workers" {
   vpc_id          = "${aws_vpc.network.id}"
   subnet_ids      = ["${aws_subnet.public.*.id}"]
   security_groups = ["${aws_security_group.worker.id}"]
-  count           = "${var.worker_count}"
+  worker_count    = "${var.worker_count}"
   instance_type   = "${var.worker_type}"
   os_image        = "${var.os_image}"
   disk_size       = "${var.disk_size}"

--- a/aws/flatcar-linux/kubernetes/workers/ami.tf
+++ b/aws/flatcar-linux/kubernetes/workers/ami.tf
@@ -47,4 +47,3 @@ data "aws_ami" "flatcar" {
     values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-*"]
   }
 }
-

--- a/aws/flatcar-linux/kubernetes/workers/ami.tf
+++ b/aws/flatcar-linux/kubernetes/workers/ami.tf
@@ -2,10 +2,10 @@ locals {
   # Pick a CoreOS Container Linux derivative
   # coreos-stable -> CoreOS Container Linux AMI
   # flatcar-stable -> Flatcar Container Linux AMI
-  ami_id = "${local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id}"
+  ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
 
-  flavor  = "${element(split("-", var.os_image), 0)}"
-  channel = "${element(split("-", var.os_image), 1)}"
+  flavor  = element(split("-", var.os_image), 0)
+  channel = element(split("-", var.os_image), 1)
 }
 
 data "aws_ami" "coreos" {
@@ -47,3 +47,4 @@ data "aws_ami" "flatcar" {
     values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-*"]
   }
 }
+

--- a/aws/flatcar-linux/kubernetes/workers/ami.tf
+++ b/aws/flatcar-linux/kubernetes/workers/ami.tf
@@ -4,8 +4,8 @@ locals {
   # flatcar-stable -> Flatcar Container Linux AMI
   ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
 
-  flavor  = element(split("-", var.os_image), 0)
-  channel = element(split("-", var.os_image), 1)
+  flavor  = split("-", var.os_image)[0]
+  channel = split("-", var.os_image)[1]
 }
 
 data "aws_ami" "coreos" {

--- a/aws/flatcar-linux/kubernetes/workers/ingress.tf
+++ b/aws/flatcar-linux/kubernetes/workers/ingress.tf
@@ -2,7 +2,7 @@
 
 resource "aws_lb_target_group" "workers-http" {
   name        = "${var.name}-workers-http"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
   target_type = "instance"
 
   protocol = "TCP"
@@ -25,7 +25,7 @@ resource "aws_lb_target_group" "workers-http" {
 
 resource "aws_lb_target_group" "workers-https" {
   name        = "${var.name}-workers-https"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
   target_type = "instance"
 
   protocol = "TCP"
@@ -45,3 +45,4 @@ resource "aws_lb_target_group" "workers-https" {
     interval = 10
   }
 }
+

--- a/aws/flatcar-linux/kubernetes/workers/ingress.tf
+++ b/aws/flatcar-linux/kubernetes/workers/ingress.tf
@@ -45,4 +45,3 @@ resource "aws_lb_target_group" "workers-https" {
     interval = 10
   }
 }
-

--- a/aws/flatcar-linux/kubernetes/workers/outputs.tf
+++ b/aws/flatcar-linux/kubernetes/workers/outputs.tf
@@ -7,4 +7,3 @@ output "target_group_https" {
   description = "ARN of a target group of workers for HTTPS traffic"
   value       = aws_lb_target_group.workers-https.arn
 }
-

--- a/aws/flatcar-linux/kubernetes/workers/outputs.tf
+++ b/aws/flatcar-linux/kubernetes/workers/outputs.tf
@@ -1,9 +1,10 @@
 output "target_group_http" {
   description = "ARN of a target group of workers for HTTP traffic"
-  value       = "${aws_lb_target_group.workers-http.arn}"
+  value       = aws_lb_target_group.workers-http.arn
 }
 
 output "target_group_https" {
   description = "ARN of a target group of workers for HTTPS traffic"
-  value       = "${aws_lb_target_group.workers-https.arn}"
+  value       = aws_lb_target_group.workers-https.arn
 }
+

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -104,4 +104,3 @@ variable "cluster_domain_suffix" {
   type        = string
   default     = "cluster.local"
 }
-

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -1,77 +1,77 @@
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Unique name for the worker pool"
 }
 
 # AWS
 
 variable "vpc_id" {
-  type        = "string"
+  type        = string
   description = "Must be set to `vpc_id` output by cluster"
 }
 
 variable "subnet_ids" {
-  type        = "list"
+  type        = list(string)
   description = "Must be set to `subnet_ids` output by cluster"
 }
 
 variable "security_groups" {
-  type        = "list"
+  type        = list(string)
   description = "Must be set to `worker_security_groups` output by cluster"
 }
 
 # instances
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of instances"
 }
 
 variable "instance_type" {
-  type        = "string"
+  type        = string
   default     = "t3.small"
   description = "EC2 instance type"
 }
 
 variable "os_image" {
-  type        = "string"
+  type        = string
   default     = "flatcar-stable"
   description = "AMI channel for a CoreOS Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
 }
 
 variable "disk_size" {
-  type        = "string"
+  type        = string
   default     = "40"
   description = "Size of the EBS volume in GB"
 }
 
 variable "disk_type" {
-  type        = "string"
+  type        = string
   default     = "gp2"
   description = "Type of the EBS volume (e.g. standard, gp2, io1)"
 }
 
 variable "disk_iops" {
-  type        = "string"
+  type        = string
   default     = "0"
   description = "IOPS of the EBS volume (required for io1)"
 }
 
 variable "spot_price" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Spot price in USD for autoscaling group spot instances. Leave as default empty string for autoscaling group to use on-demand instances. Note, switching in-place from spot to on-demand is not possible: https://github.com/terraform-providers/terraform-provider-aws/issues/4320"
 }
 
 variable "target_groups" {
-  type        = "list"
+  type        = list(string)
   description = "Additional target group ARNs to which instances should be added"
   default     = []
 }
 
 variable "clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Container Linux Config snippets"
   default     = []
 }
@@ -79,12 +79,12 @@ variable "clc_snippets" {
 # configuration
 
 variable "kubeconfig" {
-  type        = "string"
+  type        = string
   description = "Must be set to `kubeconfig` output by cluster"
 }
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
@@ -94,12 +94,14 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
+

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -22,7 +22,7 @@ variable "security_groups" {
 
 # instances
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of instances"

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -23,8 +23,8 @@ variable "security_groups" {
 # instances
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of instances"
 }
 
@@ -41,8 +41,8 @@ variable "os_image" {
 }
 
 variable "disk_size" {
-  type        = string
-  default     = "40"
+  type        = number
+  default     = 40
   description = "Size of the EBS volume in GB"
 }
 
@@ -53,8 +53,8 @@ variable "disk_type" {
 }
 
 variable "disk_iops" {
-  type        = string
-  default     = "0"
+  type        = number
+  default     = 0
   description = "IOPS of the EBS volume (required for io1)"
 }
 

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -3,9 +3,9 @@ resource "aws_autoscaling_group" "workers" {
   name = "${var.name}-worker ${aws_launch_configuration.worker.name}"
 
   # count
-  desired_capacity          = "${var.count}"
-  min_size                  = "${var.count}"
-  max_size                  = "${var.count + 2}"
+  desired_capacity          = "${var.worker_count}"
+  min_size                  = "${var.worker_count}"
+  max_size                  = "${var.worker_count + 2}"
   default_cooldown          = 30
   health_check_grace_period = 30
 

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -16,11 +16,11 @@ resource "aws_autoscaling_group" "workers" {
   launch_configuration = aws_launch_configuration.worker.name
 
   # target groups to which instances should be added
-  target_group_arns = [
+  target_group_arns = flatten([
     aws_lb_target_group.workers-http.id,
     aws_lb_target_group.workers-https.id,
     var.target_groups,
-  ]
+  ])
 
   lifecycle {
     # override the default destroy and replace update behavior

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -87,4 +87,3 @@ data "template_file" "worker-config" {
     cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
-

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -3,23 +3,23 @@ resource "aws_autoscaling_group" "workers" {
   name = "${var.name}-worker ${aws_launch_configuration.worker.name}"
 
   # count
-  desired_capacity          = "${var.worker_count}"
-  min_size                  = "${var.worker_count}"
-  max_size                  = "${var.worker_count + 2}"
+  desired_capacity          = var.worker_count
+  min_size                  = var.worker_count
+  max_size                  = var.worker_count + 2
   default_cooldown          = 30
   health_check_grace_period = 30
 
   # network
-  vpc_zone_identifier = ["${var.subnet_ids}"]
+  vpc_zone_identifier = var.subnet_ids
 
   # template
-  launch_configuration = "${aws_launch_configuration.worker.name}"
+  launch_configuration = aws_launch_configuration.worker.name
 
   # target groups to which instances should be added
   target_group_arns = [
-    "${aws_lb_target_group.workers-http.id}",
-    "${aws_lb_target_group.workers-https.id}",
-    "${var.target_groups}",
+    aws_lb_target_group.workers-http.id,
+    aws_lb_target_group.workers-https.id,
+    var.target_groups,
   ]
 
   lifecycle {
@@ -33,55 +33,58 @@ resource "aws_autoscaling_group" "workers" {
   # used. Disable wait to avoid issues and align with other clouds.
   wait_for_capacity_timeout = "0"
 
-  tags = [{
-    key                 = "Name"
-    value               = "${var.name}-worker"
-    propagate_at_launch = true
-  }]
+  tags = [
+    {
+      key                 = "Name"
+      value               = "${var.name}-worker"
+      propagate_at_launch = true
+    },
+  ]
 }
 
 # Worker template
 resource "aws_launch_configuration" "worker" {
-  image_id          = "${local.ami_id}"
-  instance_type     = "${var.instance_type}"
-  spot_price        = "${var.spot_price}"
+  image_id          = local.ami_id
+  instance_type     = var.instance_type
+  spot_price        = var.spot_price
   enable_monitoring = false
 
-  user_data = "${data.ct_config.worker-ignition.rendered}"
+  user_data = data.ct_config.worker-ignition.rendered
 
   # storage
   root_block_device {
-    volume_type = "${var.disk_type}"
-    volume_size = "${var.disk_size}"
-    iops        = "${var.disk_iops}"
+    volume_type = var.disk_type
+    volume_size = var.disk_size
+    iops        = var.disk_iops
     encrypted   = true
   }
 
   # network
-  security_groups = ["${var.security_groups}"]
+  security_groups = var.security_groups
 
   lifecycle {
     // Override the default destroy and replace update behavior
     create_before_destroy = true
-    ignore_changes        = ["image_id"]
+    ignore_changes        = [image_id]
   }
 }
 
 # Worker Ignition config
 data "ct_config" "worker-ignition" {
-  content      = "${data.template_file.worker-config.rendered}"
+  content      = data.template_file.worker-config.rendered
   pretty_print = false
-  snippets     = ["${var.clc_snippets}"]
+  snippets     = var.clc_snippets
 }
 
 # Worker Container Linux config
 data "template_file" "worker-config" {
-  template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
+  template = file("${path.module}/cl/worker.yaml.tmpl")
 
   vars = {
-    kubeconfig             = "${indent(10, var.kubeconfig)}"
-    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    kubeconfig             = indent(10, var.kubeconfig)
+    ssh_keys               = jsonencode(var.ssh_keys)
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
+

--- a/azure/flatcar-linux/kubernetes/bootkube.tf
+++ b/azure/flatcar-linux/kubernetes/bootkube.tf
@@ -4,7 +4,7 @@ module "bootkube" {
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers = [formatlist("%s.%s", azurerm_dns_a_record.etcds.*.name, var.dns_zone)]
+  etcd_servers = formatlist("%s.%s", azurerm_dns_a_record.etcds.*.name, var.dns_zone)
   asset_dir    = var.asset_dir
 
   networking = var.networking

--- a/azure/flatcar-linux/kubernetes/bootkube.tf
+++ b/azure/flatcar-linux/kubernetes/bootkube.tf
@@ -23,4 +23,3 @@ module "bootkube" {
 
   certs_validity_period_hours = var.certs_validity_period_hours
 }
-

--- a/azure/flatcar-linux/kubernetes/bootkube.tf
+++ b/azure/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=0f3156c73b846bf1bc5dd4681879048c37fb2f25"
 
   cluster_name = var.cluster_name
   api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/azure/flatcar-linux/kubernetes/bootkube.tf
+++ b/azure/flatcar-linux/kubernetes/bootkube.tf
@@ -2,12 +2,12 @@
 module "bootkube" {
   source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
 
-  cluster_name = "${var.cluster_name}"
-  api_servers  = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers = ["${formatlist("%s.%s", azurerm_dns_a_record.etcds.*.name, var.dns_zone)}"]
-  asset_dir    = "${var.asset_dir}"
+  cluster_name = var.cluster_name
+  api_servers  = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  etcd_servers = [formatlist("%s.%s", azurerm_dns_a_record.etcds.*.name, var.dns_zone)]
+  asset_dir    = var.asset_dir
 
-  networking = "${var.networking}"
+  networking = var.networking
 
   # only effective with Calico networking
   network_encapsulation = "vxlan"
@@ -15,11 +15,12 @@ module "bootkube" {
   # we should be able to use 1450 MTU, but in practice, 1410 was needed
   network_mtu = "1410"
 
-  pod_cidr              = "${var.pod_cidr}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  enable_reporting      = "${var.enable_reporting}"
-  enable_aggregation    = "${var.enable_aggregation}"
+  pod_cidr              = var.pod_cidr
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  enable_reporting      = var.enable_reporting
+  enable_aggregation    = var.enable_aggregation
 
-  certs_validity_period_hours = "${var.certs_validity_period_hours}"
+  certs_validity_period_hours = var.certs_validity_period_hours
 }
+

--- a/azure/flatcar-linux/kubernetes/controllers.tf
+++ b/azure/flatcar-linux/kubernetes/controllers.tf
@@ -175,4 +175,3 @@ data "template_file" "etcds" {
     dns_zone     = var.dns_zone
   }
 }
-

--- a/azure/flatcar-linux/kubernetes/controllers.tf
+++ b/azure/flatcar-linux/kubernetes/controllers.tf
@@ -1,54 +1,57 @@
 # Discrete DNS records for each controller's private IPv4 for etcd usage
 resource "azurerm_dns_a_record" "etcds" {
-  count               = "${var.controller_count}"
-  resource_group_name = "${var.dns_zone_group}"
+  count               = var.controller_count
+  resource_group_name = var.dns_zone_group
 
   # DNS Zone name where record should be created
-  zone_name = "${var.dns_zone}"
+  zone_name = var.dns_zone
 
   # DNS record
-  name = "${format("%s-etcd%d", var.cluster_name, count.index)}"
+  name = format("%s-etcd%d", var.cluster_name, count.index)
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = ["${element(azurerm_network_interface.controllers.*.private_ip_address, count.index)}"]
+  records = [element(
+    azurerm_network_interface.controllers.*.private_ip_address,
+    count.index,
+  )]
 }
 
 locals {
   # Channel for a CoreOS Container Linux derivative
   # coreos-stable -> CoreOS Container Linux Stable
-  channel = "${element(split("-", var.os_image), 1)}"
+  channel = element(split("-", var.os_image), 1)
 }
 
 # Controller availability set to spread controllers
 resource "azurerm_availability_set" "controllers" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                         = "${var.cluster_name}-controllers"
-  location                     = "${var.region}"
+  location                     = var.region
   platform_fault_domain_count  = 2
   platform_update_domain_count = 4
   managed                      = true
 }
 
 data "azurerm_image" "custom" {
-  name                = "${var.custom_image_name}"
-  resource_group_name = "${var.custom_image_resource_group_name}"
+  name                = var.custom_image_name
+  resource_group_name = var.custom_image_resource_group_name
 }
 
 # Controller instances
 resource "azurerm_virtual_machine" "controllers" {
-  count               = "${var.controller_count}"
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  count               = var.controller_count
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                = "${var.cluster_name}-controller-${count.index}"
-  location            = "${var.region}"
-  availability_set_id = "${azurerm_availability_set.controllers.id}"
-  vm_size             = "${var.controller_type}"
+  location            = var.region
+  availability_set_id = azurerm_availability_set.controllers.id
+  vm_size             = var.controller_type
 
   # boot
   storage_image_reference {
-    id = "${data.azurerm_image.custom.id}"
+    id = data.azurerm_image.custom.id
   }
 
   # storage
@@ -56,18 +59,18 @@ resource "azurerm_virtual_machine" "controllers" {
     name              = "${var.cluster_name}-controller-${count.index}"
     create_option     = "FromImage"
     caching           = "ReadWrite"
-    disk_size_gb      = "${var.disk_size}"
+    disk_size_gb      = var.disk_size
     os_type           = "Linux"
     managed_disk_type = "Premium_LRS"
   }
 
   # network
-  network_interface_ids = ["${element(azurerm_network_interface.controllers.*.id, count.index)}"]
+  network_interface_ids = [element(azurerm_network_interface.controllers.*.id, count.index)]
 
   os_profile {
     computer_name  = "${var.cluster_name}-controller-${count.index}"
     admin_username = "core"
-    custom_data    = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+    custom_data    = element(data.ct_config.controller-ignitions.*.rendered, count.index)
   }
 
   # Azure mandates setting an ssh_key, provide just a single key as the
@@ -77,7 +80,7 @@ resource "azurerm_virtual_machine" "controllers" {
 
     ssh_keys {
       path     = "/home/core/.ssh/authorized_keys"
-      key_data = "${element(var.ssh_keys, 0)}"
+      key_data = element(var.ssh_keys, 0)
     }
   }
 
@@ -87,86 +90,89 @@ resource "azurerm_virtual_machine" "controllers" {
 
   lifecycle {
     ignore_changes = [
-      "storage_os_disk",
-      "os_profile",
+      storage_os_disk,
+      os_profile,
     ]
   }
 }
 
 # Controller NICs with public and private IPv4
 resource "azurerm_network_interface" "controllers" {
-  count               = "${var.controller_count}"
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  count               = var.controller_count
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                      = "${var.cluster_name}-controller-${count.index}"
-  location                  = "${azurerm_resource_group.cluster.location}"
-  network_security_group_id = "${azurerm_network_security_group.controller.id}"
+  location                  = azurerm_resource_group.cluster.location
+  network_security_group_id = azurerm_network_security_group.controller.id
 
   ip_configuration {
     name                          = "ip0"
-    subnet_id                     = "${azurerm_subnet.controller.id}"
+    subnet_id                     = azurerm_subnet.controller.id
     private_ip_address_allocation = "dynamic"
 
     # public IPv4
-    public_ip_address_id = "${element(azurerm_public_ip.controllers.*.id, count.index)}"
+    public_ip_address_id = element(azurerm_public_ip.controllers.*.id, count.index)
   }
 }
 
 # Add controller NICs to the controller backend address pool
 resource "azurerm_network_interface_backend_address_pool_association" "controllers" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
-  network_interface_id    = "${element(azurerm_network_interface.controllers.*.id, count.index)}"
+  network_interface_id    = element(azurerm_network_interface.controllers.*.id, count.index)
   ip_configuration_name   = "ip0"
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.controller.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.controller.id
 }
 
 # Controller public IPv4 addresses
 resource "azurerm_public_ip" "controllers" {
-  count               = "${var.controller_count}"
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  count               = var.controller_count
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name              = "${var.cluster_name}-controller-${count.index}"
-  location          = "${azurerm_resource_group.cluster.location}"
+  location          = azurerm_resource_group.cluster.location
   sku               = "Standard"
   allocation_method = "Static"
 }
 
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
-  count        = "${var.controller_count}"
-  content      = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  count = var.controller_count
+  content = element(
+    data.template_file.controller-configs.*.rendered,
+    count.index,
+  )
   pretty_print = false
-  snippets     = ["${var.controller_clc_snippets}"]
+  snippets     = var.controller_clc_snippets
 }
 
 # Controller Container Linux configs
 data "template_file" "controller-configs" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
-  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+  template = file("${path.module}/cl/controller.yaml.tmpl")
 
   vars = {
     # Cannot use cyclic dependencies on controllers or their DNS records
     etcd_name   = "etcd${count.index}"
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
-
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster   = "${join(",", data.template_file.etcds.*.rendered)}"
-    kubeconfig             = "${indent(10, module.bootkube.kubeconfig-kubelet)}"
-    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    etcd_initial_cluster   = join(",", data.template_file.etcds.*.rendered)
+    kubeconfig             = indent(10, module.bootkube.kubeconfig-kubelet)
+    ssh_keys               = jsonencode(var.ssh_keys)
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
 
 data "template_file" "etcds" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
   vars = {
-    index        = "${count.index}"
-    cluster_name = "${var.cluster_name}"
-    dns_zone     = "${var.dns_zone}"
+    index        = count.index
+    cluster_name = var.cluster_name
+    dns_zone     = var.dns_zone
   }
 }
+

--- a/azure/flatcar-linux/kubernetes/controllers.tf
+++ b/azure/flatcar-linux/kubernetes/controllers.tf
@@ -11,16 +11,13 @@ resource "azurerm_dns_a_record" "etcds" {
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = [element(
-    azurerm_network_interface.controllers.*.private_ip_address,
-    count.index,
-  )]
+  records = [azurerm_network_interface.controllers[count.index].private_ip_address]
 }
 
 locals {
   # Channel for a CoreOS Container Linux derivative
   # coreos-stable -> CoreOS Container Linux Stable
-  channel = element(split("-", var.os_image), 1)
+  channel = split("-", var.os_image)[1]
 }
 
 # Controller availability set to spread controllers
@@ -65,12 +62,12 @@ resource "azurerm_virtual_machine" "controllers" {
   }
 
   # network
-  network_interface_ids = [element(azurerm_network_interface.controllers.*.id, count.index)]
+  network_interface_ids = [azurerm_network_interface.controllers[count.index].id]
 
   os_profile {
     computer_name  = "${var.cluster_name}-controller-${count.index}"
     admin_username = "core"
-    custom_data    = element(data.ct_config.controller-ignitions.*.rendered, count.index)
+    custom_data    = data.ct_config.controller-ignitions[count.index].rendered
   }
 
   # Azure mandates setting an ssh_key, provide just a single key as the
@@ -80,7 +77,7 @@ resource "azurerm_virtual_machine" "controllers" {
 
     ssh_keys {
       path     = "/home/core/.ssh/authorized_keys"
-      key_data = element(var.ssh_keys, 0)
+      key_data = var.ssh_keys[0]
     }
   }
 
@@ -111,7 +108,7 @@ resource "azurerm_network_interface" "controllers" {
     private_ip_address_allocation = "dynamic"
 
     # public IPv4
-    public_ip_address_id = element(azurerm_public_ip.controllers.*.id, count.index)
+    public_ip_address_id = azurerm_public_ip.controllers[count.index].id
   }
 }
 
@@ -119,7 +116,7 @@ resource "azurerm_network_interface" "controllers" {
 resource "azurerm_network_interface_backend_address_pool_association" "controllers" {
   count = var.controller_count
 
-  network_interface_id    = element(azurerm_network_interface.controllers.*.id, count.index)
+  network_interface_id    = azurerm_network_interface.controllers[count.index].id
   ip_configuration_name   = "ip0"
   backend_address_pool_id = azurerm_lb_backend_address_pool.controller.id
 }
@@ -137,11 +134,8 @@ resource "azurerm_public_ip" "controllers" {
 
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
-  count = var.controller_count
-  content = element(
-    data.template_file.controller-configs.*.rendered,
-    count.index,
-  )
+  count        = var.controller_count
+  content      = data.template_file.controller-configs[count.index].rendered
   pretty_print = false
   snippets     = var.controller_clc_snippets
 }

--- a/azure/flatcar-linux/kubernetes/lb.tf
+++ b/azure/flatcar-linux/kubernetes/lb.tf
@@ -142,4 +142,3 @@ resource "azurerm_lb_probe" "ingress" {
 
   interval_in_seconds = 5
 }
-

--- a/azure/flatcar-linux/kubernetes/lb.tf
+++ b/azure/flatcar-linux/kubernetes/lb.tf
@@ -1,123 +1,123 @@
 # DNS record for the apiserver load balancer
 resource "azurerm_dns_a_record" "apiserver" {
-  resource_group_name = "${var.dns_zone_group}"
+  resource_group_name = var.dns_zone_group
 
   # DNS Zone name where record should be created
-  zone_name = "${var.dns_zone}"
+  zone_name = var.dns_zone
 
   # DNS record
-  name = "${var.cluster_name}"
+  name = var.cluster_name
   ttl  = 300
 
   # IPv4 address of apiserver load balancer
-  records = ["${azurerm_public_ip.apiserver-ipv4.ip_address}"]
+  records = [azurerm_public_ip.apiserver-ipv4.ip_address]
 }
 
 # Static IPv4 address for the apiserver frontend
 resource "azurerm_public_ip" "apiserver-ipv4" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name              = "${var.cluster_name}-apiserver-ipv4"
-  location          = "${var.region}"
+  location          = var.region
   sku               = "Standard"
   allocation_method = "Static"
 }
 
 # Static IPv4 address for the ingress frontend
 resource "azurerm_public_ip" "ingress-ipv4" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name              = "${var.cluster_name}-ingress-ipv4"
-  location          = "${var.region}"
+  location          = var.region
   sku               = "Standard"
   allocation_method = "Static"
 }
 
 # Network Load Balancer for apiservers and ingress
 resource "azurerm_lb" "cluster" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
-  name     = "${var.cluster_name}"
-  location = "${var.region}"
+  name     = var.cluster_name
+  location = var.region
   sku      = "Standard"
 
   frontend_ip_configuration {
     name                 = "apiserver"
-    public_ip_address_id = "${azurerm_public_ip.apiserver-ipv4.id}"
+    public_ip_address_id = azurerm_public_ip.apiserver-ipv4.id
   }
 
   frontend_ip_configuration {
     name                 = "ingress"
-    public_ip_address_id = "${azurerm_public_ip.ingress-ipv4.id}"
+    public_ip_address_id = azurerm_public_ip.ingress-ipv4.id
   }
 }
 
 resource "azurerm_lb_rule" "apiserver" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                           = "apiserver"
-  loadbalancer_id                = "${azurerm_lb.cluster.id}"
+  loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "apiserver"
 
   protocol                = "Tcp"
   frontend_port           = 6443
   backend_port            = 6443
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.controller.id}"
-  probe_id                = "${azurerm_lb_probe.apiserver.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.controller.id
+  probe_id                = azurerm_lb_probe.apiserver.id
 }
 
 resource "azurerm_lb_rule" "ingress-http" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                           = "ingress-http"
-  loadbalancer_id                = "${azurerm_lb.cluster.id}"
+  loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "ingress"
 
   protocol                = "Tcp"
   frontend_port           = 80
   backend_port            = 80
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.worker.id}"
-  probe_id                = "${azurerm_lb_probe.ingress.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.worker.id
+  probe_id                = azurerm_lb_probe.ingress.id
 }
 
 resource "azurerm_lb_rule" "ingress-https" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                           = "ingress-https"
-  loadbalancer_id                = "${azurerm_lb.cluster.id}"
+  loadbalancer_id                = azurerm_lb.cluster.id
   frontend_ip_configuration_name = "ingress"
 
   protocol                = "Tcp"
   frontend_port           = 443
   backend_port            = 443
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.worker.id}"
-  probe_id                = "${azurerm_lb_probe.ingress.id}"
+  backend_address_pool_id = azurerm_lb_backend_address_pool.worker.id
+  probe_id                = azurerm_lb_probe.ingress.id
 }
 
 # Address pool of controllers
 resource "azurerm_lb_backend_address_pool" "controller" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name            = "controller"
-  loadbalancer_id = "${azurerm_lb.cluster.id}"
+  loadbalancer_id = azurerm_lb.cluster.id
 }
 
 # Address pool of workers
 resource "azurerm_lb_backend_address_pool" "worker" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name            = "worker"
-  loadbalancer_id = "${azurerm_lb.cluster.id}"
+  loadbalancer_id = azurerm_lb.cluster.id
 }
 
 # Health checks / probes
 
 # TCP health check for apiserver
 resource "azurerm_lb_probe" "apiserver" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name            = "apiserver"
-  loadbalancer_id = "${azurerm_lb.cluster.id}"
+  loadbalancer_id = azurerm_lb.cluster.id
   protocol        = "Tcp"
   port            = 6443
 
@@ -129,10 +129,10 @@ resource "azurerm_lb_probe" "apiserver" {
 
 # HTTP health check for ingress
 resource "azurerm_lb_probe" "ingress" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name            = "ingress"
-  loadbalancer_id = "${azurerm_lb.cluster.id}"
+  loadbalancer_id = azurerm_lb.cluster.id
   protocol        = "Http"
   port            = 10254
   request_path    = "/healthz"
@@ -142,3 +142,4 @@ resource "azurerm_lb_probe" "ingress" {
 
   interval_in_seconds = 5
 }
+

--- a/azure/flatcar-linux/kubernetes/network.tf
+++ b/azure/flatcar-linux/kubernetes/network.tf
@@ -1,15 +1,15 @@
 # Organize cluster into a resource group
 resource "azurerm_resource_group" "cluster" {
-  name     = "${var.cluster_name}"
-  location = "${var.region}"
+  name     = var.cluster_name
+  location = var.region
 }
 
 resource "azurerm_virtual_network" "network" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
-  name          = "${var.cluster_name}"
-  location      = "${azurerm_resource_group.cluster.location}"
-  address_space = ["${var.host_cidr}"]
+  name          = var.cluster_name
+  location      = azurerm_resource_group.cluster.location
+  address_space = [var.host_cidr]
 }
 
 # Subnets - separate subnets for controller and workers because Azure
@@ -17,17 +17,18 @@ resource "azurerm_virtual_network" "network" {
 # tags like GCP or security group membership like AWS
 
 resource "azurerm_subnet" "controller" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                 = "controller"
-  virtual_network_name = "${azurerm_virtual_network.network.name}"
-  address_prefix       = "${cidrsubnet(var.host_cidr, 1, 0)}"
+  virtual_network_name = azurerm_virtual_network.network.name
+  address_prefix       = cidrsubnet(var.host_cidr, 1, 0)
 }
 
 resource "azurerm_subnet" "worker" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                 = "worker"
-  virtual_network_name = "${azurerm_virtual_network.network.name}"
-  address_prefix       = "${cidrsubnet(var.host_cidr, 1, 1)}"
+  virtual_network_name = azurerm_virtual_network.network.name
+  address_prefix       = cidrsubnet(var.host_cidr, 1, 1)
 }
+

--- a/azure/flatcar-linux/kubernetes/network.tf
+++ b/azure/flatcar-linux/kubernetes/network.tf
@@ -31,4 +31,3 @@ resource "azurerm_subnet" "worker" {
   virtual_network_name = azurerm_virtual_network.network.name
   address_prefix       = cidrsubnet(var.host_cidr, 1, 1)
 }
-

--- a/azure/flatcar-linux/kubernetes/outputs.tf
+++ b/azure/flatcar-linux/kubernetes/outputs.tf
@@ -1,55 +1,56 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin}"
+  value = module.bootkube.kubeconfig-admin
 }
 
 # Outputs for Kubernetes Ingress
 
 output "ingress_static_ipv4" {
-  value       = "${azurerm_public_ip.ingress-ipv4.ip_address}"
+  value       = azurerm_public_ip.ingress-ipv4.ip_address
   description = "IPv4 address of the load balancer for distributing traffic to Ingress controllers"
 }
 
 # Outputs for worker pools
 
 output "region" {
-  value = "${azurerm_resource_group.cluster.location}"
+  value = azurerm_resource_group.cluster.location
 }
 
 output "resource_group_name" {
-  value = "${azurerm_resource_group.cluster.name}"
+  value = azurerm_resource_group.cluster.name
 }
 
 output "subnet_id" {
-  value = "${azurerm_subnet.worker.id}"
+  value = azurerm_subnet.worker.id
 }
 
 output "security_group_id" {
-  value = "${azurerm_network_security_group.worker.id}"
+  value = azurerm_network_security_group.worker.id
 }
 
 output "kubeconfig" {
-  value = "${module.bootkube.kubeconfig-kubelet}"
+  value = module.bootkube.kubeconfig-kubelet
 }
 
 # Outputs for custom firewalling
 
 output "worker_security_group_name" {
-  value = "${azurerm_network_security_group.worker.name}"
+  value = azurerm_network_security_group.worker.name
 }
 
 output "worker_address_prefix" {
   description = "Worker network subnet CIDR address (for source/destination)"
-  value       = "${azurerm_subnet.worker.address_prefix}"
+  value       = azurerm_subnet.worker.address_prefix
 }
 
 # Outputs for custom load balancing
 
 output "loadbalancer_id" {
   description = "ID of the cluster load balancer"
-  value       = "${azurerm_lb.cluster.id}"
+  value       = azurerm_lb.cluster.id
 }
 
 output "backend_address_pool_id" {
   description = "ID of the worker backend address pool"
-  value       = "${azurerm_lb_backend_address_pool.worker.id}"
+  value       = azurerm_lb_backend_address_pool.worker.id
 }
+

--- a/azure/flatcar-linux/kubernetes/outputs.tf
+++ b/azure/flatcar-linux/kubernetes/outputs.tf
@@ -53,4 +53,3 @@ output "backend_address_pool_id" {
   description = "ID of the worker backend address pool"
   value       = azurerm_lb_backend_address_pool.worker.id
 }
-

--- a/azure/flatcar-linux/kubernetes/require.tf
+++ b/azure/flatcar-linux/kubernetes/require.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.11.0"
+  required_version = ">= 0.12.0"
 }
 
 provider "azurerm" {

--- a/azure/flatcar-linux/kubernetes/require.tf
+++ b/azure/flatcar-linux/kubernetes/require.tf
@@ -23,4 +23,3 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0"
 }
-

--- a/azure/flatcar-linux/kubernetes/require.tf
+++ b/azure/flatcar-linux/kubernetes/require.tf
@@ -23,3 +23,4 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0"
 }
+

--- a/azure/flatcar-linux/kubernetes/security.tf
+++ b/azure/flatcar-linux/kubernetes/security.tf
@@ -285,4 +285,3 @@ resource "azurerm_network_security_rule" "worker-deny-all" {
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
 }
-

--- a/azure/flatcar-linux/kubernetes/security.tf
+++ b/azure/flatcar-linux/kubernetes/security.tf
@@ -1,17 +1,17 @@
 # Controller security group
 
 resource "azurerm_network_security_group" "controller" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name     = "${var.cluster_name}-controller"
-  location = "${azurerm_resource_group.cluster.location}"
+  location = azurerm_resource_group.cluster.location
 }
 
 resource "azurerm_network_security_rule" "controller-ssh" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-ssh"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2000"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -19,45 +19,45 @@ resource "azurerm_network_security_rule" "controller-ssh" {
   source_port_range           = "*"
   destination_port_range      = "22"
   source_address_prefix       = "*"
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 resource "azurerm_network_security_rule" "controller-etcd" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-etcd"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2005"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "2379-2380"
-  source_address_prefix       = "${azurerm_subnet.controller.address_prefix}"
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  source_address_prefix       = azurerm_subnet.controller.address_prefix
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 # Allow Prometheus to scrape etcd metrics
 resource "azurerm_network_security_rule" "controller-etcd-metrics" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-etcd-metrics"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2010"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "2381"
-  source_address_prefix       = "${azurerm_subnet.worker.address_prefix}"
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  source_address_prefix       = azurerm_subnet.worker.address_prefix
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 resource "azurerm_network_security_rule" "controller-apiserver" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-apiserver"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2015"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -65,46 +65,46 @@ resource "azurerm_network_security_rule" "controller-apiserver" {
   source_port_range           = "*"
   destination_port_range      = "6443"
   source_address_prefix       = "*"
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 resource "azurerm_network_security_rule" "controller-vxlan" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-vxlan"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2020"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Udp"
   source_port_range           = "*"
   destination_port_range      = "4789"
-  source_address_prefixes     = ["${azurerm_subnet.controller.address_prefix}", "${azurerm_subnet.worker.address_prefix}"]
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  source_address_prefixes     = [azurerm_subnet.controller.address_prefix, azurerm_subnet.worker.address_prefix]
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 # Allow Prometheus to scrape node-exporter daemonset
 resource "azurerm_network_security_rule" "controller-node-exporter" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-node-exporter"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2025"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "9100"
-  source_address_prefix       = "${azurerm_subnet.worker.address_prefix}"
-  destination_address_prefix  = "${azurerm_subnet.controller.address_prefix}"
+  source_address_prefix       = azurerm_subnet.worker.address_prefix
+  destination_address_prefix  = azurerm_subnet.controller.address_prefix
 }
 
 # Allow apiserver to access kubelet's for exec, log, port-forward
 resource "azurerm_network_security_rule" "controller-kubelet" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-kubelet"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "2030"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -113,18 +113,18 @@ resource "azurerm_network_security_rule" "controller-kubelet" {
   destination_port_range      = "10250"
 
   # allow Prometheus to scrape kubelet metrics too
-  source_address_prefixes    = ["${azurerm_subnet.controller.address_prefix}", "${azurerm_subnet.worker.address_prefix}"]
-  destination_address_prefix = "${azurerm_subnet.controller.address_prefix}"
+  source_address_prefixes    = [azurerm_subnet.controller.address_prefix, azurerm_subnet.worker.address_prefix]
+  destination_address_prefix = azurerm_subnet.controller.address_prefix
 }
 
 # Override Azure AllowVNetInBound and AllowAzureLoadBalancerInBound
 # https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#default-security-rules
 
 resource "azurerm_network_security_rule" "controller-allow-loadblancer" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-loadbalancer"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "3000"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -136,10 +136,10 @@ resource "azurerm_network_security_rule" "controller-allow-loadblancer" {
 }
 
 resource "azurerm_network_security_rule" "controller-deny-all" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "deny-all"
-  network_security_group_name = "${azurerm_network_security_group.controller.name}"
+  network_security_group_name = azurerm_network_security_group.controller.name
   priority                    = "3005"
   access                      = "Deny"
   direction                   = "Inbound"
@@ -153,32 +153,32 @@ resource "azurerm_network_security_rule" "controller-deny-all" {
 # Worker security group
 
 resource "azurerm_network_security_group" "worker" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name     = "${var.cluster_name}-worker"
-  location = "${azurerm_resource_group.cluster.location}"
+  location = azurerm_resource_group.cluster.location
 }
 
 resource "azurerm_network_security_rule" "worker-ssh" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-ssh"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2000"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefix       = "${azurerm_subnet.controller.address_prefix}"
-  destination_address_prefix  = "${azurerm_subnet.worker.address_prefix}"
+  source_address_prefix       = azurerm_subnet.controller.address_prefix
+  destination_address_prefix  = azurerm_subnet.worker.address_prefix
 }
 
 resource "azurerm_network_security_rule" "worker-http" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-http"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2005"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -186,14 +186,14 @@ resource "azurerm_network_security_rule" "worker-http" {
   source_port_range           = "*"
   destination_port_range      = "80"
   source_address_prefix       = "*"
-  destination_address_prefix  = "${azurerm_subnet.worker.address_prefix}"
+  destination_address_prefix  = azurerm_subnet.worker.address_prefix
 }
 
 resource "azurerm_network_security_rule" "worker-https" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-https"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2010"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -201,46 +201,46 @@ resource "azurerm_network_security_rule" "worker-https" {
   source_port_range           = "*"
   destination_port_range      = "443"
   source_address_prefix       = "*"
-  destination_address_prefix  = "${azurerm_subnet.worker.address_prefix}"
+  destination_address_prefix  = azurerm_subnet.worker.address_prefix
 }
 
 resource "azurerm_network_security_rule" "worker-vxlan" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-vxlan"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2015"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Udp"
   source_port_range           = "*"
   destination_port_range      = "4789"
-  source_address_prefixes     = ["${azurerm_subnet.controller.address_prefix}", "${azurerm_subnet.worker.address_prefix}"]
-  destination_address_prefix  = "${azurerm_subnet.worker.address_prefix}"
+  source_address_prefixes     = [azurerm_subnet.controller.address_prefix, azurerm_subnet.worker.address_prefix]
+  destination_address_prefix  = azurerm_subnet.worker.address_prefix
 }
 
 # Allow Prometheus to scrape node-exporter daemonset
 resource "azurerm_network_security_rule" "worker-node-exporter" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-node-exporter"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2020"
   access                      = "Allow"
   direction                   = "Inbound"
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "9100"
-  source_address_prefix       = "${azurerm_subnet.worker.address_prefix}"
-  destination_address_prefix  = "${azurerm_subnet.worker.address_prefix}"
+  source_address_prefix       = azurerm_subnet.worker.address_prefix
+  destination_address_prefix  = azurerm_subnet.worker.address_prefix
 }
 
 # Allow apiserver to access kubelet's for exec, log, port-forward
 resource "azurerm_network_security_rule" "worker-kubelet" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-kubelet"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "2025"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -249,18 +249,18 @@ resource "azurerm_network_security_rule" "worker-kubelet" {
   destination_port_range      = "10250"
 
   # allow Prometheus to scrape kubelet metrics too
-  source_address_prefixes    = ["${azurerm_subnet.controller.address_prefix}", "${azurerm_subnet.worker.address_prefix}"]
-  destination_address_prefix = "${azurerm_subnet.worker.address_prefix}"
+  source_address_prefixes    = [azurerm_subnet.controller.address_prefix, azurerm_subnet.worker.address_prefix]
+  destination_address_prefix = azurerm_subnet.worker.address_prefix
 }
 
 # Override Azure AllowVNetInBound and AllowAzureLoadBalancerInBound
 # https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#default-security-rules
 
 resource "azurerm_network_security_rule" "worker-allow-loadblancer" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "allow-loadbalancer"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "3000"
   access                      = "Allow"
   direction                   = "Inbound"
@@ -272,10 +272,10 @@ resource "azurerm_network_security_rule" "worker-allow-loadblancer" {
 }
 
 resource "azurerm_network_security_rule" "worker-deny-all" {
-  resource_group_name = "${azurerm_resource_group.cluster.name}"
+  resource_group_name = azurerm_resource_group.cluster.name
 
   name                        = "deny-all"
-  network_security_group_name = "${azurerm_network_security_group.worker.name}"
+  network_security_group_name = azurerm_network_security_group.worker.name
   priority                    = "3005"
   access                      = "Deny"
   direction                   = "Inbound"
@@ -285,3 +285,4 @@ resource "azurerm_network_security_rule" "worker-deny-all" {
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
 }
+

--- a/azure/flatcar-linux/kubernetes/ssh.tf
+++ b/azure/flatcar-linux/kubernetes/ssh.tf
@@ -6,7 +6,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(azurerm_public_ip.controllers.*.ip_address, count.index)
+    host    = azurerm_public_ip.controllers[count.index].ip_address
     user    = "core"
     timeout = "15m"
   }
@@ -74,7 +74,7 @@ resource "null_resource" "bootkube-start" {
 
   connection {
     type    = "ssh"
-    host    = element(azurerm_public_ip.controllers.*.ip_address, 0)
+    host    = azurerm_public_ip.controllers[0].ip_address
     user    = "core"
     timeout = "15m"
   }

--- a/azure/flatcar-linux/kubernetes/ssh.tf
+++ b/azure/flatcar-linux/kubernetes/ssh.tf
@@ -91,4 +91,3 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
-

--- a/azure/flatcar-linux/kubernetes/ssh.tf
+++ b/azure/flatcar-linux/kubernetes/ssh.tf
@@ -1,50 +1,48 @@
 # Secure copy etcd TLS assets to controllers.
 resource "null_resource" "copy-controller-secrets" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
-  depends_on = [
-    "azurerm_virtual_machine.controllers",
-  ]
+  depends_on = [azurerm_virtual_machine.controllers]
 
   connection {
     type    = "ssh"
-    host    = "${element(azurerm_public_ip.controllers.*.ip_address, count.index)}"
+    host    = element(azurerm_public_ip.controllers.*.ip_address, count.index)
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_ca_cert}"
+    content     = module.bootkube.etcd_ca_cert
     destination = "$HOME/etcd-client-ca.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_cert}"
+    content     = module.bootkube.etcd_client_cert
     destination = "$HOME/etcd-client.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_key}"
+    content     = module.bootkube.etcd_client_key
     destination = "$HOME/etcd-client.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_cert}"
+    content     = module.bootkube.etcd_server_cert
     destination = "$HOME/etcd-server.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_key}"
+    content     = module.bootkube.etcd_server_key
     destination = "$HOME/etcd-server.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_cert}"
+    content     = module.bootkube.etcd_peer_cert
     destination = "$HOME/etcd-peer.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_key}"
+    content     = module.bootkube.etcd_peer_key
     destination = "$HOME/etcd-peer.key"
   }
 
@@ -68,21 +66,21 @@ resource "null_resource" "copy-controller-secrets" {
 # one-time self-hosted cluster bootstrapping.
 resource "null_resource" "bootkube-start" {
   depends_on = [
-    "module.bootkube",
-    "module.workers",
-    "azurerm_dns_a_record.apiserver",
-    "null_resource.copy-controller-secrets",
+    module.bootkube,
+    module.workers,
+    azurerm_dns_a_record.apiserver,
+    null_resource.copy-controller-secrets,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${element(azurerm_public_ip.controllers.*.ip_address, 0)}"
+    host    = element(azurerm_public_ip.controllers.*.ip_address, 0)
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    source      = "${var.asset_dir}"
+    source      = var.asset_dir
     destination = "$HOME/assets"
   }
 
@@ -93,3 +91,4 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
+

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -33,14 +33,14 @@ variable "custom_image_name" {
 # instances
 
 variable "controller_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of workers"
 }
 
@@ -63,8 +63,8 @@ variable "os_image" {
 }
 
 variable "disk_size" {
-  type        = string
-  default     = "40"
+  type        = number
+  default     = 40
   description = "Size of the disk in GB"
 }
 
@@ -134,21 +134,21 @@ variable "cluster_domain_suffix" {
 }
 
 variable "enable_reporting" {
-  type        = string
+  type        = bool
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = "false"
+  default     = false
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 # Certificates
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = string
+  type        = number
   default     = 8760
 }

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -152,4 +152,3 @@ variable "certs_validity_period_hours" {
   type        = string
   default     = 8760
 }
-

--- a/azure/flatcar-linux/kubernetes/variables.tf
+++ b/azure/flatcar-linux/kubernetes/variables.tf
@@ -1,87 +1,87 @@
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
 # Azure
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "Azure Region (e.g. centralus , see `az account list-locations --output table`)"
 }
 
 variable "dns_zone" {
-  type        = "string"
+  type        = string
   description = "Azure DNS Zone (e.g. azure.example.com)"
 }
 
 variable "dns_zone_group" {
-  type        = "string"
+  type        = string
   description = "Resource group where the Azure DNS Zone resides (e.g. global)"
 }
 
 variable "custom_image_resource_group_name" {
-  type        = "string"
+  type        = string
   description = "The name of the Resource Group in which the Custom Image exists."
 }
 
 variable "custom_image_name" {
-  type        = "string"
+  type        = string
   description = "The name of the Custom Image to provision this Virtual Machine from."
 }
 
 # instances
 
 variable "controller_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of workers"
 }
 
 variable "controller_type" {
-  type        = "string"
+  type        = string
   default     = "Standard_B2s"
   description = "Machine type for controllers (see `az vm list-skus --location centralus`)"
 }
 
 variable "worker_type" {
-  type        = "string"
+  type        = string
   default     = "Standard_B2s"
   description = "Machine type for workers (see `az vm list-skus --location centralus`)"
 }
 
 variable "os_image" {
-  type        = "string"
+  type        = string
   default     = "coreos-stable"
   description = "Channel for a CoreOS Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha)"
 }
 
 variable "disk_size" {
-  type        = "string"
+  type        = string
   default     = "40"
   description = "Size of the disk in GB"
 }
 
 variable "worker_priority" {
-  type        = "string"
+  type        = string
   default     = "Regular"
   description = "Set worker priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time."
 }
 
 variable "controller_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
 
 variable "worker_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Worker Container Linux Config snippets"
   default     = []
 }
@@ -89,30 +89,30 @@ variable "worker_clc_snippets" {
 # configuration
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "networking" {
   description = "Choice of networking provider (flannel or calico)"
-  type        = "string"
+  type        = string
   default     = "flannel"
 }
 
 variable "host_cidr" {
   description = "CIDR IPv4 range to assign to instances"
-  type        = "string"
+  type        = string
   default     = "10.0.0.0/16"
 }
 
 variable "pod_cidr" {
   description = "CIDR IPv4 range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.2.0.0/16"
 }
 
@@ -122,25 +122,26 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type        = string
   description = "Enable usage or analytics reporting to upstreams (Calico)"
   default     = "false"
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
@@ -148,6 +149,7 @@ variable "enable_aggregation" {
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = "string"
+  type        = string
   default     = 8760
 }
+

--- a/azure/flatcar-linux/kubernetes/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers.tf
@@ -24,4 +24,3 @@ module "workers" {
   cluster_domain_suffix = var.cluster_domain_suffix
   clc_snippets          = var.worker_clc_snippets
 }
-

--- a/azure/flatcar-linux/kubernetes/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers.tf
@@ -1,26 +1,27 @@
 module "workers" {
   source = "./workers"
-  name   = "${var.cluster_name}"
+  name   = var.cluster_name
 
   # Azure
-  resource_group_name     = "${azurerm_resource_group.cluster.name}"
-  region                  = "${azurerm_resource_group.cluster.location}"
-  subnet_id               = "${azurerm_subnet.worker.id}"
-  security_group_id       = "${azurerm_network_security_group.worker.id}"
-  backend_address_pool_id = "${azurerm_lb_backend_address_pool.worker.id}"
+  resource_group_name     = azurerm_resource_group.cluster.name
+  region                  = azurerm_resource_group.cluster.location
+  subnet_id               = azurerm_subnet.worker.id
+  security_group_id       = azurerm_network_security_group.worker.id
+  backend_address_pool_id = azurerm_lb_backend_address_pool.worker.id
 
-  worker_count = "${var.worker_count}"
-  vm_type      = "${var.worker_type}"
-  os_image     = "${var.os_image}"
-  priority     = "${var.worker_priority}"
+  worker_count = var.worker_count
+  vm_type      = var.worker_type
+  os_image     = var.os_image
+  priority     = var.worker_priority
 
-  custom_image_resource_group_name = "${var.custom_image_resource_group_name}"
-  custom_image_name = "${var.custom_image_name}"
+  custom_image_resource_group_name = var.custom_image_resource_group_name
+  custom_image_name                = var.custom_image_name
 
   # configuration
-  kubeconfig            = "${module.bootkube.kubeconfig-kubelet}"
-  ssh_keys              = "${var.ssh_keys}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  clc_snippets          = "${var.worker_clc_snippets}"
+  kubeconfig            = module.bootkube.kubeconfig-kubelet
+  ssh_keys              = var.ssh_keys
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  clc_snippets          = var.worker_clc_snippets
 }
+

--- a/azure/flatcar-linux/kubernetes/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers.tf
@@ -9,10 +9,10 @@ module "workers" {
   security_group_id       = "${azurerm_network_security_group.worker.id}"
   backend_address_pool_id = "${azurerm_lb_backend_address_pool.worker.id}"
 
-  count    = "${var.worker_count}"
-  vm_type  = "${var.worker_type}"
-  os_image = "${var.os_image}"
-  priority = "${var.worker_priority}"
+  worker_count = "${var.worker_count}"
+  vm_type      = "${var.worker_type}"
+  os_image     = "${var.os_image}"
+  priority     = "${var.worker_priority}"
 
   custom_image_resource_group_name = "${var.custom_image_resource_group_name}"
   custom_image_name = "${var.custom_image_name}"

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -100,4 +100,3 @@ variable "cluster_domain_suffix" {
   type        = string
   default     = "cluster.local"
 }
-

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -43,8 +43,8 @@ variable "custom_image_name" {
 # instances
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of instances"
 }
 

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -42,7 +42,7 @@ variable "custom_image_name" {
 
 # instances
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of instances"

--- a/azure/flatcar-linux/kubernetes/workers/variables.tf
+++ b/azure/flatcar-linux/kubernetes/workers/variables.tf
@@ -1,73 +1,73 @@
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Unique name for the worker pool"
 }
 
 # Azure
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "Must be set to the Azure Region of cluster"
 }
 
 variable "resource_group_name" {
-  type        = "string"
+  type        = string
   description = "Must be set to the resource group name of cluster"
 }
 
 variable "subnet_id" {
-  type        = "string"
+  type        = string
   description = "Must be set to the `worker_subnet_id` output by cluster"
 }
 
 variable "security_group_id" {
-  type        = "string"
+  type        = string
   description = "Must be set to the `worker_security_group_id` output by cluster"
 }
 
 variable "backend_address_pool_id" {
-  type        = "string"
+  type        = string
   description = "Must be set to the `worker_backend_address_pool_id` output by cluster"
 }
 
 variable "custom_image_resource_group_name" {
-  type        = "string"
+  type        = string
   description = "The name of the Resource Group in which the Custom Image exists."
 }
 
 variable "custom_image_name" {
-  type        = "string"
+  type        = string
   description = "The name of the Custom Image to provision this Virtual Machine from."
 }
 
 # instances
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of instances"
 }
 
 variable "vm_type" {
-  type        = "string"
+  type        = string
   default     = "Standard_DS1_v2"
   description = "Machine type for instances (see `az vm list-skus --location centralus`)"
 }
 
 variable "os_image" {
-  type        = "string"
+  type        = string
   default     = "coreos-stable"
   description = "Channel for a CoreOS Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha)"
 }
 
 variable "priority" {
-  type        = "string"
+  type        = string
   default     = "Regular"
   description = "Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be evicted at any time."
 }
 
 variable "clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Container Linux Config snippets"
   default     = []
 }
@@ -75,12 +75,12 @@ variable "clc_snippets" {
 # configuration
 
 variable "kubeconfig" {
-  type        = "string"
+  type        = string
   description = "Must be set to `kubeconfig` output by cluster"
 }
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
@@ -90,12 +90,14 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
+

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -117,4 +117,3 @@ data "template_file" "worker-config" {
     cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
-

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,7 +1,7 @@
 locals {
   # Channel for a CoreOS Container Linux derivative
   # coreos-stable -> CoreOS Container Linux Stable
-  channel = element(split("-", var.os_image), 1)
+  channel = split("-", var.os_image)[1]
 }
 
 data "azurerm_image" "custom_workers" {
@@ -49,7 +49,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
 
     ssh_keys {
       path     = "/home/core/.ssh/authorized_keys"
-      key_data = element(var.ssh_keys, 0)
+      key_data = var.ssh_keys[0]
     }
   }
 

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,31 +1,31 @@
 locals {
   # Channel for a CoreOS Container Linux derivative
   # coreos-stable -> CoreOS Container Linux Stable
-  channel = "${element(split("-", var.os_image), 1)}"
+  channel = element(split("-", var.os_image), 1)
 }
 
 data "azurerm_image" "custom_workers" {
-  name                = "${var.custom_image_name}"
-  resource_group_name = "${var.custom_image_resource_group_name}"
+  name                = var.custom_image_name
+  resource_group_name = var.custom_image_resource_group_name
 }
 
 # Workers scale set
 resource "azurerm_virtual_machine_scale_set" "workers" {
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = var.resource_group_name
 
   name                   = "${var.name}-workers"
-  location               = "${var.region}"
+  location               = var.region
   single_placement_group = false
 
   sku {
-    name     = "${var.vm_type}"
+    name     = var.vm_type
     tier     = "standard"
-    capacity = "${var.worker_count}"
+    capacity = var.worker_count
   }
 
   # boot
   storage_profile_image_reference {
-    id = "${data.azurerm_image.custom_workers.id}"
+    id = data.azurerm_image.custom_workers.id
   }
 
   # storage
@@ -39,7 +39,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
   os_profile {
     computer_name_prefix = "${var.name}-worker-"
     admin_username       = "core"
-    custom_data          = "${data.ct_config.worker-ignition.rendered}"
+    custom_data          = data.ct_config.worker-ignition.rendered
   }
 
   # Azure mandates setting an ssh_key, provide just a single key as the
@@ -49,7 +49,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
 
     ssh_keys {
       path     = "/home/core/.ssh/authorized_keys"
-      key_data = "${element(var.ssh_keys, 0)}"
+      key_data = element(var.ssh_keys, 0)
     }
   }
 
@@ -57,15 +57,15 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
   network_profile {
     name                      = "nic0"
     primary                   = true
-    network_security_group_id = "${var.security_group_id}"
+    network_security_group_id = var.security_group_id
 
     ip_configuration {
       name      = "ip0"
       primary   = true
-      subnet_id = "${var.subnet_id}"
+      subnet_id = var.subnet_id
 
       # backend address pool to which the NIC should be added
-      load_balancer_backend_address_pool_ids = ["${var.backend_address_pool_id}"]
+      load_balancer_backend_address_pool_ids = [var.backend_address_pool_id]
     }
   }
 
@@ -73,47 +73,48 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
   upgrade_policy_mode = "Manual"
 
   # eviction policy may only be set when priority is Low
-  priority        = "${var.priority}"
-  eviction_policy = "${var.priority == "Low" ? "Delete" : null}"
+  priority        = var.priority
+  eviction_policy = var.priority == "Low" ? "Delete" : null
 }
 
 # Scale up or down to maintain desired number, tolerating deallocations.
 resource "azurerm_monitor_autoscale_setting" "workers" {
-  resource_group_name = "${var.resource_group_name}"
+  resource_group_name = var.resource_group_name
 
   name     = "${var.name}-maintain-desired"
-  location = "${var.region}"
+  location = var.region
 
   # autoscale
   enabled            = true
-  target_resource_id = "${azurerm_virtual_machine_scale_set.workers.id}"
+  target_resource_id = azurerm_virtual_machine_scale_set.workers.id
 
   profile {
     name = "default"
 
     capacity {
-      minimum = "${var.worker_count}"
-      default = "${var.worker_count}"
-      maximum = "${var.worker_count}"
+      minimum = var.worker_count
+      default = var.worker_count
+      maximum = var.worker_count
     }
   }
 }
 
 # Worker Ignition configs
 data "ct_config" "worker-ignition" {
-  content      = "${data.template_file.worker-config.rendered}"
+  content      = data.template_file.worker-config.rendered
   pretty_print = false
-  snippets     = ["${var.clc_snippets}"]
+  snippets     = var.clc_snippets
 }
 
 # Worker Container Linux configs
 data "template_file" "worker-config" {
-  template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
+  template = file("${path.module}/cl/worker.yaml.tmpl")
 
   vars = {
-    kubeconfig             = "${indent(10, var.kubeconfig)}"
-    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    kubeconfig             = indent(10, var.kubeconfig)
+    ssh_keys               = jsonencode(var.ssh_keys)
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
+

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -74,11 +74,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
 
   # eviction policy may only be set when priority is Low
   priority        = "${var.priority}"
-  # It is not possible to assign an optional argument in terraform 0.11,
-  # (https://github.com/hashicorp/terraform/issues/17968)
-  # however azurerm provider v1.35 ignores the value if the priority
-  # is not low. https://github.com/terraform-providers/terraform-provider-azurerm/blob/3b0ba54174ed56d2082228349b1bc19c38b75eca/azurerm/resource_arm_virtual_machine_scale_set.go#L866
-  eviction_policy = "${var.priority == "Low" ? "Delete" : "Deallocate" }"
+  eviction_policy = "${var.priority == "Low" ? "Delete" : null}"
 }
 
 # Scale up or down to maintain desired number, tolerating deallocations.

--- a/azure/flatcar-linux/kubernetes/workers/workers.tf
+++ b/azure/flatcar-linux/kubernetes/workers/workers.tf
@@ -20,7 +20,7 @@ resource "azurerm_virtual_machine_scale_set" "workers" {
   sku {
     name     = "${var.vm_type}"
     tier     = "standard"
-    capacity = "${var.count}"
+    capacity = "${var.worker_count}"
   }
 
   # boot
@@ -96,9 +96,9 @@ resource "azurerm_monitor_autoscale_setting" "workers" {
     name = "default"
 
     capacity {
-      minimum = "${var.count}"
-      default = "${var.count}"
-      maximum = "${var.count}"
+      minimum = "${var.worker_count}"
+      default = "${var.worker_count}"
+      maximum = "${var.worker_count}"
     }
   }
 }

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -17,4 +17,3 @@ module "bootkube" {
 
   certs_validity_period_hours = var.certs_validity_period_hours
 }
-

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -4,7 +4,7 @@ module "bootkube" {
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]
-  etcd_servers                    = [var.controller_domains]
+  etcd_servers                    = var.controller_domains
   asset_dir                       = var.asset_dir
   networking                      = var.networking
   network_mtu                     = var.network_mtu

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -2,18 +2,19 @@
 module "bootkube" {
   source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
 
-  cluster_name                    = "${var.cluster_name}"
-  api_servers                     = ["${var.k8s_domain_name}"]
-  etcd_servers                    = ["${var.controller_domains}"]
-  asset_dir                       = "${var.asset_dir}"
-  networking                      = "${var.networking}"
-  network_mtu                     = "${var.network_mtu}"
-  network_ip_autodetection_method = "${var.network_ip_autodetection_method}"
-  pod_cidr                        = "${var.pod_cidr}"
-  service_cidr                    = "${var.service_cidr}"
-  cluster_domain_suffix           = "${var.cluster_domain_suffix}"
-  enable_reporting                = "${var.enable_reporting}"
-  enable_aggregation              = "${var.enable_aggregation}"
+  cluster_name                    = var.cluster_name
+  api_servers                     = [var.k8s_domain_name]
+  etcd_servers                    = [var.controller_domains]
+  asset_dir                       = var.asset_dir
+  networking                      = var.networking
+  network_mtu                     = var.network_mtu
+  network_ip_autodetection_method = var.network_ip_autodetection_method
+  pod_cidr                        = var.pod_cidr
+  service_cidr                    = var.service_cidr
+  cluster_domain_suffix           = var.cluster_domain_suffix
+  enable_reporting                = var.enable_reporting
+  enable_aggregation              = var.enable_aggregation
 
-  certs_validity_period_hours = "${var.certs_validity_period_hours}"
+  certs_validity_period_hours = var.certs_validity_period_hours
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/bootkube.tf
+++ b/bare-metal/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=0f3156c73b846bf1bc5dd4681879048c37fb2f25"
 
   cluster_name                    = var.cluster_name
   api_servers                     = [var.k8s_domain_name]

--- a/bare-metal/flatcar-linux/kubernetes/groups.tf
+++ b/bare-metal/flatcar-linux/kubernetes/groups.tf
@@ -1,33 +1,51 @@
 resource "matchbox_group" "install" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
+  count = length(var.controller_names) + length(var.worker_names)
 
-  name = "${format("install-%s", element(concat(var.controller_names, var.worker_names), count.index))}"
+  name = format(
+    "install-%s",
+    element(concat(var.controller_names, var.worker_names), count.index),
+  )
 
-  profile = "${local.flavor == "flatcar" ? var.cached_install == "true" ? element(matchbox_profile.cached-flatcar-linux-install.*.name, count.index) : element(matchbox_profile.flatcar-install.*.name, count.index) : var.cached_install == "true" ? element(matchbox_profile.cached-container-linux-install.*.name, count.index) : element(matchbox_profile.container-linux-install.*.name, count.index)}"
+  profile = local.flavor == "flatcar" ? var.cached_install == "true" ? element(
+    matchbox_profile.cached-flatcar-linux-install.*.name,
+    count.index,
+    ) : element(matchbox_profile.flatcar-install.*.name, count.index) : var.cached_install == "true" ? element(
+    matchbox_profile.cached-container-linux-install.*.name,
+    count.index,
+  ) : element(matchbox_profile.container-linux-install.*.name, count.index)
 
   selector = {
-    mac = "${element(concat(var.controller_macs, var.worker_macs), count.index)}"
+    mac = element(concat(var.controller_macs, var.worker_macs), count.index)
   }
 }
 
 resource "matchbox_group" "controller" {
-  count   = "${length(var.controller_names)}"
-  name    = "${format("%s-%s", var.cluster_name, element(var.controller_names, count.index))}"
-  profile = "${element(matchbox_profile.controllers.*.name, count.index)}"
+  count = length(var.controller_names)
+  name = format(
+    "%s-%s",
+    var.cluster_name,
+    element(var.controller_names, count.index),
+  )
+  profile = element(matchbox_profile.controllers.*.name, count.index)
 
   selector = {
-    mac = "${element(var.controller_macs, count.index)}"
+    mac = element(var.controller_macs, count.index)
     os  = "installed"
   }
 }
 
 resource "matchbox_group" "worker" {
-  count   = "${length(var.worker_names)}"
-  name    = "${format("%s-%s", var.cluster_name, element(var.worker_names, count.index))}"
-  profile = "${element(matchbox_profile.workers.*.name, count.index)}"
+  count = length(var.worker_names)
+  name = format(
+    "%s-%s",
+    var.cluster_name,
+    element(var.worker_names, count.index),
+  )
+  profile = element(matchbox_profile.workers.*.name, count.index)
 
   selector = {
-    mac = "${element(var.worker_macs, count.index)}"
+    mac = element(var.worker_macs, count.index)
     os  = "installed"
   }
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/groups.tf
+++ b/bare-metal/flatcar-linux/kubernetes/groups.tf
@@ -3,19 +3,13 @@ resource "matchbox_group" "install" {
 
   name = format(
     "install-%s",
-    element(concat(var.controller_names, var.worker_names), count.index),
+    concat(var.controller_names, var.worker_names)[count.index]
   )
 
-  profile = local.flavor == "flatcar" ? var.cached_install == "true" ? element(
-    matchbox_profile.cached-flatcar-linux-install.*.name,
-    count.index,
-    ) : element(matchbox_profile.flatcar-install.*.name, count.index) : var.cached_install == "true" ? element(
-    matchbox_profile.cached-container-linux-install.*.name,
-    count.index,
-  ) : element(matchbox_profile.container-linux-install.*.name, count.index)
+  profile = local.flavor == "flatcar" ? var.cached_install == "true" ? matchbox_profile.cached-flatcar-linux-install[count.index].name : matchbox_profile.flatcar-install[count.index].name : var.cached_install == "true" ? matchbox_profile.cached-container-linux-install[count.index].name : matchbox_profile.container-linux-install[count.index].name
 
   selector = {
-    mac = element(concat(var.controller_macs, var.worker_macs), count.index)
+    mac = concat(var.controller_macs, var.worker_macs)[count.index]
   }
 }
 
@@ -24,12 +18,12 @@ resource "matchbox_group" "controller" {
   name = format(
     "%s-%s",
     var.cluster_name,
-    element(var.controller_names, count.index),
+    var.controller_names[count.index]
   )
-  profile = element(matchbox_profile.controllers.*.name, count.index)
+  profile = matchbox_profile.controllers[count.index].name
 
   selector = {
-    mac = element(var.controller_macs, count.index)
+    mac = var.controller_macs[count.index]
     os  = "installed"
   }
 }
@@ -39,12 +33,12 @@ resource "matchbox_group" "worker" {
   name = format(
     "%s-%s",
     var.cluster_name,
-    element(var.worker_names, count.index),
+    var.worker_names[count.index]
   )
-  profile = element(matchbox_profile.workers.*.name, count.index)
+  profile = matchbox_profile.workers[count.index].name
 
   selector = {
-    mac = element(var.worker_macs, count.index)
+    mac = var.worker_macs[count.index]
     os  = "installed"
   }
 }

--- a/bare-metal/flatcar-linux/kubernetes/groups.tf
+++ b/bare-metal/flatcar-linux/kubernetes/groups.tf
@@ -6,7 +6,7 @@ resource "matchbox_group" "install" {
     concat(var.controller_names, var.worker_names)[count.index]
   )
 
-  profile = local.flavor == "flatcar" ? var.cached_install == "true" ? matchbox_profile.cached-flatcar-linux-install[count.index].name : matchbox_profile.flatcar-install[count.index].name : var.cached_install == "true" ? matchbox_profile.cached-container-linux-install[count.index].name : matchbox_profile.container-linux-install[count.index].name
+  profile = local.flavor == "flatcar" ? var.cached_install == true ? matchbox_profile.cached-flatcar-linux-install[count.index].name : matchbox_profile.flatcar-install[count.index].name : var.cached_install == true ? matchbox_profile.cached-container-linux-install[count.index].name : matchbox_profile.container-linux-install[count.index].name
 
   selector = {
     mac = concat(var.controller_macs, var.worker_macs)[count.index]

--- a/bare-metal/flatcar-linux/kubernetes/groups.tf
+++ b/bare-metal/flatcar-linux/kubernetes/groups.tf
@@ -48,4 +48,3 @@ resource "matchbox_group" "worker" {
     os  = "installed"
   }
 }
-

--- a/bare-metal/flatcar-linux/kubernetes/outputs.tf
+++ b/bare-metal/flatcar-linux/kubernetes/outputs.tf
@@ -1,3 +1,4 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin}"
+  value = module.bootkube.kubeconfig-admin
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/outputs.tf
+++ b/bare-metal/flatcar-linux/kubernetes/outputs.tf
@@ -1,4 +1,3 @@
 output "kubeconfig-admin" {
   value = module.bootkube.kubeconfig-admin
 }
-

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -276,4 +276,3 @@ data "template_file" "clc-default-snippets" {
   count    = length(var.controller_names) + length(var.worker_names)
   template = "\n"
 }
-

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -1,15 +1,19 @@
 locals {
   # coreos-stable -> coreos flavor, stable channel
   # flatcar-stable -> flatcar flavor, stable channel
-  flavor = "${element(split("-", var.os_channel), 0)}"
+  flavor = element(split("-", var.os_channel), 0)
 
-  channel = "${element(split("-", var.os_channel), 1)}"
+  channel = element(split("-", var.os_channel), 1)
 }
 
 // CoreOS Container Linux Install profile (from release.core-os.net)
 resource "matchbox_profile" "container-linux-install" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
-  name  = "${format("%s-container-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))}"
+  count = length(var.controller_names) + length(var.worker_names)
+  name = format(
+    "%s-container-linux-install-%s",
+    var.cluster_name,
+    element(concat(var.controller_names, var.worker_names), count.index),
+  )
 
   kernel = "${var.download_protocol}://${local.channel}.release.core-os.net/amd64-usr/${var.os_version}/coreos_production_pxe.vmlinuz"
 
@@ -23,26 +27,28 @@ resource "matchbox_profile" "container-linux-install" {
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
-    "${var.kernel_args}",
+    var.kernel_args,
   ]
 
-  container_linux_config = "${element(data.template_file.container-linux-install-configs.*.rendered, count.index)}"
+  container_linux_config = element(
+    data.template_file.container-linux-install-configs.*.rendered,
+    count.index,
+  )
 }
 
 data "template_file" "container-linux-install-configs" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
+  count = length(var.controller_names) + length(var.worker_names)
 
-  template = "${file("${path.module}/cl/install.yaml.tmpl")}"
+  template = file("${path.module}/cl/install.yaml.tmpl")
 
   vars = {
-    os_flavor           = "${local.flavor}"
-    os_channel          = "${local.channel}"
-    os_version          = "${var.os_version}"
-    ignition_endpoint   = "${format("%s/ignition", var.matchbox_http_endpoint)}"
-    install_disk        = "${var.install_disk}"
-    container_linux_oem = "${var.container_linux_oem}"
-    ssh_keys            = "${jsonencode("${var.ssh_keys}")}"
-
+    os_flavor           = local.flavor
+    os_channel          = local.channel
+    os_version          = var.os_version
+    ignition_endpoint   = format("%s/ignition", var.matchbox_http_endpoint)
+    install_disk        = var.install_disk
+    container_linux_oem = var.container_linux_oem
+    ssh_keys            = jsonencode(var.ssh_keys)
     # only cached-container-linux profile adds -b baseurl
     baseurl_flag = ""
   }
@@ -51,8 +57,12 @@ data "template_file" "container-linux-install-configs" {
 // CoreOS Container Linux Install profile (from matchbox /assets cache)
 // Note: Admin must have downloaded os_version into matchbox assets/coreos.
 resource "matchbox_profile" "cached-container-linux-install" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
-  name  = "${format("%s-cached-container-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))}"
+  count = length(var.controller_names) + length(var.worker_names)
+  name = format(
+    "%s-cached-container-linux-install-%s",
+    var.cluster_name,
+    element(concat(var.controller_names, var.worker_names), count.index),
+  )
 
   kernel = "/assets/coreos/${var.os_version}/coreos_production_pxe.vmlinuz"
 
@@ -66,26 +76,28 @@ resource "matchbox_profile" "cached-container-linux-install" {
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
-    "${var.kernel_args}",
+    var.kernel_args,
   ]
 
-  container_linux_config = "${element(data.template_file.cached-container-linux-install-configs.*.rendered, count.index)}"
+  container_linux_config = element(
+    data.template_file.cached-container-linux-install-configs.*.rendered,
+    count.index,
+  )
 }
 
 data "template_file" "cached-container-linux-install-configs" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
+  count = length(var.controller_names) + length(var.worker_names)
 
-  template = "${file("${path.module}/cl/install.yaml.tmpl")}"
+  template = file("${path.module}/cl/install.yaml.tmpl")
 
   vars = {
-    os_flavor           = "${local.flavor}"
-    os_channel          = "${local.channel}"
-    os_version          = "${var.os_version}"
-    ignition_endpoint   = "${format("%s/ignition", var.matchbox_http_endpoint)}"
-    install_disk        = "${var.install_disk}"
-    container_linux_oem = "${var.container_linux_oem}"
-    ssh_keys            = "${jsonencode("${var.ssh_keys}")}"
-
+    os_flavor           = local.flavor
+    os_channel          = local.channel
+    os_version          = var.os_version
+    ignition_endpoint   = format("%s/ignition", var.matchbox_http_endpoint)
+    install_disk        = var.install_disk
+    container_linux_oem = var.container_linux_oem
+    ssh_keys            = jsonencode(var.ssh_keys)
     # profile uses -b baseurl to install from matchbox cache
     baseurl_flag = "-b ${var.matchbox_http_endpoint}/assets/${local.flavor}"
   }
@@ -93,8 +105,12 @@ data "template_file" "cached-container-linux-install-configs" {
 
 // Flatcar Container Linux install profile (from release.flatcar-linux.net)
 resource "matchbox_profile" "flatcar-install" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
-  name  = "${format("%s-flatcar-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))}"
+  count = length(var.controller_names) + length(var.worker_names)
+  name = format(
+    "%s-flatcar-install-%s",
+    var.cluster_name,
+    element(concat(var.controller_names, var.worker_names), count.index),
+  )
 
   kernel = "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe.vmlinuz"
 
@@ -108,17 +124,24 @@ resource "matchbox_profile" "flatcar-install" {
     "flatcar.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
-    "${var.kernel_args}",
+    var.kernel_args,
   ]
 
-  container_linux_config = "${element(data.template_file.container-linux-install-configs.*.rendered, count.index)}"
+  container_linux_config = element(
+    data.template_file.container-linux-install-configs.*.rendered,
+    count.index,
+  )
 }
 
 // Flatcar Container Linux Install profile (from matchbox /assets cache)
 // Note: Admin must have downloaded os_version into matchbox assets/flatcar.
 resource "matchbox_profile" "cached-flatcar-linux-install" {
-  count = "${length(var.controller_names) + length(var.worker_names)}"
-  name  = "${format("%s-cached-flatcar-linux-install-%s", var.cluster_name, element(concat(var.controller_names, var.worker_names), count.index))}"
+  count = length(var.controller_names) + length(var.worker_names)
+  name = format(
+    "%s-cached-flatcar-linux-install-%s",
+    var.cluster_name,
+    element(concat(var.controller_names, var.worker_names), count.index),
+  )
 
   kernel = "/assets/flatcar/${var.os_version}/flatcar_production_pxe.vmlinuz"
 
@@ -132,69 +155,106 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     "flatcar.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
-    "${var.kernel_args}",
+    var.kernel_args,
   ]
 
-  container_linux_config = "${element(data.template_file.cached-container-linux-install-configs.*.rendered, count.index)}"
+  container_linux_config = element(
+    data.template_file.cached-container-linux-install-configs.*.rendered,
+    count.index,
+  )
 }
 
 // Kubernetes Controller profiles
 resource "matchbox_profile" "controllers" {
-  count        = "${length(var.controller_names)}"
-  name         = "${format("%s-controller-%s", var.cluster_name, element(var.controller_names, count.index))}"
-  raw_ignition = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+  count = length(var.controller_names)
+  name = format(
+    "%s-controller-%s",
+    var.cluster_name,
+    element(var.controller_names, count.index),
+  )
+  raw_ignition = element(data.ct_config.controller-ignitions.*.rendered, count.index)
 }
 
 data "ct_config" "controller-ignitions" {
-  count        = "${length(var.controller_names)}"
-  content      = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  count = length(var.controller_names)
+  content = element(
+    data.template_file.controller-configs.*.rendered,
+    count.index,
+  )
   pretty_print = false
 
   # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps
-  snippets = ["${local.clc_map[element(var.controller_names, count.index)]}"]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  snippets = [local.clc_map[element(var.controller_names, count.index)]]
 }
 
 data "template_file" "controller-configs" {
-  count = "${length(var.controller_names)}"
+  count = length(var.controller_names)
 
-  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+  template = file("${path.module}/cl/controller.yaml.tmpl")
 
   vars = {
-    domain_name            = "${element(var.controller_domains, count.index)}"
-    etcd_name              = "${element(var.controller_names, count.index)}"
-    etcd_initial_cluster   = "${join(",", formatlist("%s=https://%s:2380", var.controller_names, var.controller_domains))}"
-    cluster_dns_service_ip = "${module.bootkube.cluster_dns_service_ip}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
-    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
+    domain_name = element(var.controller_domains, count.index)
+    etcd_name   = element(var.controller_names, count.index)
+    etcd_initial_cluster = join(
+      ",",
+      formatlist(
+        "%s=https://%s:2380",
+        var.controller_names,
+        var.controller_domains,
+      ),
+    )
+    cluster_dns_service_ip = module.bootkube.cluster_dns_service_ip
+    cluster_domain_suffix  = var.cluster_domain_suffix
+    ssh_keys               = jsonencode(var.ssh_keys)
   }
 }
 
 // Kubernetes Worker profiles
 resource "matchbox_profile" "workers" {
-  count        = "${length(var.worker_names)}"
-  name         = "${format("%s-worker-%s", var.cluster_name, element(var.worker_names, count.index))}"
-  raw_ignition = "${element(data.ct_config.worker-ignitions.*.rendered, count.index)}"
+  count = length(var.worker_names)
+  name = format(
+    "%s-worker-%s",
+    var.cluster_name,
+    element(var.worker_names, count.index),
+  )
+  raw_ignition = element(data.ct_config.worker-ignitions.*.rendered, count.index)
 }
 
 data "ct_config" "worker-ignitions" {
-  count        = "${length(var.worker_names)}"
-  content      = "${element(data.template_file.worker-configs.*.rendered, count.index)}"
+  count        = length(var.worker_names)
+  content      = element(data.template_file.worker-configs.*.rendered, count.index)
   pretty_print = false
 
   # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps
-  snippets = ["${local.clc_map[element(var.worker_names, count.index)]}"]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  snippets = [local.clc_map[element(var.worker_names, count.index)]]
 }
 
 data "template_file" "worker-configs" {
-  count = "${length(var.worker_names)}"
+  count = length(var.worker_names)
 
-  template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
+  template = file("${path.module}/cl/worker.yaml.tmpl")
 
   vars = {
-    domain_name            = "${element(var.worker_domains, count.index)}"
-    cluster_dns_service_ip = "${module.bootkube.cluster_dns_service_ip}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
-    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
+    domain_name            = element(var.worker_domains, count.index)
+    cluster_dns_service_ip = module.bootkube.cluster_dns_service_ip
+    cluster_domain_suffix  = var.cluster_domain_suffix
+    ssh_keys               = jsonencode(var.ssh_keys)
   }
 }
 
@@ -202,14 +262,18 @@ locals {
   # Hack to workaround https://github.com/hashicorp/terraform/issues/17251
   # Default CoreOS Container Linux config snippets map every node names to list("\n") so
   # all lookups succeed
-  clc_defaults = "${zipmap(concat(var.controller_names, var.worker_names), chunklist(data.template_file.clc-default-snippets.*.rendered, 1))}"
+  clc_defaults = zipmap(
+    concat(var.controller_names, var.worker_names),
+    chunklist(data.template_file.clc-default-snippets.*.rendered, 1),
+  )
 
   # Union of the default and user specific snippets, later overrides prior.
-  clc_map = "${merge(local.clc_defaults, var.clc_snippets)}"
+  clc_map = merge(local.clc_defaults, var.clc_snippets)
 }
 
 // Horrible hack to generate a Terraform list of node count length
 data "template_file" "clc-default-snippets" {
-  count    = "${length(var.controller_names) + length(var.worker_names)}"
+  count    = length(var.controller_names) + length(var.worker_names)
   template = "\n"
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/profiles.tf
+++ b/bare-metal/flatcar-linux/kubernetes/profiles.tf
@@ -21,14 +21,14 @@ resource "matchbox_profile" "container-linux-install" {
     "${var.download_protocol}://${local.channel}.release.core-os.net/amd64-usr/${var.os_version}/coreos_production_pxe_image.cpio.gz",
   ]
 
-  args = [
+  args = flatten([
     "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
     var.kernel_args,
-  ]
+  ])
 
   container_linux_config = element(
     data.template_file.container-linux-install-configs.*.rendered,
@@ -70,14 +70,14 @@ resource "matchbox_profile" "cached-container-linux-install" {
     "/assets/coreos/${var.os_version}/coreos_production_pxe_image.cpio.gz",
   ]
 
-  args = [
+  args = flatten([
     "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
     var.kernel_args,
-  ]
+  ])
 
   container_linux_config = element(
     data.template_file.cached-container-linux-install-configs.*.rendered,
@@ -118,14 +118,14 @@ resource "matchbox_profile" "flatcar-install" {
     "${var.download_protocol}://${local.channel}.release.flatcar-linux.net/amd64-usr/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
   ]
 
-  args = [
+  args = flatten([
     "initrd=flatcar_production_pxe_image.cpio.gz",
     "ignition.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "flatcar.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
     var.kernel_args,
-  ]
+  ])
 
   container_linux_config = element(
     data.template_file.container-linux-install-configs.*.rendered,
@@ -149,14 +149,14 @@ resource "matchbox_profile" "cached-flatcar-linux-install" {
     "/assets/flatcar/${var.os_version}/flatcar_production_pxe_image.cpio.gz",
   ]
 
-  args = [
+  args = flatten([
     "initrd=flatcar_production_pxe_image.cpio.gz",
     "ignition.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "flatcar.first_boot=yes",
     "console=tty0",
     "console=ttyS0",
     var.kernel_args,
-  ]
+  ])
 
   container_linux_config = element(
     data.template_file.cached-container-linux-install-configs.*.rendered,
@@ -184,15 +184,7 @@ data "ct_config" "controller-ignitions" {
   pretty_print = false
 
   # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
-  snippets = [local.clc_map[element(var.controller_names, count.index)]]
+  snippets = local.clc_map[element(var.controller_names, count.index)]
 }
 
 data "template_file" "controller-configs" {
@@ -234,15 +226,7 @@ data "ct_config" "worker-ignitions" {
   pretty_print = false
 
   # Must use direct lookup. Cannot use lookup(map, key) since it only works for flat maps
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
-  snippets = [local.clc_map[element(var.worker_names, count.index)]]
+  snippets = local.clc_map[element(var.worker_names, count.index)]
 }
 
 data "template_file" "worker-configs" {
@@ -259,6 +243,7 @@ data "template_file" "worker-configs" {
 }
 
 locals {
+  # TODO: Probably it is not needed anymore with terraform 0.12
   # Hack to workaround https://github.com/hashicorp/terraform/issues/17251
   # Default CoreOS Container Linux config snippets map every node names to list("\n") so
   # all lookups succeed

--- a/bare-metal/flatcar-linux/kubernetes/require.tf
+++ b/bare-metal/flatcar-linux/kubernetes/require.tf
@@ -19,4 +19,3 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0"
 }
-

--- a/bare-metal/flatcar-linux/kubernetes/require.tf
+++ b/bare-metal/flatcar-linux/kubernetes/require.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.11.0"
+  required_version = ">= 0.12.0"
 }
 
 provider "local" {

--- a/bare-metal/flatcar-linux/kubernetes/require.tf
+++ b/bare-metal/flatcar-linux/kubernetes/require.tf
@@ -19,3 +19,4 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0"
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -1,59 +1,59 @@
 # Secure copy etcd TLS assets and kubeconfig to controllers. Activates kubelet.service
 resource "null_resource" "copy-controller-secrets" {
-  count = "${length(var.controller_names)}"
+  count = length(var.controller_names)
 
   # Without depends_on, remote-exec could start and wait for machines before
   # matchbox groups are written, causing a deadlock.
   depends_on = [
-    "matchbox_group.install",
-    "matchbox_group.controller",
-    "matchbox_group.worker",
+    matchbox_group.install,
+    matchbox_group.controller,
+    matchbox_group.worker,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${element(var.controller_domains, count.index)}"
+    host    = element(var.controller_domains, count.index)
     user    = "core"
     timeout = "60m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.kubeconfig-kubelet}"
+    content     = module.bootkube.kubeconfig-kubelet
     destination = "$HOME/kubeconfig"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_ca_cert}"
+    content     = module.bootkube.etcd_ca_cert
     destination = "$HOME/etcd-client-ca.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_cert}"
+    content     = module.bootkube.etcd_client_cert
     destination = "$HOME/etcd-client.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_key}"
+    content     = module.bootkube.etcd_client_key
     destination = "$HOME/etcd-client.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_cert}"
+    content     = module.bootkube.etcd_server_cert
     destination = "$HOME/etcd-server.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_key}"
+    content     = module.bootkube.etcd_server_key
     destination = "$HOME/etcd-server.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_cert}"
+    content     = module.bootkube.etcd_peer_cert
     destination = "$HOME/etcd-peer.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_key}"
+    content     = module.bootkube.etcd_peer_key
     destination = "$HOME/etcd-peer.key"
   }
 
@@ -76,25 +76,25 @@ resource "null_resource" "copy-controller-secrets" {
 
 # Secure copy kubeconfig to all workers. Activates kubelet.service
 resource "null_resource" "copy-worker-secrets" {
-  count = "${length(var.worker_names)}"
+  count = length(var.worker_names)
 
   # Without depends_on, remote-exec could start and wait for machines before
   # matchbox groups are written, causing a deadlock.
   depends_on = [
-    "matchbox_group.install",
-    "matchbox_group.controller",
-    "matchbox_group.worker",
+    matchbox_group.install,
+    matchbox_group.controller,
+    matchbox_group.worker,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${element(var.worker_domains, count.index)}"
+    host    = element(var.worker_domains, count.index)
     user    = "core"
     timeout = "60m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.kubeconfig-kubelet}"
+    content     = module.bootkube.kubeconfig-kubelet
     destination = "$HOME/kubeconfig"
   }
 
@@ -112,19 +112,19 @@ resource "null_resource" "bootkube-start" {
   # Terraform only does one task at a time, so it would try to bootstrap
   # while no Kubelets are running.
   depends_on = [
-    "null_resource.copy-controller-secrets",
-    "null_resource.copy-worker-secrets",
+    null_resource.copy-controller-secrets,
+    null_resource.copy-worker-secrets,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${element(var.controller_domains, 0)}"
+    host    = element(var.controller_domains, 0)
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    source      = "${var.asset_dir}"
+    source      = var.asset_dir
     destination = "$HOME/assets"
   }
 
@@ -135,3 +135,4 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -135,4 +135,3 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
-

--- a/bare-metal/flatcar-linux/kubernetes/ssh.tf
+++ b/bare-metal/flatcar-linux/kubernetes/ssh.tf
@@ -12,7 +12,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(var.controller_domains, count.index)
+    host    = var.controller_domains[count.index]
     user    = "core"
     timeout = "60m"
   }
@@ -88,7 +88,7 @@ resource "null_resource" "copy-worker-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(var.worker_domains, count.index)
+    host    = var.worker_domains[count.index]
     user    = "core"
     timeout = "60m"
   }
@@ -118,7 +118,7 @@ resource "null_resource" "bootkube-start" {
 
   connection {
     type    = "ssh"
-    host    = element(var.controller_domains, 0)
+    host    = var.controller_domains[0]
     user    = "core"
     timeout = "15m"
   }

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -1,22 +1,22 @@
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name"
 }
 
 # bare-metal
 
 variable "matchbox_http_endpoint" {
-  type        = "string"
+  type        = string
   description = "Matchbox HTTP read-only endpoint (e.g. http://matchbox.example.com:8080)"
 }
 
 variable "os_channel" {
-  type        = "string"
+  type        = string
   description = "Channel for a CoreOS Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
 }
 
 variable "os_version" {
-  type        = "string"
+  type        = string
   description = "Version for a CoreOS Container Linux derivative to PXE and install (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
 }
 
@@ -24,37 +24,37 @@ variable "os_version" {
 # Terraform's crude "type system" does not properly support lists of maps so we do this.
 
 variable "controller_names" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of controller names (e.g. [node1])"
 }
 
 variable "controller_macs" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of controller identifying MAC addresses (e.g. [52:54:00:a1:9c:ae])"
 }
 
 variable "controller_domains" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of controller FQDNs (e.g. [node1.example.com])"
 }
 
 variable "worker_names" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of worker names (e.g. [node2, node3])"
 }
 
 variable "worker_macs" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of worker identifying MAC addresses (e.g. [52:54:00:b2:2f:86, 52:54:00:c3:61:77])"
 }
 
 variable "worker_domains" {
-  type        = "list"
+  type        = list(string)
   description = "Ordered list of worker FQDNs (e.g. [node2.example.com, node3.example.com])"
 }
 
 variable "clc_snippets" {
-  type        = "map"
+  type        = map(string)
   description = "Map from machine names to lists of Container Linux Config snippets"
   default     = {}
 }
@@ -63,40 +63,40 @@ variable "clc_snippets" {
 
 variable "k8s_domain_name" {
   description = "Controller DNS name which resolves to a controller instance. Workers and kubeconfig's will communicate with this endpoint (e.g. cluster.example.com)"
-  type        = "string"
+  type        = string
 }
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "networking" {
   description = "Choice of networking provider (flannel or calico)"
-  type        = "string"
+  type        = string
   default     = "calico"
 }
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only)"
-  type        = "string"
+  type        = string
   default     = "1480"
 }
 
 variable "network_ip_autodetection_method" {
   description = "Method to autodetect the host IPv4 address (applies to calico only)"
-  type        = "string"
+  type        = string
   default     = "first-found"
 }
 
 variable "pod_cidr" {
   description = "CIDR IPv4 range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.2.0.0/16"
 }
 
@@ -106,7 +106,8 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.3.0.0/16"
 }
 
@@ -114,49 +115,49 @@ EOD
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
 
 variable "download_protocol" {
-  type        = "string"
+  type        = string
   default     = "https"
   description = "Protocol iPXE should use to download the kernel and initrd. Defaults to https, which requires iPXE compiled with crypto support. Unused if cached_install is true."
 }
 
 variable "cached_install" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "Whether the operating system should PXE boot and install from matchbox /assets cache. Note that the admin must have downloaded the os_version into matchbox assets."
 }
 
 variable "install_disk" {
-  type        = "string"
+  type        = string
   default     = "/dev/sda"
   description = "Disk device to which the install profiles should install the operating system (e.g. /dev/sda)"
 }
 
 variable "container_linux_oem" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "DEPRECATED: Specify an OEM image id to use as base for the installation (e.g. ami, vmware_raw, xen) or leave blank for the default image"
 }
 
 variable "kernel_args" {
   description = "Additional kernel arguments to provide at PXE boot."
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type        = string
   description = "Enable usage or analytics reporting to upstreams (Calico)"
   default     = "false"
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
@@ -164,6 +165,7 @@ variable "enable_aggregation" {
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = "string"
+  type        = string
   default     = 8760
 }
+

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -168,4 +168,3 @@ variable "certs_validity_period_hours" {
   type        = string
   default     = 8760
 }
-

--- a/bare-metal/flatcar-linux/kubernetes/variables.tf
+++ b/bare-metal/flatcar-linux/kubernetes/variables.tf
@@ -84,8 +84,8 @@ variable "networking" {
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only)"
-  type        = string
-  default     = "1480"
+  type        = number
+  default     = 1480
 }
 
 variable "network_ip_autodetection_method" {
@@ -126,8 +126,8 @@ variable "download_protocol" {
 }
 
 variable "cached_install" {
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
   description = "Whether the operating system should PXE boot and install from matchbox /assets cache. Note that the admin must have downloaded the os_version into matchbox assets."
 }
 
@@ -150,21 +150,21 @@ variable "kernel_args" {
 }
 
 variable "enable_reporting" {
-  type        = string
+  type        = bool
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = "false"
+  default     = false
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 # Certificates
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = string
+  type        = number
   default     = 8760
 }

--- a/ci/aws/aws-cluster.tf.envsubst
+++ b/ci/aws/aws-cluster.tf.envsubst
@@ -2,11 +2,11 @@ module "aws-tempest" {
   source = "../../aws/flatcar-linux/kubernetes"
 
   providers = {
-    aws = "aws.default"
-    local = "local.default"
-    null = "null.default"
-    template = "template.default"
-    tls = "tls.default"
+    aws      = aws.default
+    local    = local.default
+    null     = null.default
+    template = template.default
+    tls      = tls.default
   }
 
   cluster_name = "$CLUSTER_ID"
@@ -14,7 +14,7 @@ module "aws-tempest" {
   dns_zone_id = "$AWS_DNS_ZONE_ID"
   ssh_keys = ["$PUB_KEY"]
 
-  asset_dir = "${pathexpand("~/assets")}"
+  asset_dir = pathexpand("~/assets")
 
   worker_count = 2
   worker_type  = "t3.small"

--- a/ci/packet/packet-cluster.tf.envsubst
+++ b/ci/packet/packet-cluster.tf.envsubst
@@ -2,12 +2,12 @@ module "controller" {
   source = "../../packet/flatcar-linux/kubernetes"
 
   providers = {
-    aws      = "aws.default"
-    local    = "local.default"
-    null     = "null.default"
-    template = "template.default"
-    tls      = "tls.default"
-    packet   = "packet.default"
+    aws      = aws.default
+    local    = local.default
+    null     = null.default
+    template = template.default
+    tls      = tls.default
+    packet   = packet.default
   }
 
   dns_zone = "$AWS_DNS_ZONE"
@@ -15,7 +15,7 @@ module "controller" {
 
   ssh_keys = ["$PUB_KEY"]
 
-  asset_dir = "${pathexpand("~/assets")}"
+  asset_dir = pathexpand("~/assets")
   cluster_name = "$CLUSTER_ID"
   project_id = "$PACKET_PROJECT_ID"
 
@@ -35,10 +35,10 @@ module "worker-pool-1" {
   source = "../../packet/flatcar-linux/kubernetes/workers"
 
   providers = {
-    local    = "local.default"
-    template = "template.default"
-    tls      = "tls.default"
-    packet   = "packet.default"
+    local    = local.default
+    template = template.default
+    tls      = tls.default
+    packet   = packet.default
   }
 
 
@@ -53,7 +53,7 @@ module "worker-pool-1" {
   worker_count = 2
   type  = "c2.medium.x86"
 
-  kubeconfig = "${module.controller.kubeconfig}"
+  kubeconfig = module.controller.kubeconfig
 
   labels = "node.supernova.io/role=backend"
 }

--- a/ci/packet/packet-cluster.tf.envsubst
+++ b/ci/packet/packet-cluster.tf.envsubst
@@ -50,7 +50,7 @@ module "worker-pool-1" {
   facility     = "ams1"
   pool_name    = "pool-1"
 
-  count = 2
+  worker_count = 2
   type  = "c2.medium.x86"
 
   kubeconfig = "${module.controller.kubeconfig}"

--- a/ci/packet/provider.tf
+++ b/ci/packet/provider.tf
@@ -28,6 +28,6 @@ provider "tls" {
 }
 
 provider "packet" {
-  version = "~> 1.2"
+  version = "~> 2.7.3"
   alias   = "default"
 }

--- a/ci/set-terraform-version
+++ b/ci/set-terraform-version
@@ -1,2 +1,2 @@
 #!/bin/sh
-ln -fs ~/.local/bin/terraform11 ~/.local/bin/terraform
+ln -fs ~/.local/bin/terraform12 ~/.local/bin/terraform

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -240,9 +240,9 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | controller_type | EC2 instance type for controllers | "t3.small" | See below |
 | worker_type | EC2 instance type for workers | "t3.small" | See below |
 | os_image | AMI channel for Flatcar Container Linux | flatcar-stable | flatcar-stable, flatcar-beta, flatcar-alpha |
-| disk_size | Size of the EBS volume in GB | "40" | "100" |
+| disk_size | Size of the EBS volume in GB | 40 | 100 |
 | disk_type | Type of the EBS volume | "gp2" | standard, gp2, io1 |
-| disk_iops | IOPS of the EBS volume | "0" (i.e. auto) | "400" |
+| disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |
 | worker_target_groups | Target group ARNs to which worker instances should be added | [] | ["${aws_lb_target_group.app.id}"] |
 | worker_price | Spot price in USD for workers. Leave as default empty string for regular on-demand instances | "" | "0.10" |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
@@ -253,7 +253,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
-| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
+| certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |
 
 Check the list of valid [instance types](https://aws.amazon.com/ec2/instance-types/).
 

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -10,15 +10,15 @@ Controllers are provisioned to run an `etcd-member` peer and a `kubelet` service
 
 * AWS Account and IAM credentials
 * AWS Route53 DNS Zone (registered Domain Name or delegated subdomain)
-* Terraform v0.11.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
+* Terraform v0.12.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
 
 ## Terraform Setup
 
-Install [Terraform](https://www.terraform.io/downloads.html) v0.11.x on your system.
+Install [Terraform](https://www.terraform.io/downloads.html) v0.12.x on your system.
 
 ```sh
 $ terraform version
-Terraform v0.11.13
+Terraform v0.12.17
 ```
 
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
@@ -95,11 +95,11 @@ module "aws-tempest" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//aws/flatcar-linux/kubernetes?ref=<hash>"
 
   providers = {
-    aws = "aws.default"
-    local = "local.default"
-    null = "null.default"
-    template = "template.default"
-    tls = "tls.default"
+    aws = aws.default
+    local = local.default
+    null = null.default
+    template = template.default
+    tls = tls.default
   }
 
   # AWS

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -13,7 +13,7 @@ Controllers are provisioned to run an `etcd-member` peer and a `kubelet` service
 
 * Azure account
 * Azure DNS Zone (registered Domain Name or delegated subdomain)
-* Terraform v0.11.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
+* Terraform v0.12.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
 
 ## Terraform Setup
 
@@ -21,7 +21,7 @@ Install [Terraform](https://www.terraform.io/downloads.html) v0.11.x on your sys
 
 ```sh
 $ terraform version
-Terraform v0.11.12
+Terraform v0.12.17
 ```
 
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
@@ -90,11 +90,11 @@ module "azure-ramius" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//azure/flatcar-linux/kubernetes"
 
   providers = {
-    azurerm  = "azurerm.default"
-    local    = "local.default"
-    null     = "null.default"
-    template = "template.default"
-    tls      = "tls.default"
+    azurerm  = azurerm.default
+    local    = local.default
+    null     = null.default
+    template = template.default
+    tls      = tls.default
   }
 
   # Azure

--- a/docs/flatcar-linux/azure.md
+++ b/docs/flatcar-linux/azure.md
@@ -253,7 +253,7 @@ Reference the DNS zone with `"${azurerm_dns_zone.clusters.name}"` and its resour
 | controller_type | Machine type for controllers | "Standard_DS1_v2" | See below |
 | worker_type | Machine type for workers | "Standard_F1" | See below |
 | os_image | Channel for a Flatcar Container Linux | flatcar-stable | flatcar-stable, flatcar-beta, flatcar-alpha |
-| disk_size | Size of the disk in GB | "40" | "100" |
+| disk_size | Size of the disk in GB | 40 | 100 |
 | worker_priority | Set priority to Low to use reduced cost surplus capacity, with the tradeoff that instances can be deallocated at any time | Regular | Low |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
 | worker_clc_snippets | Worker Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
@@ -261,7 +261,7 @@ Reference the DNS zone with `"${azurerm_dns_zone.clusters.name}"` and its resour
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
-| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
+| certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |
 
 Check the list of valid [machine types](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/) and their [specs](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-general). Use `az vm list-skus` to get the identifier.
 

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -392,5 +392,5 @@ Check the [variables.tf](https://github.com/kinvolk/lokomotive-kubernetes/blob/m
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | kernel_args | Additional kernel args to provide at PXE boot | [] | "kvm-intel.nested=1" |
-| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
+| certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |
 

--- a/docs/flatcar-linux/bare-metal.md
+++ b/docs/flatcar-linux/bare-metal.md
@@ -12,7 +12,7 @@ Controllers are provisioned to run an `etcd-member` peer and a `kubelet` service
 * PXE-enabled [network boot](https://coreos.com/matchbox/docs/latest/network-setup.html) environment (with HTTPS support)
 * Matchbox v0.6+ deployment with API enabled
 * Matchbox credentials `client.crt`, `client.key`, `ca.crt`
-* Terraform v0.11.x, [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox), and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
+* Terraform v0.12.x, [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox), and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
 
 ## Machines
 
@@ -107,11 +107,11 @@ Read about the [many ways](https://coreos.com/matchbox/docs/latest/network-setup
 
 ## Terraform Setup
 
-Install [Terraform](https://www.terraform.io/downloads.html) v0.11.x on your system.
+Install [Terraform](https://www.terraform.io/downloads.html) v0.12.x on your system.
 
 ```sh
 $ terraform version
-Terraform v0.11.13
+Terraform v0.12.17
 ```
 
 Add the [terraform-provider-matchbox](https://github.com/poseidon/terraform-provider-matchbox) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
@@ -183,10 +183,10 @@ module "bare-metal-mercury" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//bare-metal/flatcar-linux/kubernetes?ref=<hash>"
 
   providers = {
-    local = "local.default"
-    null = "null.default"
-    template = "template.default"
-    tls = "tls.default"
+    local = local.default
+    null = null.default
+    template = template.default
+    tls = tls.default
   }
 
   # bare-metal

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -256,11 +256,11 @@ resource "google_dns_managed_zone" "zone-for-clusters" {
 | pod_cidr | CIDR IPv4 range to assign to Kubernetes pods | "10.2.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
-| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
+| certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |
 
 Check the list of valid [machine types](https://cloud.google.com/compute/docs/machine-types).
 
 #### Preemption
 
-Add `worker_preemeptible = "true"` to allow worker nodes to be [preempted](https://cloud.google.com/compute/docs/instances/preemptible) at random, but pay [significantly](https://cloud.google.com/compute/pricing) less. Clusters tolerate stopping instances fairly well (reschedules pods, but cannot drain) and preemption provides a nice reward for running fault-tolerant cluster systems.`
+Add `worker_preemeptible = true` to allow worker nodes to be [preempted](https://cloud.google.com/compute/docs/instances/preemptible) at random, but pay [significantly](https://cloud.google.com/compute/pricing) less. Clusters tolerate stopping instances fairly well (reschedules pods, but cannot drain) and preemption provides a nice reward for running fault-tolerant cluster systems.`
 

--- a/docs/flatcar-linux/google-cloud.md
+++ b/docs/flatcar-linux/google-cloud.md
@@ -10,7 +10,7 @@ Controllers are provisioned to run an `etcd-member` peer and a `kubelet` service
 
 * Google Cloud Account and Service Account
 * Google Cloud DNS Zone (registered Domain Name or delegated subdomain)
-* Terraform v0.11.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
+* Terraform v0.12.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
 
 ## Terraform Setup
 
@@ -18,7 +18,7 @@ Install [Terraform](https://www.terraform.io/downloads.html) v0.11.x on your sys
 
 ```sh
 $ terraform version
-Terraform v0.11.12
+Terraform v0.12.17
 ```
 
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
@@ -52,7 +52,7 @@ provider "google" {
   version = "2.16.0"
   alias   = "default"
 
-  credentials = "${file("~/.config/google-cloud/terraform.json")}"
+  credentials = file("~/.config/google-cloud/terraform.json")
   project     = "project-id"
   region      = "us-central1"
 }
@@ -96,11 +96,11 @@ module "google-cloud-yavin" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//google-cloud/flatcar-linux/kubernetes?ref=<hash>"
 
   providers = {
-    google   = "google.default"
-    local    = "local.default"
-    null     = "null.default"
-    template = "template.default"
-    tls      = "tls.default"
+    google   = google.default
+    local    = local.default
+    null     = null.default
+    template = template.default
+    tls      = tls.default
   }
 
   # Google Cloud

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -198,7 +198,7 @@ module "worker-pool-one" {
 
   pool_name = "one"
 
-  count = 1
+  worker_count = 1
 
   kubeconfig = "${module.controller.kubeconfig}"
 
@@ -341,7 +341,7 @@ source.
 #### Optional
 | Name | Description | Default | Example |
 |:-----|:------------|:--------|:--------|
-| count | Number of worker VMs | "1" | "3" |
+| worker_count | Number of worker VMs | "1" | "3" |
 | cluster_domain_suffix | The cluster's suffix answered by coredns | "cluster.local" | "k8s.example.com" |
 | labels | Custom label to assign to worker nodes. Provide comma separated key=value pairs as labels." | "" | "foo=oof,bar=,baz=zab" |
 | service_cidr | CIDR IPv4 range to assign Kubernetes services. The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns. | "10.2.0.0/16" | "10.3.0.0/24" |

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -86,33 +86,14 @@ tar xzf terraform-provider-ct-v0.4.0-linux-amd64.tar.gz
 mv terraform-provider-ct-v0.4.0-linux-amd64/terraform-provider-ct ~/.terraform.d/plugins/terraform-provider-ct_v0.4.0
 ```
 
-Add the [terraform-provider-libvirt](https://github.com/dmacvicar/terraform-provider-libvirt) plugin binary for your system
-to `~/.terraform.d/plugins/`, noting the `_v0.5.3` suffix. As long as this version is unreleased you have to build the plugin
-yourself. The version must include the `fw_cfg_name` feature as well as the experimental
-[pool definition feature](https://github.com/dmacvicar/terraform-provider-libvirt/commit/9f00f3d46c489f24c71d02fde816f5fda34d3f7c).
-
-When building from source, you have to do a final `mv $GOPATH/bin/terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.3`:
-
-When building from source, you will need to install the package `libvirt-dev` for Debian/Ubuntu or `libvirt-devel` for Fedora/CentOS.
+Download the tar file for your distribution from the [release page](https://github.com/dmacvicar/terraform-provider-libvirt/releases):
 
 ```sh
-$ # From any (even temporary) directory
-$ git clone https://github.com/dmacvicar/terraform-provider-libvirt.git
-$ export GO111MODULE=on
-$ export GOFLAGS=-mod=vendor
-$ make install
-$ mv "$GOPATH/bin/terraform-provider-libvirt" ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.3
+wget https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.6.0/terraform-provider-libvirt-0.6.0+git.1569597268.1c8597df.Fedora_28.x86_64.tar.gz
+# or, e.g., https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.6.0/terraform-provider-libvirt-0.6.0+git.1569597268.1c8597df.Ubuntu_18.04.amd64.tar.gz
+tar xzf terraform-provider-libvirt-0.6.0+git.1569597268.1c8597df.Fedora_28.x86_64.tar.gz
+mv terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.6.0
 ```
-
-In the future you can download the tar file for your distribution from the [release page](https://github.com/dmacvicar/terraform-provider-libvirt/releases):
-
-```sh
-wget https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.5.3/terraform-provider-libvirt-0.5.3.Fedora_28.x86_64.tar.gz
-# or, e.g., https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.5.2/terraform-provider-libvirt-0.5.3.Ubuntu_18.04.amd64.tar.gz
-tar xzf terraform-provider-libvirt-0.5.3.Fedora_28.x86_64.tar.gz
-mv terraform-provider-libvirt ~/.terraform.d/plugins/terraform-provider-libvirt_v0.5.3
-```
-
 
 Read [concepts](/docs/architecture/concepts.md) to learn about Terraform, modules, and organizing resources if the following confuses you.
 
@@ -154,7 +135,7 @@ provider "tls" {
 }
 
 provider "libvirt" {
-  version = "~> 0.5.3"
+  version = "~> 0.6.0"
   uri     = "qemu:///system"
   alias   = "default"
 }

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -70,11 +70,11 @@ $ newgrp libvirt
 
 ## Terraform Setup
 
-Install [Terraform](https://www.terraform.io/downloads.html) v0.11.x on your system.
+Install [Terraform](https://www.terraform.io/downloads.html) v0.12.x on your system.
 
 ```sh
 $ terraform version
-Terraform v0.11.13
+Terraform v0.12.17
 ```
 
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system
@@ -153,11 +153,11 @@ module "controller" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//kvm-libvirt/flatcar-linux/kubernetes"
 
   providers = {
-    local    = "local.default"
-    null     = "null.default"
-    template = "template.default"
-    tls      = "tls.default"
-    libvirt  = "libvirt.default"
+    local    = local.default
+    null     = null.default
+    template = template.default
+    tls      = tls.default
+    libvirt  = libvirt.default
   }
 
   # Path to where the image was prepared, note the triple slash for the absolute path
@@ -176,31 +176,30 @@ module "controller" {
   node_ip_pool = "192.168.192.0/24"
 
   controller_count = 1
-
 }
 
 module "worker-pool-one" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//kvm-libvirt/flatcar-linux/kubernetes/workers"
 
   providers = {
-    local    = "local.default"
-    template = "template.default"
-    tls      = "tls.default"
-    libvirt  = "libvirt.default"
+    local    = local.default
+    template = template.default
+    tls      = tls.default
+    libvirt  = libvirt.default
   }
 
-  ssh_keys = "${module.controller.ssh_keys}"
+  ssh_keys = "module.controller.ssh_keys
 
-  machine_domain = "${module.controller.machine_domain}"
-  cluster_name = "${module.controller.cluster_name}"
-  libvirtpool = "${module.controller.libvirtpool}"
-  libvirtbaseid = "${module.controller.libvirtbaseid}"
+  machine_domain = module.controller.machine_domain
+  cluster_name = module.controller.cluster_name
+  libvirtpool = module.controller.libvirtpool
+  libvirtbaseid = module.controller.libvirtbaseid
 
   pool_name = "one"
 
   worker_count = 1
 
-  kubeconfig = "${module.controller.kubeconfig}"
+  kubeconfig = module.controller.kubeconfig
 
   labels = "node.supernova.io/role=backend"
 }

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -78,7 +78,7 @@ Terraform v0.11.13
 ```
 
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system
-to `~/.terraform.d/plugins/`, noting the `_v0.3.1` suffix.
+to `~/.terraform.d/plugins/`, noting the `_v0.4.0` suffix.
 
 ```sh
 wget https://github.com/poseidon/terraform-provider-ct/releases/download/v0.4.0/terraform-provider-ct-v0.4.0-linux-amd64.tar.gz

--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -308,18 +308,18 @@ source.
 | Name | Description | Default | Example |
 |:-----|:------------|:--------|:--------|
 | cluster_domain_suffix | Queries for domains with the suffix will be answered by coredns | "cluster.local" | "k8s.example.com" |
-| controller_count | Number of controller VMs | "1" | "1" |
-| enable_aggregation | Enable the Kubernetes Aggregation Layer | "false" | "true" |
-| enable_reporting | Enable usage or analytics reporting to upstreams (Calico) | "false" | "true" |
-| network_mtu | CNI interface MTU (applies to calico only) | "1480" | "8981" |
+| controller_count | Number of controller VMs | 1 | 1 |
+| enable_aggregation | Enable the Kubernetes Aggregation Layer | false | true |
+| enable_reporting | Enable usage or analytics reporting to upstreams (Calico) | false | true |
+| network_mtu | CNI interface MTU (applies to calico only) | 1480 | 8981 |
 | network_ip_autodetection_method | Method to autodetect the host IPv4 address (applies to calico only) | "first-found" or "can-reach=192.168.192.1" |
 | networking | Choice of networking provider | "calico" | "calico" or "flannel" |
 | node_ip_pool | Unique VM IP CIDR (different per cluster) | "192.168.192.0/24" | | "192.168.13.0/24" |
 | pod_cidr | CIDR IPv4 range to assign Kubernetes pods | "10.1.0.0/16" | "10.22.0.0/16" |
 | service_cidr | CIDR IPv4 range to assign Kubernetes services. The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns. | "10.2.0.0/16" | "10.3.0.0/24" |
-| virtual_cpus | Number of virtual CPUs | "1" | "2" |
-| virtual_memory | Virtual RAM in MB | "2048" | "4096" |
-| certs_validity_period_hours | Validity of all the certificates in hours | "8760" | "17520" |
+| virtual_cpus | Number of virtual CPUs | 1 | 2 |
+| virtual_memory | Virtual RAM in MB | 2048 | 4096 |
+| certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |
 | controller_clc_snippets | Controller Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
 
 ### Worker
@@ -340,13 +340,14 @@ source.
 #### Optional
 | Name | Description | Default | Example |
 |:-----|:------------|:--------|:--------|
-| worker_count | Number of worker VMs | "1" | "3" |
+| worker_count | Number of worker VMs | 1 | 3 |
 | cluster_domain_suffix | The cluster's suffix answered by coredns | "cluster.local" | "k8s.example.com" |
 | labels | Custom label to assign to worker nodes. Provide comma separated key=value pairs as labels." | "" | "foo=oof,bar=,baz=zab" |
 | service_cidr | CIDR IPv4 range to assign Kubernetes services. The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns. | "10.2.0.0/16" | "10.3.0.0/24" |
-| virtual_cpus | Number of virtual CPUs | "1" | "2" |
-| virtual_memory | Virtual RAM in MB | "2048" | "4096" |
+| virtual_cpus | Number of virtual CPUs | 1 | 2 |
+| virtual_memory | Virtual RAM in MB | 2048 | 4096 |
 | clc_snippets | Worker Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
+
 
 #### Closing Notes
 

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -11,15 +11,15 @@ Controllers are provisioned to run an `etcd-member` peer and a `kubelet` service
 * Packet account, Project ID and [API key](https://support.packet.com/kb/articles/api-integrations) (Note, that the term "Auth Token" is also used to refer to the API key in the packet docs)
 * AWS Account and IAM credentials
 * AWS Route53 DNS Zone (registered Domain Name or delegated subdomain)
-* Terraform v0.11.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
+* Terraform v0.12.x and [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) installed locally
 
 ## Terraform Setup
 
-Install [Terraform](https://www.terraform.io/downloads.html) v0.11.x on your system.
+Install [Terraform](https://www.terraform.io/downloads.html) v0.12.x on your system.
 
 ```sh
 $ terraform version
-Terraform v0.11.13
+Terraform v0.12.17
 ```
 
 Add the [terraform-provider-ct](https://github.com/poseidon/terraform-provider-ct) plugin binary for your system to `~/.terraform.d/plugins/`, noting the final name.
@@ -113,12 +113,12 @@ module "controller" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes?ref=<hash>"
 
   providers = {
-    aws      = "aws.default"
-    local    = "local.default"
-    null     = "null.default"
-    template = "template.default"
-    tls      = "tls.default"
-    packet   = "packet.default"
+    aws      = aws.default
+    local    = local.default
+    null     = null.default
+    template = template.default
+    tls      = tls.default
+    packet   = packet.default
   }
 
   # Route53
@@ -157,10 +157,10 @@ module "worker-pool-helium" {
   source = "git::https://github.com/kinvolk/lokomotive-kubernetes//packet/flatcar-linux/kubernetes/workers?ref=<hash>"
 
   providers = {
-    local    = "local.default"
-    template = "template.default"
-    tls      = "tls.default"
-    packet   = "packet.default"
+    local    = local.default
+    template = template.default
+    tls      = tls.default
+    packet   = packet.default
   }
 
   ssh_keys = [
@@ -176,7 +176,7 @@ module "worker-pool-helium" {
   worker_count = 2
   type  = "t1.small.x86"
 
-  kubeconfig = "${module.controller.kubeconfig}"
+  kubeconfig = module.controller.kubeconfig
 
   labels = "node.supernova.io/role=backend"
 }

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -173,7 +173,7 @@ module "worker-pool-helium" {
   facility     = "ams1"
   pool_name    = "helium"
 
-  count = 2
+  worker_count = 2
   type  = "t1.small.x86"
 
   kubeconfig = "${module.controller.kubeconfig}"
@@ -345,7 +345,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 
 | Name | Description | Default | Example |
 |:-----|:------------|:--------|:--------|
-| count | Number of worker nodes | 1 | 3 |
+| worker_count | Number of worker nodes | 1 | 3 |
 | type | Type of nodes to provision | "baremetal_0" | "t1.small.x86". See https://www.packet.com/developers/api/#plans for more |
 | labels | Comma separated labels to be added to the worker nodes | "" | "node.supernova.io/role=backend" |
 | os_channel | Flatcar Container Linux channel to install from | stable | stable, beta, alpha, edge |
@@ -377,7 +377,7 @@ See [issue #111](https://github.com/kinvolk/lokomotive-kubernetes/issues/111) fo
 Currently the only tested ways to modify a cluster are:
 
 * Adding new worker pools, done by adding a new worker module.
-* Scaling a worker pool by changing the `count` to delete or add nodes, even to 0 (but the worker pool definition has to be kept and the total number of workers must be > 0).
+* Scaling a worker pool by changing the `worker_count` to delete or add nodes, even to 0 (but the worker pool definition has to be kept and the total number of workers must be > 0).
 * Changing the instance type of a worker pool by altering `type`, e.g., from `t1.small.x86` to `c1.small.x86`, which will recreate the nodes, causing downtime since they are destroyed first and then created again.
 
 This list may be expanded in the future but for now other changes are not supported but can be done at your own risk.

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -87,7 +87,7 @@ provider "tls" {
 }
 
 provider "packet" {
-  version = "~> 1.2"
+  version = "~> 2.7.3"
   alias   = "default"
 }
 ```

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -354,10 +354,10 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | ipxe_script_url | URL that contains iPXE script to boot Flatcar on the node over PXE | "" | https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/amd64-usr/packet.ipxe, https://raw.githubusercontent.com/kinvolk/flatcar-ipxe-scripts/arm64-usr/packet.ipxe |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
-| setup_raid | Flag to create a RAID 0 from extra disks on a Packet node | "false" | "true" |
-| setup_raid_hdd    | Flag to create a RAID 0 from extra Hard Disk Drives (HDD) only. Has no effect if `setup_raid` is `"true"`   | "false" | "true" |
-| setup_raid_ssd    | Flag to create a RAID 0 from extra Solid State Drives (SSD) only. Has no effect if `setup_raid` is `"true"` | "false" | "true" |
-| setup_raid_ssd_fs | Flag to create a file system on RAID 0 created using flag `setup_raid_ssd`. Has no effect if `setup_raid` is `"true"` | "true" | "false" |
+| setup_raid | Flag to create a RAID 0 from extra disks on a Packet node | false | true |
+| setup_raid_hdd    | Flag to create a RAID 0 from extra Hard Disk Drives (HDD) only. Has no effect if `setup_raid` is `true`   | false | true |
+| setup_raid_ssd    | Flag to create a RAID 0 from extra Solid State Drives (SSD) only. Has no effect if `setup_raid` is `true` | false | true |
+| setup_raid_ssd_fs | Flag to create a file system on RAID 0 created using flag `setup_raid_ssd`. Has no effect if `setup_raid` is `true` | true | false |
 | taints | Comma separated list of custom taints for all workers in the worker pool | "" | "clusterType=staging:NoSchedule,nodeType=storage:NoSchedule" |
 | reservation_ids | Map Packet hardware reservation IDs to instances. | {} | { worker-0 = "55555f20-a1fb-55bd-1e11-11af11d11111" } |
 | reservation_ids_default | Default hardware reservation ID for nodes not listed in the `reservation_ids` map. | "" | "next-available"|

--- a/google-cloud/flatcar-linux/kubernetes/apiserver.tf
+++ b/google-cloud/flatcar-linux/kubernetes/apiserver.tf
@@ -99,4 +99,3 @@ resource "google_compute_health_check" "apiserver" {
     port = "6443"
   }
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/apiserver.tf
+++ b/google-cloud/flatcar-linux/kubernetes/apiserver.tf
@@ -67,9 +67,9 @@ resource "google_compute_instance_group" "controllers" {
   name = format(
     "%s-controllers-%s",
     var.cluster_name,
-    element(local.zones, count.index),
+    local.zones[count.index]
   )
-  zone = element(local.zones, count.index)
+  zone = local.zones[count.index]
 
   named_port {
     name = "apiserver"
@@ -80,7 +80,7 @@ resource "google_compute_instance_group" "controllers" {
   instances = matchkeys(
     google_compute_instance.controllers.*.self_link,
     google_compute_instance.controllers.*.zone,
-    [element(local.zones, count.index)],
+    [local.zones[count.index]],
   )
 }
 

--- a/google-cloud/flatcar-linux/kubernetes/apiserver.tf
+++ b/google-cloud/flatcar-linux/kubernetes/apiserver.tf
@@ -1,15 +1,15 @@
 # TCP Proxy load balancer DNS record
 resource "google_dns_record_set" "apiserver" {
   # DNS Zone name where record should be created
-  managed_zone = "${var.dns_zone_name}"
+  managed_zone = var.dns_zone_name
 
   # DNS record
-  name = "${format("%s.%s.", var.cluster_name, var.dns_zone)}"
+  name = format("%s.%s.", var.cluster_name, var.dns_zone)
   type = "A"
   ttl  = 300
 
   # IPv4 address of apiserver TCP Proxy load balancer
-  rrdatas = ["${google_compute_global_address.apiserver-ipv4.address}"]
+  rrdatas = [google_compute_global_address.apiserver-ipv4.address]
 }
 
 # Static IPv4 address for the TCP Proxy Load Balancer
@@ -21,17 +21,17 @@ resource "google_compute_global_address" "apiserver-ipv4" {
 # Forward IPv4 TCP traffic to the TCP proxy load balancer
 resource "google_compute_global_forwarding_rule" "apiserver" {
   name        = "${var.cluster_name}-apiserver"
-  ip_address  = "${google_compute_global_address.apiserver-ipv4.address}"
+  ip_address  = google_compute_global_address.apiserver-ipv4.address
   ip_protocol = "TCP"
   port_range  = "443"
-  target      = "${google_compute_target_tcp_proxy.apiserver.self_link}"
+  target      = google_compute_target_tcp_proxy.apiserver.self_link
 }
 
 # Global TCP Proxy Load Balancer for apiservers
 resource "google_compute_target_tcp_proxy" "apiserver" {
   name            = "${var.cluster_name}-apiserver"
   description     = "Distribute TCP load across ${var.cluster_name} controllers"
-  backend_service = "${google_compute_backend_service.apiserver.self_link}"
+  backend_service = google_compute_backend_service.apiserver.self_link
 }
 
 # Global backend service backed by unmanaged instance groups
@@ -46,26 +46,30 @@ resource "google_compute_backend_service" "apiserver" {
 
   # controller(s) spread across zonal instance groups
   backend {
-    group = "${google_compute_instance_group.controllers.0.self_link}"
+    group = google_compute_instance_group.controllers[0].self_link
   }
 
   backend {
-    group = "${google_compute_instance_group.controllers.1.self_link}"
+    group = google_compute_instance_group.controllers[1].self_link
   }
 
   backend {
-    group = "${google_compute_instance_group.controllers.2.self_link}"
+    group = google_compute_instance_group.controllers[2].self_link
   }
 
-  health_checks = ["${google_compute_health_check.apiserver.self_link}"]
+  health_checks = [google_compute_health_check.apiserver.self_link]
 }
 
 # Instance group of heterogeneous (unmanged) controller instances
 resource "google_compute_instance_group" "controllers" {
-  count = "${length(local.zones)}"
+  count = length(local.zones)
 
-  name = "${format("%s-controllers-%s", var.cluster_name, element(local.zones, count.index))}"
-  zone = "${element(local.zones, count.index)}"
+  name = format(
+    "%s-controllers-%s",
+    var.cluster_name,
+    element(local.zones, count.index),
+  )
+  zone = element(local.zones, count.index)
 
   named_port {
     name = "apiserver"
@@ -73,11 +77,11 @@ resource "google_compute_instance_group" "controllers" {
   }
 
   # add instances in the zone into the instance group
-  instances = [
-    "${matchkeys(google_compute_instance.controllers.*.self_link,
-      google_compute_instance.controllers.*.zone,
-      list(element(local.zones, count.index)))}",
-  ]
+  instances = matchkeys(
+    google_compute_instance.controllers.*.self_link,
+    google_compute_instance.controllers.*.zone,
+    [element(local.zones, count.index)],
+  )
 }
 
 # TCP health check for apiserver
@@ -95,3 +99,4 @@ resource "google_compute_health_check" "apiserver" {
     port = "6443"
   }
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/bootkube.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootkube.tf
@@ -4,7 +4,7 @@ module "bootkube" {
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers          = [google_dns_record_set.etcds.*.name]
+  etcd_servers          = google_dns_record_set.etcds.*.name
   asset_dir             = var.asset_dir
   networking            = var.networking
   network_mtu           = 1440

--- a/google-cloud/flatcar-linux/kubernetes/bootkube.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootkube.tf
@@ -19,4 +19,3 @@ module "bootkube" {
 
   certs_validity_period_hours = var.certs_validity_period_hours
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/bootkube.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootkube.tf
@@ -2,20 +2,21 @@
 module "bootkube" {
   source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
 
-  cluster_name          = "${var.cluster_name}"
-  api_servers           = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers          = ["${google_dns_record_set.etcds.*.name}"]
-  asset_dir             = "${var.asset_dir}"
-  networking            = "${var.networking}"
+  cluster_name          = var.cluster_name
+  api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  etcd_servers          = [google_dns_record_set.etcds.*.name]
+  asset_dir             = var.asset_dir
+  networking            = var.networking
   network_mtu           = 1440
-  pod_cidr              = "${var.pod_cidr}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  enable_reporting      = "${var.enable_reporting}"
-  enable_aggregation    = "${var.enable_aggregation}"
+  pod_cidr              = var.pod_cidr
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  enable_reporting      = var.enable_reporting
+  enable_aggregation    = var.enable_aggregation
 
   // temporary
   external_apiserver_port = 443
 
-  certs_validity_period_hours = "${var.certs_validity_period_hours}"
+  certs_validity_period_hours = var.certs_validity_period_hours
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/bootkube.tf
+++ b/google-cloud/flatcar-linux/kubernetes/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=0f3156c73b846bf1bc5dd4681879048c37fb2f25"
 
   cluster_name          = var.cluster_name
   api_servers           = [format("%s.%s", var.cluster_name, var.dns_zone)]

--- a/google-cloud/flatcar-linux/kubernetes/controllers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/controllers.tf
@@ -1,105 +1,110 @@
 # Discrete DNS records for each controller's private IPv4 for etcd usage
 resource "google_dns_record_set" "etcds" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   # DNS Zone name where record should be created
-  managed_zone = "${var.dns_zone_name}"
+  managed_zone = var.dns_zone_name
 
   # DNS record
-  name = "${format("%s-etcd%d.%s.", var.cluster_name, count.index,  var.dns_zone)}"
+  name = format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)
   type = "A"
   ttl  = 300
 
   # private IPv4 address for etcd
-  rrdatas = ["${element(google_compute_instance.controllers.*.network_interface.0.network_ip, count.index)}"]
+  rrdatas = [element(
+    google_compute_instance.controllers.*.network_interface.0.network_ip,
+    count.index,
+  )]
 }
 
 # Zones in the region
 data "google_compute_zones" "all" {
-  region = "${var.region}"
+  region = var.region
 }
 
 locals {
   # TCP proxy load balancers require a fixed number of zonal backends. Spread
   # controllers over up to 3 zones, since all GCP regions have at least 3.
-  zones = "${slice(data.google_compute_zones.all.names, 0, 3)}"
+  zones = slice(data.google_compute_zones.all.names, 0, 3)
 
-  controllers_ipv4_public = ["${google_compute_instance.controllers.*.network_interface.0.access_config.0.nat_ip}"]
+  controllers_ipv4_public = [google_compute_instance.controllers.*.network_interface.0.access_config.0.nat_ip]
 }
 
 # Controller instances
 resource "google_compute_instance" "controllers" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   name         = "${var.cluster_name}-controller-${count.index}"
-  zone         = "${element(local.zones, count.index)}"
-  machine_type = "${var.controller_type}"
+  zone         = element(local.zones, count.index)
+  machine_type = var.controller_type
 
   metadata = {
-    user-data = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+    user-data = element(data.ct_config.controller-ignitions.*.rendered, count.index)
   }
 
   boot_disk {
     auto_delete = true
 
     initialize_params {
-      image = "${var.os_image}"
-      size  = "${var.disk_size}"
+      image = var.os_image
+      size  = var.disk_size
     }
   }
 
   network_interface {
-    network = "${google_compute_network.network.name}"
+    network = google_compute_network.network.name
 
     # Ephemeral external IP
-    access_config = {}
+    access_config {
+    }
   }
 
   can_ip_forward = true
   tags           = ["${var.cluster_name}-controller"]
 
   lifecycle {
-    ignore_changes = [
-      "metadata",
-    ]
+    ignore_changes = [metadata]
   }
 }
 
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
-  count        = "${var.controller_count}"
-  content      = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
+  count = var.controller_count
+  content = element(
+    data.template_file.controller-configs.*.rendered,
+    count.index,
+  )
   pretty_print = false
-  snippets     = ["${var.controller_clc_snippets}"]
+  snippets     = var.controller_clc_snippets
 }
 
 # Controller Container Linux configs
 data "template_file" "controller-configs" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
-  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+  template = file("${path.module}/cl/controller.yaml.tmpl")
 
   vars = {
     # Cannot use cyclic dependencies on controllers or their DNS records
     etcd_name   = "etcd${count.index}"
     etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
-
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster   = "${join(",", data.template_file.etcds.*.rendered)}"
-    kubeconfig             = "${indent(10, module.bootkube.kubeconfig-kubelet)}"
-    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    etcd_initial_cluster   = join(",", data.template_file.etcds.*.rendered)
+    kubeconfig             = indent(10, module.bootkube.kubeconfig-kubelet)
+    ssh_keys               = jsonencode(var.ssh_keys)
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
 
 data "template_file" "etcds" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
   vars = {
-    index        = "${count.index}"
-    cluster_name = "${var.cluster_name}"
-    dns_zone     = "${var.dns_zone}"
+    index        = count.index
+    cluster_name = var.cluster_name
+    dns_zone     = var.dns_zone
   }
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/controllers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/controllers.tf
@@ -11,10 +11,7 @@ resource "google_dns_record_set" "etcds" {
   ttl  = 300
 
   # private IPv4 address for etcd
-  rrdatas = [element(
-    google_compute_instance.controllers.*.network_interface.0.network_ip,
-    count.index,
-  )]
+  rrdatas = [google_compute_instance.controllers[count.index].network_interface.0.network_ip]
 }
 
 # Zones in the region
@@ -35,11 +32,11 @@ resource "google_compute_instance" "controllers" {
   count = var.controller_count
 
   name         = "${var.cluster_name}-controller-${count.index}"
-  zone         = element(local.zones, count.index)
+  zone         = local.zones[count.index]
   machine_type = var.controller_type
 
   metadata = {
-    user-data = element(data.ct_config.controller-ignitions.*.rendered, count.index)
+    user-data = data.ct_config.controller-ignitions[count.index].rendered
   }
 
   boot_disk {
@@ -69,11 +66,8 @@ resource "google_compute_instance" "controllers" {
 
 # Controller Ignition configs
 data "ct_config" "controller-ignitions" {
-  count = var.controller_count
-  content = element(
-    data.template_file.controller-configs.*.rendered,
-    count.index,
-  )
+  count        = var.controller_count
+  content      = data.template_file.controller-configs[count.index].rendered
   pretty_print = false
   snippets     = var.controller_clc_snippets
 }

--- a/google-cloud/flatcar-linux/kubernetes/controllers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/controllers.tf
@@ -107,4 +107,3 @@ data "template_file" "etcds" {
     dns_zone     = var.dns_zone
   }
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/controllers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/controllers.tf
@@ -27,7 +27,7 @@ locals {
   # controllers over up to 3 zones, since all GCP regions have at least 3.
   zones = slice(data.google_compute_zones.all.names, 0, 3)
 
-  controllers_ipv4_public = [google_compute_instance.controllers.*.network_interface.0.access_config.0.nat_ip]
+  controllers_ipv4_public = google_compute_instance.controllers.*.network_interface.0.access_config.0.nat_ip
 }
 
 # Controller instances

--- a/google-cloud/flatcar-linux/kubernetes/ingress.tf
+++ b/google-cloud/flatcar-linux/kubernetes/ingress.tf
@@ -14,52 +14,52 @@ resource "google_compute_global_address" "ingress-ipv6" {
 # Google Cloud does not allow TCP proxies for port 80. Must use HTTP proxy.
 resource "google_compute_global_forwarding_rule" "ingress-http-ipv4" {
   name        = "${var.cluster_name}-ingress-http-ipv4"
-  ip_address  = "${google_compute_global_address.ingress-ipv4.address}"
+  ip_address  = google_compute_global_address.ingress-ipv4.address
   ip_protocol = "TCP"
   port_range  = "80"
-  target      = "${google_compute_target_http_proxy.ingress-http.self_link}"
+  target      = google_compute_target_http_proxy.ingress-http.self_link
 }
 
 # Forward IPv4 TCP traffic to the TCP proxy load balancer
 resource "google_compute_global_forwarding_rule" "ingress-https-ipv4" {
   name        = "${var.cluster_name}-ingress-https-ipv4"
-  ip_address  = "${google_compute_global_address.ingress-ipv4.address}"
+  ip_address  = google_compute_global_address.ingress-ipv4.address
   ip_protocol = "TCP"
   port_range  = "443"
-  target      = "${google_compute_target_tcp_proxy.ingress-https.self_link}"
+  target      = google_compute_target_tcp_proxy.ingress-https.self_link
 }
 
 # Forward IPv6 TCP traffic to the HTTP proxy load balancer
 # Google Cloud does not allow TCP proxies for port 80. Must use HTTP proxy.
 resource "google_compute_global_forwarding_rule" "ingress-http-ipv6" {
   name        = "${var.cluster_name}-ingress-http-ipv6"
-  ip_address  = "${google_compute_global_address.ingress-ipv6.address}"
+  ip_address  = google_compute_global_address.ingress-ipv6.address
   ip_protocol = "TCP"
   port_range  = "80"
-  target      = "${google_compute_target_http_proxy.ingress-http.self_link}"
+  target      = google_compute_target_http_proxy.ingress-http.self_link
 }
 
 # Forward IPv6 TCP traffic to the TCP proxy load balancer
 resource "google_compute_global_forwarding_rule" "ingress-https-ipv6" {
   name        = "${var.cluster_name}-ingress-https-ipv6"
-  ip_address  = "${google_compute_global_address.ingress-ipv6.address}"
+  ip_address  = google_compute_global_address.ingress-ipv6.address
   ip_protocol = "TCP"
   port_range  = "443"
-  target      = "${google_compute_target_tcp_proxy.ingress-https.self_link}"
+  target      = google_compute_target_tcp_proxy.ingress-https.self_link
 }
 
 # HTTP proxy load balancer for ingress controllers
 resource "google_compute_target_http_proxy" "ingress-http" {
   name        = "${var.cluster_name}-ingress-http"
   description = "Distribute HTTP load across ${var.cluster_name} workers"
-  url_map     = "${google_compute_url_map.ingress-http.self_link}"
+  url_map     = google_compute_url_map.ingress-http.self_link
 }
 
 # TCP proxy load balancer for ingress controllers
 resource "google_compute_target_tcp_proxy" "ingress-https" {
   name            = "${var.cluster_name}-ingress-https"
   description     = "Distribute HTTPS load across ${var.cluster_name} workers"
-  backend_service = "${google_compute_backend_service.ingress-https.self_link}"
+  backend_service = google_compute_backend_service.ingress-https.self_link
 }
 
 # HTTP URL Map (required)
@@ -67,7 +67,7 @@ resource "google_compute_url_map" "ingress-http" {
   name = "${var.cluster_name}-ingress-http"
 
   # Do not add host/path rules for applications here. Use Ingress resources.
-  default_service = "${google_compute_backend_service.ingress-http.self_link}"
+  default_service = google_compute_backend_service.ingress-http.self_link
 }
 
 # Backend service backed by managed instance group of workers
@@ -81,10 +81,10 @@ resource "google_compute_backend_service" "ingress-http" {
   timeout_sec      = "60"
 
   backend {
-    group = "${module.workers.instance_group}"
+    group = module.workers.instance_group
   }
 
-  health_checks = ["${google_compute_health_check.ingress.self_link}"]
+  health_checks = [google_compute_health_check.ingress.self_link]
 }
 
 # Backend service backed by managed instance group of workers
@@ -98,10 +98,10 @@ resource "google_compute_backend_service" "ingress-https" {
   timeout_sec      = "60"
 
   backend {
-    group = "${module.workers.instance_group}"
+    group = module.workers.instance_group
   }
 
-  health_checks = ["${google_compute_health_check.ingress.self_link}"]
+  health_checks = [google_compute_health_check.ingress.self_link]
 }
 
 # Ingress HTTP Health Check
@@ -120,3 +120,4 @@ resource "google_compute_health_check" "ingress" {
     request_path = "/healthz"
   }
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/ingress.tf
+++ b/google-cloud/flatcar-linux/kubernetes/ingress.tf
@@ -120,4 +120,3 @@ resource "google_compute_health_check" "ingress" {
     request_path = "/healthz"
   }
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/network.tf
+++ b/google-cloud/flatcar-linux/kubernetes/network.tf
@@ -1,5 +1,5 @@
 resource "google_compute_network" "network" {
-  name                    = "${var.cluster_name}"
+  name                    = var.cluster_name
   description             = "Network for the ${var.cluster_name} cluster"
   auto_create_subnetworks = true
 
@@ -10,7 +10,7 @@ resource "google_compute_network" "network" {
 
 resource "google_compute_firewall" "allow-ssh" {
   name    = "${var.cluster_name}-allow-ssh"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   allow {
     protocol = "tcp"
@@ -23,7 +23,7 @@ resource "google_compute_firewall" "allow-ssh" {
 
 resource "google_compute_firewall" "internal-etcd" {
   name    = "${var.cluster_name}-internal-etcd"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   allow {
     protocol = "tcp"
@@ -37,7 +37,7 @@ resource "google_compute_firewall" "internal-etcd" {
 # Allow Prometheus to scrape etcd metrics
 resource "google_compute_firewall" "internal-etcd-metrics" {
   name    = "${var.cluster_name}-internal-etcd-metrics"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   allow {
     protocol = "tcp"
@@ -50,7 +50,7 @@ resource "google_compute_firewall" "internal-etcd-metrics" {
 
 resource "google_compute_firewall" "allow-apiserver" {
   name    = "${var.cluster_name}-allow-apiserver"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   allow {
     protocol = "tcp"
@@ -64,10 +64,10 @@ resource "google_compute_firewall" "allow-apiserver" {
 # BGP and IPIP
 # https://docs.projectcalico.org/latest/reference/public-cloud/gce
 resource "google_compute_firewall" "internal-bgp" {
-  count = "${var.networking != "flannel" ? 1 : 0}"
+  count = var.networking != "flannel" ? 1 : 0
 
   name    = "${var.cluster_name}-internal-bgp"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   allow {
     protocol = "tcp"
@@ -84,10 +84,10 @@ resource "google_compute_firewall" "internal-bgp" {
 
 # flannel VXLAN
 resource "google_compute_firewall" "internal-vxlan" {
-  count = "${var.networking == "flannel" ? 1 : 0}"
+  count = var.networking == "flannel" ? 1 : 0
 
   name    = "${var.cluster_name}-internal-vxlan"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   allow {
     protocol = "udp"
@@ -101,7 +101,7 @@ resource "google_compute_firewall" "internal-vxlan" {
 # Allow Prometheus to scrape node-exporter daemonset
 resource "google_compute_firewall" "internal-node-exporter" {
   name    = "${var.cluster_name}-internal-node-exporter"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   allow {
     protocol = "tcp"
@@ -115,7 +115,7 @@ resource "google_compute_firewall" "internal-node-exporter" {
 # Allow apiserver to access kubelets for exec, log, port-forward
 resource "google_compute_firewall" "internal-kubelet" {
   name    = "${var.cluster_name}-internal-kubelet"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   allow {
     protocol = "tcp"
@@ -131,7 +131,7 @@ resource "google_compute_firewall" "internal-kubelet" {
 
 resource "google_compute_firewall" "allow-ingress" {
   name    = "${var.cluster_name}-allow-ingress"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   allow {
     protocol = "tcp"
@@ -144,7 +144,7 @@ resource "google_compute_firewall" "allow-ingress" {
 
 resource "google_compute_firewall" "google-ingress-health-checks" {
   name    = "${var.cluster_name}-ingress-health"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   allow {
     protocol = "tcp"
@@ -153,17 +153,13 @@ resource "google_compute_firewall" "google-ingress-health-checks" {
 
   # https://cloud.google.com/load-balancing/docs/health-check-concepts#method
   source_ranges = [
-    # Global LB health checks
     "35.191.0.0/16",
-
     "130.211.0.0/22",
-
-    # Region LB health checks
     "35.191.0.0/16",
-
     "209.85.152.0/22",
     "209.85.204.0/22",
   ]
 
   target_tags = ["${var.cluster_name}-worker"]
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/network.tf
+++ b/google-cloud/flatcar-linux/kubernetes/network.tf
@@ -162,4 +162,3 @@ resource "google_compute_firewall" "google-ingress-health-checks" {
 
   target_tags = ["${var.cluster_name}-worker"]
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/outputs.tf
+++ b/google-cloud/flatcar-linux/kubernetes/outputs.tf
@@ -41,4 +41,3 @@ output "worker_target_pool" {
   description = "Worker target pool self link"
   value       = module.workers.target_pool
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/outputs.tf
+++ b/google-cloud/flatcar-linux/kubernetes/outputs.tf
@@ -1,43 +1,44 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin}"
+  value = module.bootkube.kubeconfig-admin
 }
 
 # Outputs for Kubernetes Ingress
 
 output "ingress_static_ipv4" {
   description = "Global IPv4 address for proxy load balancing to the nearest Ingress controller"
-  value       = "${google_compute_global_address.ingress-ipv4.address}"
+  value       = google_compute_global_address.ingress-ipv4.address
 }
 
 output "ingress_static_ipv6" {
   description = "Global IPv6 address for proxy load balancing to the nearest Ingress controller"
-  value       = "${google_compute_global_address.ingress-ipv6.address}"
+  value       = google_compute_global_address.ingress-ipv6.address
 }
 
 # Outputs for worker pools
 
 output "network_name" {
-  value = "${google_compute_network.network.name}"
+  value = google_compute_network.network.name
 }
 
 output "kubeconfig" {
-  value = "${module.bootkube.kubeconfig-kubelet}"
+  value = module.bootkube.kubeconfig-kubelet
 }
 
 # Outputs for custom firewalling
 
 output "network_self_link" {
-  value = "${google_compute_network.network.self_link}"
+  value = google_compute_network.network.self_link
 }
 
 # Outputs for custom load balancing
 
 output "worker_instance_group" {
   description = "Worker managed instance group full URL"
-  value       = "${module.workers.instance_group}"
+  value       = module.workers.instance_group
 }
 
 output "worker_target_pool" {
   description = "Worker target pool self link"
-  value       = "${module.workers.target_pool}"
+  value       = module.workers.target_pool
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/require.tf
+++ b/google-cloud/flatcar-linux/kubernetes/require.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.11.0"
+  required_version = ">= 0.12.0"
 }
 
 provider "google" {

--- a/google-cloud/flatcar-linux/kubernetes/require.tf
+++ b/google-cloud/flatcar-linux/kubernetes/require.tf
@@ -23,4 +23,3 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0"
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/require.tf
+++ b/google-cloud/flatcar-linux/kubernetes/require.tf
@@ -23,3 +23,4 @@ provider "template" {
 provider "tls" {
   version = "~> 2.0"
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/ssh.tf
+++ b/google-cloud/flatcar-linux/kubernetes/ssh.tf
@@ -4,7 +4,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(local.controllers_ipv4_public, count.index)
+    host    = local.controllers_ipv4_public[count.index]
     user    = "core"
     timeout = "15m"
   }
@@ -72,7 +72,7 @@ resource "null_resource" "bootkube-start" {
 
   connection {
     type    = "ssh"
-    host    = element(local.controllers_ipv4_public, 0)
+    host    = local.controllers_ipv4_public[0]
     user    = "core"
     timeout = "15m"
   }

--- a/google-cloud/flatcar-linux/kubernetes/ssh.tf
+++ b/google-cloud/flatcar-linux/kubernetes/ssh.tf
@@ -89,4 +89,3 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/ssh.tf
+++ b/google-cloud/flatcar-linux/kubernetes/ssh.tf
@@ -1,46 +1,46 @@
 # Secure copy etcd TLS assets to controllers.
 resource "null_resource" "copy-controller-secrets" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   connection {
     type    = "ssh"
-    host    = "${element(local.controllers_ipv4_public, count.index)}"
+    host    = element(local.controllers_ipv4_public, count.index)
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_ca_cert}"
+    content     = module.bootkube.etcd_ca_cert
     destination = "$HOME/etcd-client-ca.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_cert}"
+    content     = module.bootkube.etcd_client_cert
     destination = "$HOME/etcd-client.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_key}"
+    content     = module.bootkube.etcd_client_key
     destination = "$HOME/etcd-client.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_cert}"
+    content     = module.bootkube.etcd_server_cert
     destination = "$HOME/etcd-server.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_key}"
+    content     = module.bootkube.etcd_server_key
     destination = "$HOME/etcd-server.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_cert}"
+    content     = module.bootkube.etcd_peer_cert
     destination = "$HOME/etcd-peer.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_key}"
+    content     = module.bootkube.etcd_peer_key
     destination = "$HOME/etcd-peer.key"
   }
 
@@ -64,21 +64,21 @@ resource "null_resource" "copy-controller-secrets" {
 # one-time self-hosted cluster bootstrapping.
 resource "null_resource" "bootkube-start" {
   depends_on = [
-    "module.bootkube",
-    "module.workers",
-    "google_dns_record_set.apiserver",
-    "null_resource.copy-controller-secrets",
+    module.bootkube,
+    module.workers,
+    google_dns_record_set.apiserver,
+    null_resource.copy-controller-secrets,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${element(local.controllers_ipv4_public, 0)}"
+    host    = element(local.controllers_ipv4_public, 0)
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    source      = "${var.asset_dir}"
+    source      = var.asset_dir
     destination = "$HOME/assets"
   }
 
@@ -89,3 +89,4 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -136,4 +136,3 @@ variable "certs_validity_period_hours" {
   type        = string
   default     = 8760
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -23,14 +23,14 @@ variable "dns_zone_name" {
 # instances
 
 variable "controller_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of workers"
 }
 
@@ -53,14 +53,14 @@ variable "os_image" {
 }
 
 variable "disk_size" {
-  type        = string
-  default     = "40"
+  type        = number
+  default     = 40
   description = "Size of the disk in GB"
 }
 
 variable "worker_preemptible" {
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
   description = "If enabled, Compute Engine will terminate workers randomly within 24 hours"
 }
 
@@ -118,21 +118,21 @@ variable "cluster_domain_suffix" {
 }
 
 variable "enable_reporting" {
-  type        = string
+  type        = bool
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = "false"
+  default     = false
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 # Certificates
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = string
+  type        = number
   default     = 8760
 }

--- a/google-cloud/flatcar-linux/kubernetes/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/variables.tf
@@ -1,77 +1,77 @@
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
 # Google Cloud
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "Google Cloud Region (e.g. us-central1, see `gcloud compute regions list`)"
 }
 
 variable "dns_zone" {
-  type        = "string"
+  type        = string
   description = "Google Cloud DNS Zone (e.g. google-cloud.example.com)"
 }
 
 variable "dns_zone_name" {
-  type        = "string"
+  type        = string
   description = "Google Cloud DNS Zone name (e.g. example-zone)"
 }
 
 # instances
 
 variable "controller_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of workers"
 }
 
 variable "controller_type" {
-  type        = "string"
+  type        = string
   default     = "n1-standard-1"
   description = "Machine type for controllers (see `gcloud compute machine-types list`)"
 }
 
 variable "worker_type" {
-  type        = "string"
+  type        = string
   default     = "n1-standard-1"
   description = "Machine type for controllers (see `gcloud compute machine-types list`)"
 }
 
 variable "os_image" {
-  type        = "string"
+  type        = string
   default     = "flatcar-stable"
   description = "Flatcar Container Linux image for compute instances (e.g. flatcar-stable)"
 }
 
 variable "disk_size" {
-  type        = "string"
+  type        = string
   default     = "40"
   description = "Size of the disk in GB"
 }
 
 variable "worker_preemptible" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "If enabled, Compute Engine will terminate workers randomly within 24 hours"
 }
 
 variable "controller_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
 
 variable "worker_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Worker Container Linux Config snippets"
   default     = []
 }
@@ -79,24 +79,24 @@ variable "worker_clc_snippets" {
 # configuration
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "networking" {
   description = "Choice of networking provider (flannel or calico)"
-  type        = "string"
+  type        = string
   default     = "calico"
 }
 
 variable "pod_cidr" {
   description = "CIDR IPv4 range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.2.0.0/16"
 }
 
@@ -106,25 +106,26 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type        = string
   description = "Enable usage or analytics reporting to upstreams (Calico)"
   default     = "false"
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
@@ -132,6 +133,7 @@ variable "enable_aggregation" {
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = "string"
+  type        = string
   default     = 8760
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers.tf
@@ -1,21 +1,22 @@
 module "workers" {
   source       = "./workers"
-  name         = "${var.cluster_name}"
-  cluster_name = "${var.cluster_name}"
+  name         = var.cluster_name
+  cluster_name = var.cluster_name
 
   # GCE
-  region       = "${var.region}"
-  network      = "${google_compute_network.network.name}"
-  worker_count = "${var.worker_count}"
-  machine_type = "${var.worker_type}"
-  os_image     = "${var.os_image}"
-  disk_size    = "${var.disk_size}"
-  preemptible  = "${var.worker_preemptible}"
+  region       = var.region
+  network      = google_compute_network.network.name
+  worker_count = var.worker_count
+  machine_type = var.worker_type
+  os_image     = var.os_image
+  disk_size    = var.disk_size
+  preemptible  = var.worker_preemptible
 
   # configuration
-  kubeconfig            = "${module.bootkube.kubeconfig-kubelet}"
-  ssh_keys              = "${var.ssh_keys}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  clc_snippets          = "${var.worker_clc_snippets}"
+  kubeconfig            = module.bootkube.kubeconfig-kubelet
+  ssh_keys              = var.ssh_keys
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  clc_snippets          = var.worker_clc_snippets
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers.tf
@@ -6,7 +6,7 @@ module "workers" {
   # GCE
   region       = "${var.region}"
   network      = "${google_compute_network.network.name}"
-  count        = "${var.worker_count}"
+  worker_count = "${var.worker_count}"
   machine_type = "${var.worker_type}"
   os_image     = "${var.os_image}"
   disk_size    = "${var.disk_size}"

--- a/google-cloud/flatcar-linux/kubernetes/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers.tf
@@ -19,4 +19,3 @@ module "workers" {
   cluster_domain_suffix = var.cluster_domain_suffix
   clc_snippets          = var.worker_clc_snippets
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/workers/outputs.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/outputs.tf
@@ -2,12 +2,13 @@
 
 output "instance_group" {
   description = "Worker managed instance group full URL"
-  value       = "${google_compute_region_instance_group_manager.workers.instance_group}"
+  value       = google_compute_region_instance_group_manager.workers.instance_group
 }
 
 # Outputs for regional load balancing
 
 output "target_pool" {
   description = "Worker target pool self link"
-  value       = "${google_compute_target_pool.workers.self_link}"
+  value       = google_compute_target_pool.workers.self_link
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/workers/outputs.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/outputs.tf
@@ -11,4 +11,3 @@ output "target_pool" {
   description = "Worker target pool self link"
   value       = google_compute_target_pool.workers.self_link
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/workers/target_pool.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/target_pool.tf
@@ -1,11 +1,11 @@
 # Target pool for TCP/UDP load balancing
 resource "google_compute_target_pool" "workers" {
   name             = "${var.name}-worker-pool"
-  region           = "${var.region}"
+  region           = var.region
   session_affinity = "NONE"
 
   health_checks = [
-    "${google_compute_http_health_check.workers.name}",
+    google_compute_http_health_check.workers.name,
   ]
 }
 
@@ -20,3 +20,4 @@ resource "google_compute_http_health_check" "workers" {
   port         = 10254
   request_path = "/healthz"
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/workers/target_pool.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/target_pool.tf
@@ -20,4 +20,3 @@ resource "google_compute_http_health_check" "workers" {
   port         = 10254
   request_path = "/healthz"
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
@@ -23,8 +23,8 @@ variable "network" {
 # instances
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of worker compute instances the instance group should manage"
 }
 
@@ -41,14 +41,14 @@ variable "os_image" {
 }
 
 variable "disk_size" {
-  type        = string
-  default     = "40"
+  type        = number
+  default     = 40
   description = "Size of the disk in GB"
 }
 
 variable "preemptible" {
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
   description = "If enabled, Compute Engine will terminate instances randomly within 24 hours"
 }
 
@@ -96,7 +96,7 @@ variable "accelerator_type" {
 }
 
 variable "accelerator_count" {
-  type        = string
-  default     = "0"
+  type        = number
+  default     = 0
   description = "Number of compute engine accelerators"
 }

--- a/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
@@ -1,53 +1,53 @@
 variable "name" {
-  type        = "string"
+  type        = string
   description = "Unique name for the worker pool"
 }
 
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Must be set to `cluster_name of cluster`"
 }
 
 # Google Cloud
 
 variable "region" {
-  type        = "string"
+  type        = string
   description = "Must be set to `region` of cluster"
 }
 
 variable "network" {
-  type        = "string"
+  type        = string
   description = "Must be set to `network_name` output by cluster"
 }
 
 # instances
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of worker compute instances the instance group should manage"
 }
 
 variable "machine_type" {
-  type        = "string"
+  type        = string
   default     = "n1-standard-1"
   description = "Machine type for compute instances (e.g. gcloud compute machine-types list)"
 }
 
 variable "os_image" {
-  type        = "string"
+  type        = string
   default     = "flatcar-stable"
   description = "Flatcar Container Linux image for compute instanges (e.g. gcloud compute images list)"
 }
 
 variable "disk_size" {
-  type        = "string"
+  type        = string
   default     = "40"
   description = "Size of the disk in GB"
 }
 
 variable "preemptible" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "If enabled, Compute Engine will terminate instances randomly within 24 hours"
 }
@@ -55,12 +55,12 @@ variable "preemptible" {
 # configuration
 
 variable "kubeconfig" {
-  type        = "string"
+  type        = string
   description = "Must be set to `kubeconfig` output by cluster"
 }
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
@@ -70,18 +70,19 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
 
 variable "clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Container Linux Config snippets"
   default     = []
 }
@@ -89,13 +90,14 @@ variable "clc_snippets" {
 # unofficial, undocumented, unsupported, temporary
 
 variable "accelerator_type" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Google Compute Engine accelerator type (e.g. nvidia-tesla-k80, see gcloud compute accelerator-types list)"
 }
 
 variable "accelerator_count" {
-  type        = "string"
+  type        = string
   default     = "0"
   description = "Number of compute engine accelerators"
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
@@ -22,7 +22,7 @@ variable "network" {
 
 # instances
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of worker compute instances the instance group should manage"

--- a/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/variables.tf
@@ -100,4 +100,3 @@ variable "accelerator_count" {
   default     = "0"
   description = "Number of compute engine accelerators"
 }
-

--- a/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
@@ -8,7 +8,7 @@ resource "google_compute_region_instance_group_manager" "workers" {
   instance_template  = "${google_compute_instance_template.worker.self_link}"
   region             = "${var.region}"
 
-  target_size  = "${var.count}"
+  target_size  = "${var.worker_count}"
   target_pools = ["${google_compute_target_pool.workers.self_link}"]
 
   named_port {

--- a/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
@@ -5,11 +5,11 @@ resource "google_compute_region_instance_group_manager" "workers" {
 
   # instance name prefix for instances in the group
   base_instance_name = "${var.name}-worker"
-  instance_template  = "${google_compute_instance_template.worker.self_link}"
-  region             = "${var.region}"
+  instance_template  = google_compute_instance_template.worker.self_link
+  region             = var.region
 
-  target_size  = "${var.worker_count}"
-  target_pools = ["${google_compute_target_pool.workers.self_link}"]
+  target_size  = var.worker_count
+  target_pools = [google_compute_target_pool.workers.self_link]
 
   named_port {
     name = "http"
@@ -26,37 +26,38 @@ resource "google_compute_region_instance_group_manager" "workers" {
 resource "google_compute_instance_template" "worker" {
   name_prefix  = "${var.name}-worker-"
   description  = "Worker Instance template"
-  machine_type = "${var.machine_type}"
+  machine_type = var.machine_type
 
   metadata = {
-    user-data = "${data.ct_config.worker-ignition.rendered}"
+    user-data = data.ct_config.worker-ignition.rendered
   }
 
   scheduling {
-    automatic_restart = "${var.preemptible ? false : true}"
-    preemptible       = "${var.preemptible}"
+    automatic_restart = var.preemptible ? false : true
+    preemptible       = var.preemptible
   }
 
   disk {
     auto_delete  = true
     boot         = true
-    source_image = "${var.os_image}"
-    disk_size_gb = "${var.disk_size}"
+    source_image = var.os_image
+    disk_size_gb = var.disk_size
   }
 
   network_interface {
-    network = "${var.network}"
+    network = var.network
 
     # Ephemeral external IP
-    access_config = {}
+    access_config {
+    }
   }
 
   can_ip_forward = true
   tags           = ["worker", "${var.cluster_name}-worker", "${var.name}-worker"]
 
   guest_accelerator {
-    count = "${var.accelerator_count}"
-    type  = "${var.accelerator_type}"
+    count = var.accelerator_count
+    type  = var.accelerator_type
   }
 
   lifecycle {
@@ -67,19 +68,20 @@ resource "google_compute_instance_template" "worker" {
 
 # Worker Ignition config
 data "ct_config" "worker-ignition" {
-  content      = "${data.template_file.worker-config.rendered}"
+  content      = data.template_file.worker-config.rendered
   pretty_print = false
-  snippets     = ["${var.clc_snippets}"]
+  snippets     = var.clc_snippets
 }
 
 # Worker Container Linux config
 data "template_file" "worker-config" {
-  template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
+  template = file("${path.module}/cl/worker.yaml.tmpl")
 
   vars = {
-    kubeconfig             = "${indent(10, var.kubeconfig)}"
-    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    kubeconfig             = indent(10, var.kubeconfig)
+    ssh_keys               = jsonencode(var.ssh_keys)
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
+

--- a/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
+++ b/google-cloud/flatcar-linux/kubernetes/workers/workers.tf
@@ -84,4 +84,3 @@ data "template_file" "worker-config" {
     cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
-

--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -7,7 +7,7 @@ module "bootkube" {
   api_servers          = [data.template_file.controllernames[0].rendered]
   api_servers_external = libvirt_domain.controller-machine.*.network_interface.0.addresses.0
   api_servers_ips      = libvirt_domain.controller-machine.*.network_interface.0.addresses.0
-  etcd_servers         = [data.template_file.controllernames.*.rendered]
+  etcd_servers         = data.template_file.controllernames.*.rendered
   asset_dir            = var.asset_dir
   networking           = var.networking
   network_mtu          = var.network_mtu

--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -33,4 +33,3 @@ data "template_file" "controllernames" {
     machine_domain = var.machine_domain
   }
 }
-

--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -1,35 +1,36 @@
 module "bootkube" {
   source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
 
-  cluster_name = "${var.cluster_name}"
+  cluster_name = var.cluster_name
 
   # Cannot use cyclic dependencies on controllers or their DNS records
-  api_servers          = ["${data.template_file.controllernames.0.rendered}"]
-  api_servers_external = "${libvirt_domain.controller-machine.*.network_interface.0.addresses.0}"
-  api_servers_ips      = "${libvirt_domain.controller-machine.*.network_interface.0.addresses.0}"
-  etcd_servers         = ["${data.template_file.controllernames.*.rendered}"]
-  asset_dir            = "${var.asset_dir}"
-  networking           = "${var.networking}"
-  network_mtu          = "${var.network_mtu}"
+  api_servers          = [data.template_file.controllernames[0].rendered]
+  api_servers_external = libvirt_domain.controller-machine.*.network_interface.0.addresses.0
+  api_servers_ips      = libvirt_domain.controller-machine.*.network_interface.0.addresses.0
+  etcd_servers         = [data.template_file.controllernames.*.rendered]
+  asset_dir            = var.asset_dir
+  networking           = var.networking
+  network_mtu          = var.network_mtu
 
-  network_ip_autodetection_method = "${var.network_ip_autodetection_method}"
+  network_ip_autodetection_method = var.network_ip_autodetection_method
 
-  pod_cidr              = "${var.pod_cidr}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  enable_reporting      = "${var.enable_reporting}"
-  enable_aggregation    = "${var.enable_aggregation}"
+  pod_cidr              = var.pod_cidr
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  enable_reporting      = var.enable_reporting
+  enable_aggregation    = var.enable_aggregation
 
-  certs_validity_period_hours = "${var.certs_validity_period_hours}"
+  certs_validity_period_hours = var.certs_validity_period_hours
 }
 
 data "template_file" "controllernames" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   template = "$${cluster_name}-controller-$${index}.$${machine_domain}"
 
-  vars {
-    index          = "${count.index}"
-    cluster_name   = "${var.cluster_name}"
-    machine_domain = "${var.machine_domain}"
+  vars = {
+    index          = count.index
+    cluster_name   = var.cluster_name
+    machine_domain = var.machine_domain
   }
 }
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=0f3156c73b846bf1bc5dd4681879048c37fb2f25"
 
   cluster_name = var.cluster_name
 

--- a/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
@@ -102,4 +102,3 @@ data "template_file" "etcds" {
     cluster_name = var.cluster_name
   }
 }
-

--- a/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
@@ -11,50 +11,49 @@ resource "libvirt_pool" "volumetmp" {
 
 resource "libvirt_volume" "base" {
   name   = "${var.cluster_name}-base"
-  source = "${var.os_image_unpacked}"
-  pool   = "${libvirt_pool.volumetmp.name}"
+  source = var.os_image_unpacked
+  pool   = libvirt_pool.volumetmp.name
   format = "qcow2"
 }
 
 resource "libvirt_volume" "controller-disk" {
   name           = "${var.cluster_name}-controller-${count.index}.qcow2"
-  count          = "${var.controller_count}"
-  base_volume_id = "${libvirt_volume.base.id}"
-  pool           = "${libvirt_pool.volumetmp.name}"
+  count          = var.controller_count
+  base_volume_id = libvirt_volume.base.id
+  pool           = libvirt_pool.volumetmp.name
   format         = "qcow2"
 }
 
 resource "libvirt_ignition" "ignition" {
   name    = "${var.cluster_name}-controller-${count.index}-ignition"
-  pool    = "${libvirt_pool.volumetmp.name}"
-  count   = "${var.controller_count}"
-  content = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+  pool    = libvirt_pool.volumetmp.name
+  count   = var.controller_count
+  content = element(data.ct_config.controller-ignitions.*.rendered, count.index)
 }
 
 resource "libvirt_network" "vmnet" {
-  name      = "${var.cluster_name}"
+  name      = var.cluster_name
   mode      = "nat"
-  domain    = "${var.machine_domain}"
-  addresses = ["${var.node_ip_pool}"]
+  domain    = var.machine_domain
+  addresses = [var.node_ip_pool]
 
-  dns = {
+  dns {
     local_only = true
-
     # can specify local names here
   }
 }
 
 resource "libvirt_domain" "controller-machine" {
-  count  = "${var.controller_count}"
+  count  = var.controller_count
   name   = "${var.cluster_name}-controller-${count.index}"
-  vcpu   = "${var.virtual_cpus}"
-  memory = "${var.virtual_memory}"
+  vcpu   = var.virtual_cpus
+  memory = var.virtual_memory
 
   fw_cfg_name     = "opt/org.flatcar-linux/config"
-  coreos_ignition = "${element(libvirt_ignition.ignition.*.id, count.index)}"
+  coreos_ignition = element(libvirt_ignition.ignition.*.id, count.index)
 
   disk {
-    volume_id = "${element(libvirt_volume.controller-disk.*.id, count.index)}"
+    volume_id = element(libvirt_volume.controller-disk.*.id, count.index)
   }
 
   graphics {
@@ -62,41 +61,45 @@ resource "libvirt_domain" "controller-machine" {
   }
 
   network_interface {
-    network_id     = "${libvirt_network.vmnet.id}"
+    network_id     = libvirt_network.vmnet.id
     hostname       = "${var.cluster_name}-controller-${count.index}"
-    addresses      = ["${cidrhost(var.node_ip_pool, 10 + count.index)}"] # TODO: use as public addr in kubeconfig
+    addresses      = [cidrhost(var.node_ip_pool, 10 + count.index)] # TODO: use as public addr in kubeconfig
     wait_for_lease = true
   }
 }
 
 data "ct_config" "controller-ignitions" {
-  count    = "${var.controller_count}"
-  content  = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
-  snippets = ["${var.controller_clc_snippets}"]
+  count = var.controller_count
+  content = element(
+    data.template_file.controller-configs.*.rendered,
+    count.index,
+  )
+  snippets = var.controller_clc_snippets
 }
 
 data "template_file" "controller-configs" {
-  count    = "${var.controller_count}"
-  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+  count    = var.controller_count
+  template = file("${path.module}/cl/controller.yaml.tmpl")
 
-  vars {
+  vars = {
     # Cannot use cyclic dependencies on controllers or their DNS records
     etcd_name              = "${var.cluster_name}-controller-${count.index}"
     etcd_domain            = "${var.cluster_name}-controller-${count.index}.${var.machine_domain}"
-    etcd_initial_cluster   = "${join(",", data.template_file.etcds.*.rendered)}"
-    kubeconfig             = "${indent(10, module.bootkube.kubeconfig-kubelet)}"
-    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    etcd_initial_cluster   = join(",", data.template_file.etcds.*.rendered)
+    kubeconfig             = indent(10, module.bootkube.kubeconfig-kubelet)
+    ssh_keys               = jsonencode(var.ssh_keys)
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
 
 data "template_file" "etcds" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   template = "$${cluster_name}-controller-$${index}=https://$${cluster_name}-controller-$${index}.${var.machine_domain}:2380" # as etcd_domain above
 
-  vars {
-    index        = "${count.index}"
-    cluster_name = "${var.cluster_name}"
+  vars = {
+    index        = count.index
+    cluster_name = var.cluster_name
   }
 }
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/controllers.tf
@@ -28,7 +28,7 @@ resource "libvirt_ignition" "ignition" {
   name    = "${var.cluster_name}-controller-${count.index}-ignition"
   pool    = libvirt_pool.volumetmp.name
   count   = var.controller_count
-  content = element(data.ct_config.controller-ignitions.*.rendered, count.index)
+  content = data.ct_config.controller-ignitions[count.index].rendered
 }
 
 resource "libvirt_network" "vmnet" {
@@ -50,10 +50,10 @@ resource "libvirt_domain" "controller-machine" {
   memory = var.virtual_memory
 
   fw_cfg_name     = "opt/org.flatcar-linux/config"
-  coreos_ignition = element(libvirt_ignition.ignition.*.id, count.index)
+  coreos_ignition = libvirt_ignition.ignition[count.index].id
 
   disk {
-    volume_id = element(libvirt_volume.controller-disk.*.id, count.index)
+    volume_id = libvirt_volume.controller-disk[count.index].id
   }
 
   graphics {
@@ -69,11 +69,8 @@ resource "libvirt_domain" "controller-machine" {
 }
 
 data "ct_config" "controller-ignitions" {
-  count = var.controller_count
-  content = element(
-    data.template_file.controller-configs.*.rendered,
-    count.index,
-  )
+  count    = var.controller_count
+  content  = data.template_file.controller-configs[count.index].rendered
   snippets = var.controller_clc_snippets
 }
 

--- a/kvm-libvirt/flatcar-linux/kubernetes/outputs.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/outputs.tf
@@ -25,4 +25,3 @@ output "libvirtpool" {
 output "libvirtbaseid" {
   value = libvirt_volume.base.id
 }
-

--- a/kvm-libvirt/flatcar-linux/kubernetes/outputs.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/outputs.tf
@@ -1,27 +1,28 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin}"
+  value = module.bootkube.kubeconfig-admin
 }
 
 output "kubeconfig" {
-  value = "${module.bootkube.kubeconfig-kubelet}"
+  value = module.bootkube.kubeconfig-kubelet
 }
 
 output "machine_domain" {
-  value = "${var.machine_domain}"
+  value = var.machine_domain
 }
 
 output "cluster_name" {
-  value = "${var.cluster_name}"
+  value = var.cluster_name
 }
 
 output "ssh_keys" {
-  value = "${var.ssh_keys}"
+  value = var.ssh_keys
 }
 
 output "libvirtpool" {
-  value = "${libvirt_pool.volumetmp.name}"
+  value = libvirt_pool.volumetmp.name
 }
 
 output "libvirtbaseid" {
-  value = "${libvirt_volume.base.id}"
+  value = libvirt_volume.base.id
 }
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -28,4 +28,3 @@ provider "libvirt" {
   version = "~> 0.6.0"
   uri     = "qemu:///system"
 }
-

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -28,3 +28,4 @@ provider "libvirt" {
   version = "~> 0.6.0"
   uri     = "qemu:///system"
 }
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.11.0"
+  required_version = ">= 0.12.0"
 }
 
 provider "ct" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/require.tf
@@ -25,6 +25,6 @@ provider "tls" {
 }
 
 provider "libvirt" {
-  version = "~> 0.5.3"
+  version = "~> 0.6.0"
   uri     = "qemu:///system"
 }

--- a/kvm-libvirt/flatcar-linux/kubernetes/ssh.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/ssh.tf
@@ -3,11 +3,8 @@ resource "null_resource" "copy-controller-secrets" {
   count = var.controller_count
 
   connection {
-    type = "ssh"
-    host = element(
-      libvirt_domain.controller-machine.*.network_interface.0.addresses.0,
-      count.index,
-    )
+    type    = "ssh"
+    host    = libvirt_domain.controller-machine[count.index].network_interface.0.addresses.0
     user    = "core"
     timeout = "15m"
   }

--- a/kvm-libvirt/flatcar-linux/kubernetes/ssh.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/ssh.tf
@@ -70,7 +70,7 @@ resource "null_resource" "bootkube-start" {
 
   connection {
     type    = "ssh"
-    host    = libvirt_domain.controller-machine[0].network_interface[0].addresses
+    host    = libvirt_domain.controller-machine[0].network_interface[0].addresses[0]
     user    = "core"
     timeout = "15m"
   }

--- a/kvm-libvirt/flatcar-linux/kubernetes/ssh.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/ssh.tf
@@ -1,46 +1,49 @@
 # Secure copy etcd TLS assets to controllers.
 resource "null_resource" "copy-controller-secrets" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   connection {
-    type    = "ssh"
-    host    =  "${element(libvirt_domain.controller-machine.*.network_interface.0.addresses.0, count.index)}"
+    type = "ssh"
+    host = element(
+      libvirt_domain.controller-machine.*.network_interface.0.addresses.0,
+      count.index,
+    )
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_ca_cert}"
+    content     = module.bootkube.etcd_ca_cert
     destination = "$HOME/etcd-client-ca.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_cert}"
+    content     = module.bootkube.etcd_client_cert
     destination = "$HOME/etcd-client.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_client_key}"
+    content     = module.bootkube.etcd_client_key
     destination = "$HOME/etcd-client.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_cert}"
+    content     = module.bootkube.etcd_server_cert
     destination = "$HOME/etcd-server.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_server_key}"
+    content     = module.bootkube.etcd_server_key
     destination = "$HOME/etcd-server.key"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_cert}"
+    content     = module.bootkube.etcd_peer_cert
     destination = "$HOME/etcd-peer.crt"
   }
 
   provisioner "file" {
-    content     = "${module.bootkube.etcd_peer_key}"
+    content     = module.bootkube.etcd_peer_key
     destination = "$HOME/etcd-peer.key"
   }
 
@@ -64,20 +67,19 @@ resource "null_resource" "copy-controller-secrets" {
 # one-time self-hosted cluster bootstrapping.
 resource "null_resource" "bootkube-start" {
   depends_on = [
-    "module.bootkube",
-    # "module.workers",
-    "null_resource.copy-controller-secrets",
+    module.bootkube,
+    null_resource.copy-controller-secrets,
   ]
 
   connection {
     type    = "ssh"
-    host    = "${libvirt_domain.controller-machine.0.network_interface.0.addresses}"
+    host    = libvirt_domain.controller-machine[0].network_interface[0].addresses
     user    = "core"
     timeout = "15m"
   }
 
   provisioner "file" {
-    source      = "${var.asset_dir}"
+    source      = var.asset_dir
     destination = "$HOME/assets"
   }
 

--- a/kvm-libvirt/flatcar-linux/kubernetes/ssh.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/ssh.tf
@@ -90,4 +90,3 @@ resource "null_resource" "bootkube-start" {
     ]
   }
 }
-

--- a/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
@@ -1,47 +1,47 @@
 # DNS records
 
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name"
 }
 
 # Nodes
 variable "os_image_unpacked" {
-  type        = "string"
+  type        = string
   description = "Path to unpacked Flatcar Container Linux image flatcar_production_qemu_image.img (probably after a qemu-img resize IMG +5G)"
 }
 
 variable "controller_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "machine_domain" {
-  type        = "string"
+  type        = string
   description = "Machine domain"
 }
 
 variable "node_ip_pool" {
-  type        = "string"
+  type        = string
   default     = "192.168.192.0/24"
   description = "Unique VM IP CIDR"
 }
 
 variable "virtual_cpus" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of virtual CPUs"
 }
 
 variable "virtual_memory" {
-  type        = "string"
+  type        = string
   default     = "2048"
   description = "Virtual RAM in MB"
 }
 
 variable "controller_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
@@ -49,36 +49,36 @@ variable "controller_clc_snippets" {
 # Configuration
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "networking" {
   description = "Choice of networking provider (flannel or calico)"
-  type        = "string"
+  type        = string
   default     = "calico"
 }
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only)"
-  type        = "string"
+  type        = string
   default     = "1480"
 }
 
 variable "network_ip_autodetection_method" {
   description = "Method to autodetect the host IPv4 address (applies to calico only)"
-  type        = "string"
+  type        = string
   default     = "first-found"
 }
 
 variable "pod_cidr" {
   description = "CIDR IPv4 range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.1.0.0/16"
 }
 
@@ -88,25 +88,26 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.2.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type        = string
   description = "Enable usage or analytics reporting to upstreams (Calico)"
   default     = "false"
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
@@ -114,6 +115,7 @@ variable "enable_aggregation" {
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = "string"
+  type        = string
   default     = 8760
 }
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
@@ -12,8 +12,8 @@ variable "os_image_unpacked" {
 }
 
 variable "controller_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of controllers (i.e. masters)"
 }
 
@@ -29,14 +29,14 @@ variable "node_ip_pool" {
 }
 
 variable "virtual_cpus" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of virtual CPUs"
 }
 
 variable "virtual_memory" {
-  type        = string
-  default     = "2048"
+  type        = number
+  default     = 2048
   description = "Virtual RAM in MB"
 }
 
@@ -66,8 +66,8 @@ variable "networking" {
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only)"
-  type        = string
-  default     = "1480"
+  type        = number
+  default     = 1480
 }
 
 variable "network_ip_autodetection_method" {
@@ -100,21 +100,21 @@ variable "cluster_domain_suffix" {
 }
 
 variable "enable_reporting" {
-  type        = string
+  type        = bool
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = "false"
+  default     = false
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 # Certificates
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = string
+  type        = number
   default     = 8760
 }

--- a/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/variables.tf
@@ -118,4 +118,3 @@ variable "certs_validity_period_hours" {
   type        = string
   default     = 8760
 }
-

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
@@ -24,3 +24,4 @@ provider "libvirt" {
   version = "~> 0.6.0"
   uri     = "qemu:///system"
 }
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.11.0"
+  required_version = ">= 0.12.0"
 }
 
 provider "ct" {

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
@@ -21,6 +21,6 @@ provider "tls" {
 }
 
 provider "libvirt" {
-  version = "~> 0.5.3"
+  version = "~> 0.6.0"
   uri     = "qemu:///system"
 }

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/require.tf
@@ -24,4 +24,3 @@ provider "libvirt" {
   version = "~> 0.6.0"
   uri     = "qemu:///system"
 }
-

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
@@ -15,7 +15,7 @@ variable "pool_name" {
   description = "Unique worker pool name (prepended to hostname)"
 }
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of workers"

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
@@ -16,20 +16,20 @@ variable "pool_name" {
 }
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of workers"
 }
 
 variable "virtual_cpus" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of virtual CPUs"
 }
 
 variable "virtual_memory" {
-  type        = string
-  default     = "2048"
+  type        = number
+  default     = 2048
   description = "Virtual RAM in MB"
 }
 

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
@@ -83,4 +83,3 @@ EOD
   type    = string
   default = "10.2.0.0/16"
 }
-

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/variables.tf
@@ -1,34 +1,34 @@
 # Cluster
 
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
 variable "machine_domain" {
-  type        = "string"
+  type        = string
   description = "Machine domain"
 }
 
 variable "pool_name" {
-  type        = "string"
+  type        = string
   description = "Unique worker pool name (prepended to hostname)"
 }
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of workers"
 }
 
 variable "virtual_cpus" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of virtual CPUs"
 }
 
 variable "virtual_memory" {
-  type        = "string"
+  type        = string
   default     = "2048"
   description = "Virtual RAM in MB"
 }
@@ -36,40 +36,40 @@ variable "virtual_memory" {
 # TODO: migrate to `templatefile` when Terraform `0.12` is out and use `{% for ~}`
 # to avoid specifying `--node-labels` again when the var is empty.
 variable "labels" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Custom labels to assign to worker nodes. Provide comma separated key=value pairs as labels. e.g. 'foo=oof,bar=,baz=zab'"
 }
 
 variable "libvirtpool" {
-  type        = "string"
+  type        = string
   description = "libvirt volume pool with base image"
 }
 
 variable "libvirtbaseid" {
-  type        = "string"
+  type        = string
   description = "base image id for libvirt"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
 
 variable "clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Container Linux Config snippets"
   default     = []
 }
 
 variable "kubeconfig" {
   description = "Kubeconfig file"
-  type        = "string"
+  type        = string
 }
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
@@ -79,6 +79,8 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.2.0.0/16"
 }
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,29 +1,29 @@
 resource "libvirt_volume" "worker-disk" {
   name           = "${var.cluster_name}-${var.pool_name}-worker-${count.index}.qcow2"
-  count          = "${var.worker_count}"
-  base_volume_id = "${var.libvirtbaseid}"
-  pool           = "${var.libvirtpool}"
+  count          = var.worker_count
+  base_volume_id = var.libvirtbaseid
+  pool           = var.libvirtpool
   format         = "qcow2"
 }
 
 resource "libvirt_ignition" "ignition" {
   name    = "${var.cluster_name}-${var.pool_name}-worker-${count.index}-ignition"
-  pool    = "${var.libvirtpool}"
-  count   = "${var.worker_count}"
-  content = "${element(data.ct_config.worker-ignition.*.rendered, count.index)}"
+  pool    = var.libvirtpool
+  count   = var.worker_count
+  content = element(data.ct_config.worker-ignition.*.rendered, count.index)
 }
 
 resource "libvirt_domain" "worker-machine" {
-  count  = "${var.worker_count}"
+  count  = var.worker_count
   name   = "${var.cluster_name}-${var.pool_name}-worker-${count.index}"
-  vcpu   = "${var.virtual_cpus}"
-  memory = "${var.virtual_memory}"
+  vcpu   = var.virtual_cpus
+  memory = var.virtual_memory
 
   fw_cfg_name     = "opt/org.flatcar-linux/config"
-  coreos_ignition = "${element(libvirt_ignition.ignition.*.id, count.index)}"
+  coreos_ignition = element(libvirt_ignition.ignition.*.id, count.index)
 
   disk {
-    volume_id = "${element(libvirt_volume.worker-disk.*.id, count.index)}"
+    volume_id = element(libvirt_volume.worker-disk.*.id, count.index)
   }
 
   graphics {
@@ -31,27 +31,28 @@ resource "libvirt_domain" "worker-machine" {
   }
 
   network_interface {
-    network_name   = "${var.cluster_name}"
+    network_name   = var.cluster_name
     hostname       = "${var.cluster_name}-${var.pool_name}-worker-${count.index}"
     wait_for_lease = true
   }
 }
 
 data "ct_config" "worker-ignition" {
-  count    = "${var.worker_count}"
-  content  = "${element(data.template_file.worker-config.*.rendered, count.index)}"
-  snippets = ["${var.clc_snippets}"]
+  count    = var.worker_count
+  content  = element(data.template_file.worker-config.*.rendered, count.index)
+  snippets = var.clc_snippets
 }
 
 data "template_file" "worker-config" {
-  count    = "${var.worker_count}"
-  template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
+  count    = var.worker_count
+  template = file("${path.module}/cl/worker.yaml.tmpl")
 
-  vars {
+  vars = {
     domain_name            = "${var.cluster_name}-${var.pool_name}-worker-${count.index}.${var.machine_domain}"
-    kubeconfig             = "${indent(10, "${var.kubeconfig}")}"
-    ssh_keys               = "${jsonencode("${var.ssh_keys}")}"
-    cluster_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix  = "${var.cluster_domain_suffix}"
+    kubeconfig             = indent(10, var.kubeconfig)
+    ssh_keys               = jsonencode(var.ssh_keys)
+    cluster_dns_service_ip = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
+

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
@@ -55,4 +55,3 @@ data "template_file" "worker-config" {
     cluster_domain_suffix  = var.cluster_domain_suffix
   }
 }
-

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,6 +1,6 @@
 resource "libvirt_volume" "worker-disk" {
   name           = "${var.cluster_name}-${var.pool_name}-worker-${count.index}.qcow2"
-  count          = "${var.count}"
+  count          = "${var.worker_count}"
   base_volume_id = "${var.libvirtbaseid}"
   pool           = "${var.libvirtpool}"
   format         = "qcow2"
@@ -9,12 +9,12 @@ resource "libvirt_volume" "worker-disk" {
 resource "libvirt_ignition" "ignition" {
   name    = "${var.cluster_name}-${var.pool_name}-worker-${count.index}-ignition"
   pool    = "${var.libvirtpool}"
-  count   = "${var.count}"
+  count   = "${var.worker_count}"
   content = "${element(data.ct_config.worker-ignition.*.rendered, count.index)}"
 }
 
 resource "libvirt_domain" "worker-machine" {
-  count  = "${var.count}"
+  count  = "${var.worker_count}"
   name   = "${var.cluster_name}-${var.pool_name}-worker-${count.index}"
   vcpu   = "${var.virtual_cpus}"
   memory = "${var.virtual_memory}"
@@ -38,13 +38,13 @@ resource "libvirt_domain" "worker-machine" {
 }
 
 data "ct_config" "worker-ignition" {
-  count    = "${var.count}"
+  count    = "${var.worker_count}"
   content  = "${element(data.template_file.worker-config.*.rendered, count.index)}"
   snippets = ["${var.clc_snippets}"]
 }
 
 data "template_file" "worker-config" {
-  count    = "${var.count}"
+  count    = "${var.worker_count}"
   template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
 
   vars {

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/workers.tf
@@ -10,7 +10,7 @@ resource "libvirt_ignition" "ignition" {
   name    = "${var.cluster_name}-${var.pool_name}-worker-${count.index}-ignition"
   pool    = var.libvirtpool
   count   = var.worker_count
-  content = element(data.ct_config.worker-ignition.*.rendered, count.index)
+  content = data.ct_config.worker-ignition[count.index].rendered
 }
 
 resource "libvirt_domain" "worker-machine" {
@@ -20,10 +20,10 @@ resource "libvirt_domain" "worker-machine" {
   memory = var.virtual_memory
 
   fw_cfg_name     = "opt/org.flatcar-linux/config"
-  coreos_ignition = element(libvirt_ignition.ignition.*.id, count.index)
+  coreos_ignition = libvirt_ignition.ignition[count.index].id
 
   disk {
-    volume_id = element(libvirt_volume.worker-disk.*.id, count.index)
+    volume_id = libvirt_volume.worker-disk[count.index].id
   }
 
   graphics {
@@ -39,7 +39,7 @@ resource "libvirt_domain" "worker-machine" {
 
 data "ct_config" "worker-ignition" {
   count    = var.worker_count
-  content  = element(data.template_file.worker-config.*.rendered, count.index)
+  content  = data.template_file.worker-config[count.index].rendered
   snippets = var.clc_snippets
 }
 

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -25,4 +25,3 @@ module "bootkube" {
 
   container_arch = var.os_arch
 }
-

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -1,27 +1,28 @@
 module "bootkube" {
   source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
 
-  cluster_name = "${var.cluster_name}"
+  cluster_name = var.cluster_name
 
   # Cannot use cyclic dependencies on controllers or their DNS records
-  api_servers          = ["${format("%s-private.%s", var.cluster_name, var.dns_zone)}"]
-  api_servers_external = ["${format("%s.%s", var.cluster_name, var.dns_zone)}"]
-  etcd_servers         = "${aws_route53_record.etcds.*.fqdn}"
-  asset_dir            = "${var.asset_dir}"
-  networking           = "${var.networking}"
-  network_mtu          = "${var.network_mtu}"
+  api_servers          = [format("%s-private.%s", var.cluster_name, var.dns_zone)]
+  api_servers_external = [format("%s.%s", var.cluster_name, var.dns_zone)]
+  etcd_servers         = aws_route53_record.etcds.*.fqdn
+  asset_dir            = var.asset_dir
+  networking           = var.networking
+  network_mtu          = var.network_mtu
 
   # Select private Packet NIC by using the can-reach Calico autodetection option with the first
   # host in our private CIDR.
   network_ip_autodetection_method = "can-reach=${cidrhost(var.node_private_cidr, 1)}"
 
-  pod_cidr              = "${var.pod_cidr}"
-  service_cidr          = "${var.service_cidr}"
-  cluster_domain_suffix = "${var.cluster_domain_suffix}"
-  enable_reporting      = "${var.enable_reporting}"
-  enable_aggregation    = "${var.enable_aggregation}"
+  pod_cidr              = var.pod_cidr
+  service_cidr          = var.service_cidr
+  cluster_domain_suffix = var.cluster_domain_suffix
+  enable_reporting      = var.enable_reporting
+  enable_aggregation    = var.enable_aggregation
 
-  certs_validity_period_hours = "${var.certs_validity_period_hours}"
+  certs_validity_period_hours = var.certs_validity_period_hours
 
-  container_arch = "${var.os_arch}"
+  container_arch = var.os_arch
 }
+

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -1,5 +1,5 @@
 module "bootkube" {
-  source = "github.com/kinvolk/terraform-render-bootkube?ref=555822f998208058bd60baf67138289ba3cd2ccb"
+  source = "github.com/kinvolk/terraform-render-bootkube?ref=0f3156c73b846bf1bc5dd4681879048c37fb2f25"
 
   cluster_name = var.cluster_name
 

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -54,7 +54,7 @@ resource "packet_device" "controllers" {
   )
 
   ipxe_script_url = var.ipxe_script_url
-  always_pxe      = "false"
+  always_pxe      = false
 }
 
 data "ct_config" "controller-install-ignitions" {

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -127,4 +127,3 @@ data "template_file" "etcds" {
     dns_zone     = var.dns_zone
   }
 }
-

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -1,118 +1,130 @@
 # Discrete DNS records for each controller's private IPv4 for etcd usage
 resource "aws_route53_record" "etcds" {
-  count = "${var.controller_count}"
+  count = var.controller_count
 
   # DNS Zone where record should be created
-  zone_id = "${var.dns_zone_id}"
+  zone_id = var.dns_zone_id
 
-  name = "${format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)}"
+  name = format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)
   type = "A"
   ttl  = 300
 
   # private IPv4 address for etcd
-  records = ["${element(packet_device.controllers.*.access_private_ipv4, count.index)}"]
+  records = [element(packet_device.controllers.*.access_private_ipv4, count.index)]
 }
 
 # DNS record for the API servers
 resource "aws_route53_record" "apiservers" {
-  zone_id = "${var.dns_zone_id}"
+  zone_id = var.dns_zone_id
 
-  name = "${format("%s.%s.", var.cluster_name, var.dns_zone)}"
+  name = format("%s.%s.", var.cluster_name, var.dns_zone)
   type = "A"
   ttl  = "300"
 
   # TODO - verify that a multi-controller setup actually works
-  records = ["${packet_device.controllers.*.access_public_ipv4}"]
+  records = packet_device.controllers.*.access_public_ipv4
 }
 
 resource "aws_route53_record" "apiservers_private" {
-  zone_id = "${var.dns_zone_id}"
+  zone_id = var.dns_zone_id
 
-  name = "${format("%s-private.%s.", var.cluster_name, var.dns_zone)}"
+  name = format("%s-private.%s.", var.cluster_name, var.dns_zone)
   type = "A"
   ttl  = "300"
 
   # TODO - verify that a multi-controller setup actually works
-  records = ["${packet_device.controllers.*.access_private_ipv4}"]
+  records = packet_device.controllers.*.access_private_ipv4
 }
 
 resource "packet_device" "controllers" {
-  count            = "${var.controller_count}"
+  count            = var.controller_count
   hostname         = "${var.cluster_name}-controller-${count.index}"
-  plan             = "${var.controller_type}"
-  facilities       = ["${var.facility}"]
-  operating_system = "${var.ipxe_script_url != "" ? "custom_ipxe" : format("flatcar_%s", var.os_channel)}"
+  plan             = var.controller_type
+  facilities       = [var.facility]
+  operating_system = var.ipxe_script_url != "" ? "custom_ipxe" : format("flatcar_%s", var.os_channel)
   billing_cycle    = "hourly"
-  project_id       = "${var.project_id}"
-  user_data        = "${var.ipxe_script_url != "" ? element(data.ct_config.controller-install-ignitions.*.rendered, count.index) : element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+  project_id       = var.project_id
+  user_data = var.ipxe_script_url != "" ? element(
+    data.ct_config.controller-install-ignitions.*.rendered,
+    count.index,
+  ) : element(data.ct_config.controller-ignitions.*.rendered, count.index)
 
   # If not present in the map, it uses ${var.reservation_ids_default}.
-  hardware_reservation_id = "${lookup(var.reservation_ids, format("controller-%v", count.index), var.reservation_ids_default)}"
+  hardware_reservation_id = lookup(
+    var.reservation_ids,
+    format("controller-%v", count.index),
+    var.reservation_ids_default,
+  )
 
-  ipxe_script_url  = "${var.ipxe_script_url}"
-  always_pxe       = "false"
+  ipxe_script_url = var.ipxe_script_url
+  always_pxe      = "false"
 }
 
 data "ct_config" "controller-install-ignitions" {
-  count   = "${var.controller_count}"
-  content = "${element(data.template_file.controller-install.*.rendered, count.index)}"
+  count = var.controller_count
+  content = element(
+    data.template_file.controller-install.*.rendered,
+    count.index,
+  )
 }
 
 data "template_file" "controller-install" {
-  count    = "${var.controller_count}"
-  template = "${file("${path.module}/cl/controller-install.yaml.tmpl")}"
+  count    = var.controller_count
+  template = file("${path.module}/cl/controller-install.yaml.tmpl")
 
-  vars {
-    os_channel           = "${var.os_channel}"
-    os_version           = "${var.os_version}"
-    os_arch              = "${var.os_arch}"
+  vars = {
+    os_channel           = var.os_channel
+    os_version           = var.os_version
+    os_arch              = var.os_arch
     flatcar_linux_oem    = "packet"
-    ssh_keys             = "${jsonencode("${var.ssh_keys}")}"
-    postinstall_ignition = "${element(data.ct_config.controller-ignitions.*.rendered, count.index)}"
+    ssh_keys             = jsonencode(var.ssh_keys)
+    postinstall_ignition = element(data.ct_config.controller-ignitions.*.rendered, count.index)
   }
 }
 
 data "ct_config" "controller-ignitions" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   platform = "packet"
-  content  = "${element(data.template_file.controller-configs.*.rendered, count.index)}"
-  snippets     = ["${var.controller_clc_snippets}"]
+  content = element(
+    data.template_file.controller-configs.*.rendered,
+    count.index,
+  )
+  snippets = var.controller_clc_snippets
 }
 
 data "template_file" "controller-configs" {
-  count    = "${var.controller_count}"
-  template = "${file("${path.module}/cl/controller.yaml.tmpl")}"
+  count    = var.controller_count
+  template = file("${path.module}/cl/controller.yaml.tmpl")
 
-  vars {
-    os_arch = "${var.os_arch}"
-
+  vars = {
+    os_arch = var.os_arch
     # Cannot use cyclic dependencies on controllers or their DNS records
-    etcd_name             = "etcd${count.index}"
-    etcd_domain           = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
+    etcd_name   = "etcd${count.index}"
+    etcd_domain = "${var.cluster_name}-etcd${count.index}.${var.dns_zone}"
     # we need to prepend a prefix 'docker://' for arm64, because arm64 images
     # on quay prevent us from downloading ACI correctly.
     # So it's workaround to download arm64 images until quay images could be fixed.
-    etcd_arch_url_prefix  = "${var.os_arch == "arm64" ? "docker://" : ""}"
-    etcd_arch_tag_suffix  = "${var.os_arch == "arm64" ? "-arm64" : ""}"
-    etcd_arch_rkt_args    = "${var.os_arch == "arm64" ? "--insecure-options=image" : ""}"
-    etcd_arch_options     = "${var.os_arch == "arm64" ? "ETCD_UNSUPPORTED_ARCH=arm64" : ""}"
-
+    etcd_arch_url_prefix = var.os_arch == "arm64" ? "docker://" : ""
+    etcd_arch_tag_suffix = var.os_arch == "arm64" ? "-arm64" : ""
+    etcd_arch_rkt_args   = var.os_arch == "arm64" ? "--insecure-options=image" : ""
+    etcd_arch_options    = var.os_arch == "arm64" ? "ETCD_UNSUPPORTED_ARCH=arm64" : ""
     # etcd0=https://cluster-etcd0.example.com,etcd1=https://cluster-etcd1.example.com,...
-    etcd_initial_cluster  = "${join(",", data.template_file.etcds.*.rendered)}"
-    kubeconfig            = "${indent(10, module.bootkube.kubeconfig-kubelet)}"
-    ssh_keys              = "${jsonencode("${var.ssh_keys}")}"
-    k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix = "${var.cluster_domain_suffix}"
+    etcd_initial_cluster  = join(",", data.template_file.etcds.*.rendered)
+    kubeconfig            = indent(10, module.bootkube.kubeconfig-kubelet)
+    ssh_keys              = jsonencode(var.ssh_keys)
+    k8s_dns_service_ip    = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix = var.cluster_domain_suffix
   }
 }
 
 data "template_file" "etcds" {
-  count    = "${var.controller_count}"
+  count    = var.controller_count
   template = "etcd$${index}=https://$${cluster_name}-etcd$${index}.$${dns_zone}:2380"
 
-  vars {
-    index        = "${count.index}"
-    cluster_name = "${var.cluster_name}"
-    dns_zone     = "${var.dns_zone}"
+  vars = {
+    index        = count.index
+    cluster_name = var.cluster_name
+    dns_zone     = var.dns_zone
   }
 }
+

--- a/packet/flatcar-linux/kubernetes/outputs.tf
+++ b/packet/flatcar-linux/kubernetes/outputs.tf
@@ -5,4 +5,3 @@ output "kubeconfig-admin" {
 output "kubeconfig" {
   value = module.bootkube.kubeconfig-kubelet
 }
-

--- a/packet/flatcar-linux/kubernetes/outputs.tf
+++ b/packet/flatcar-linux/kubernetes/outputs.tf
@@ -1,7 +1,8 @@
 output "kubeconfig-admin" {
-  value = "${module.bootkube.kubeconfig-admin}"
+  value = module.bootkube.kubeconfig-admin
 }
 
 output "kubeconfig" {
-  value = "${module.bootkube.kubeconfig-kubelet}"
+  value = module.bootkube.kubeconfig-kubelet
 }
+

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -25,7 +25,7 @@ provider "tls" {
 }
 
 provider "packet" {
-  version = "~> 1.4"
+  version = "~> 2.7.3"
 }
 
 provider "aws" {

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.11.0"
+  required_version = ">= 0.12.0"
 }
 
 provider "ct" {

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -31,4 +31,3 @@ provider "packet" {
 provider "aws" {
   version = "2.31.0"
 }
-

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -31,3 +31,4 @@ provider "packet" {
 provider "aws" {
   version = "2.31.0"
 }
+

--- a/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/packet/flatcar-linux/kubernetes/ssh.tf
@@ -125,4 +125,3 @@ data "template_file" "host_protection_policy" {
     etcd_server_cidrs      = jsonencode(packet_device.controllers.*.access_private_ipv4)
   }
 }
-

--- a/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/packet/flatcar-linux/kubernetes/ssh.tf
@@ -4,7 +4,7 @@ resource "null_resource" "copy-controller-secrets" {
 
   connection {
     type    = "ssh"
-    host    = element(packet_device.controllers.*.access_public_ipv4, count.index)
+    host    = packet_device.controllers[count.index].access_public_ipv4
     user    = "core"
     timeout = "60m"
   }
@@ -108,7 +108,7 @@ data "template_file" "controller_host_endpoints" {
   template = file("${path.module}/calico/controller-host-endpoint.yaml.tmpl")
 
   vars = {
-    node_name = element(packet_device.controllers.*.hostname, count.index)
+    node_name = packet_device.controllers[count.index].hostname
   }
 }
 

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -180,4 +180,3 @@ variable "certs_validity_period_hours" {
   type        = string
   default     = 8760
 }
-

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -40,8 +40,8 @@ variable "os_version" {
 }
 
 variable "controller_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of controllers (i.e. masters)"
 }
 
@@ -98,8 +98,8 @@ variable "networking" {
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only)"
-  type        = string
-  default     = "1480"
+  type        = number
+  default     = 1480
 }
 
 variable "network_ip_autodetection_method" {
@@ -132,9 +132,9 @@ variable "cluster_domain_suffix" {
 }
 
 variable "enable_reporting" {
-  type        = string
+  type        = bool
   description = "Enable usage or analytics reporting to upstreams (Calico)"
-  default     = "false"
+  default     = false
 }
 
 variable "management_cidrs" {
@@ -149,8 +149,8 @@ variable "node_private_cidr" {
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "reservation_ids" {
@@ -177,6 +177,6 @@ EOD
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = string
+  type        = number
   default     = 8760
 }

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -1,17 +1,17 @@
 # DNS records
 
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
 variable "dns_zone" {
-  type        = "string"
+  type        = string
   description = "AWS Route53 DNS Zone (e.g. aws.example.com)"
 }
 
 variable "dns_zone_id" {
-  type        = "string"
+  type        = string
   description = "AWS Route53 DNS Zone ID (e.g. Z3PAABBCFAKEC0)"
 }
 
@@ -22,37 +22,37 @@ variable "project_id" {
 # Nodes
 
 variable "os_arch" {
-  type        = "string"
+  type        = string
   default     = "amd64"
   description = "Flatcar Container Linux architecture to install (amd64, arm64)"
 }
 
 variable "os_channel" {
-  type        = "string"
+  type        = string
   default     = "stable"
   description = "Flatcar Container Linux channel to install from (stable, beta, alpha, edge)"
 }
 
 variable "os_version" {
-  type        = "string"
+  type        = string
   default     = "current"
   description = "Flatcar Container Linux version to install (for example '2191.5.0' - see https://www.flatcar-linux.org/releases/), only for iPXE"
 }
 
 variable "controller_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of controllers (i.e. masters)"
 }
 
 variable "controller_type" {
-  type        = "string"
+  type        = string
   default     = "baremetal_0"
   description = "Packet instance type for controllers"
 }
 
 variable "ipxe_script_url" {
-  type = "string"
+  type = string
 
   # Note: iPXE-booting Flatcar on Packet over HTTPS is failing due to a bug in iPXE.
   # This patch is supposed to fix this: http://git.ipxe.org/ipxe.git/commitdiff/b6ffe28a2
@@ -68,12 +68,12 @@ variable "ipxe_script_url" {
 }
 
 variable "facility" {
-  type        = "string"
+  type        = string
   description = "Packet facility to deploy the cluster in"
 }
 
 variable "controller_clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Controller Container Linux Config snippets"
   default     = []
 }
@@ -81,36 +81,36 @@ variable "controller_clc_snippets" {
 # Configuration
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
 variable "asset_dir" {
   description = "Path to a directory where generated assets should be placed (contains secrets)"
-  type        = "string"
+  type        = string
 }
 
 variable "networking" {
   description = "Choice of networking provider (flannel or calico)"
-  type        = "string"
+  type        = string
   default     = "calico"
 }
 
 variable "network_mtu" {
   description = "CNI interface MTU (applies to calico only)"
-  type        = "string"
+  type        = string
   default     = "1480"
 }
 
 variable "network_ip_autodetection_method" {
   description = "Method to autodetect the host IPv4 address (applies to calico only)"
-  type        = "string"
+  type        = string
   default     = "first-found"
 }
 
 variable "pod_cidr" {
   description = "CIDR IPv4 range to assign Kubernetes pods"
-  type        = "string"
+  type        = string
   default     = "10.2.0.0/16"
 }
 
@@ -120,41 +120,42 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.3.0.0/16"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
 
 variable "enable_reporting" {
-  type        = "string"
+  type        = string
   description = "Enable usage or analytics reporting to upstreams (Calico)"
   default     = "false"
 }
 
 variable "management_cidrs" {
   description = "List of IPv4 CIDRs authorized to access or manage the cluster"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "node_private_cidr" {
   description = "Private IPv4 CIDR of the nodes used to allow inter-node traffic"
-  type        = "string"
+  type        = string
 }
 
 variable "enable_aggregation" {
   description = "Enable the Kubernetes Aggregation Layer (defaults to false)"
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
 variable "reservation_ids" {
-  description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'controller-${index}' and the value is the reservation ID. Nodes not present in the map will use the value of `reservation_ids_default` variable. Example: reservation_ids = { controller-0 = \"<reservation_id>\" }"
-  type        = "map"
+  description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'controller-$${index}' and the value is the reservation ID. Nodes not present in the map will use the value of `reservation_ids_default` variable. Example: reservation_ids = { controller-0 = \"<reservation_id>\" }"
+  type        = map(string)
   default     = {}
 }
 
@@ -167,7 +168,8 @@ map. An empty string means "use no hardware reservation". `next-available` will
 choose any reservation that matches the pool's device type and facility.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = ""
 }
 
@@ -175,6 +177,7 @@ EOD
 
 variable "certs_validity_period_hours" {
   description = "Validity of all the certificates in hours"
-  type        = "string"
+  type        = string
   default     = 8760
 }
+

--- a/packet/flatcar-linux/kubernetes/workers/outputs.tf
+++ b/packet/flatcar-linux/kubernetes/workers/outputs.tf
@@ -5,4 +5,3 @@ output "worker_nodes_hostname" {
 output "worker_nodes_public_ipv4" {
   value = packet_device.nodes.*.access_public_ipv4
 }
-

--- a/packet/flatcar-linux/kubernetes/workers/outputs.tf
+++ b/packet/flatcar-linux/kubernetes/workers/outputs.tf
@@ -1,7 +1,8 @@
 output "worker_nodes_hostname" {
-  value = "${packet_device.nodes.*.hostname}"
+  value = packet_device.nodes.*.hostname
 }
 
 output "worker_nodes_public_ipv4" {
-  value = "${packet_device.nodes.*.access_public_ipv4}"
+  value = packet_device.nodes.*.access_public_ipv4
 }
+

--- a/packet/flatcar-linux/kubernetes/workers/require.tf
+++ b/packet/flatcar-linux/kubernetes/workers/require.tf
@@ -23,3 +23,4 @@ provider "tls" {
 provider "packet" {
   version = "~> 2.7.3"
 }
+

--- a/packet/flatcar-linux/kubernetes/workers/require.tf
+++ b/packet/flatcar-linux/kubernetes/workers/require.tf
@@ -1,7 +1,7 @@
 # Terraform version and plugin versions
 
 terraform {
-  required_version = ">= 0.11.0"
+  required_version = ">= 0.12.0"
 }
 
 provider "ct" {

--- a/packet/flatcar-linux/kubernetes/workers/require.tf
+++ b/packet/flatcar-linux/kubernetes/workers/require.tf
@@ -23,4 +23,3 @@ provider "tls" {
 provider "packet" {
   version = "~> 2.7.3"
 }
-

--- a/packet/flatcar-linux/kubernetes/workers/require.tf
+++ b/packet/flatcar-linux/kubernetes/workers/require.tf
@@ -21,5 +21,5 @@ provider "tls" {
 }
 
 provider "packet" {
-  version = "~> 1.4"
+  version = "~> 2.7.3"
 }

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -1,7 +1,7 @@
 # Cluster
 
 variable "cluster_name" {
-  type        = "string"
+  type        = string
   description = "Unique cluster name (prepended to dns_zone)"
 }
 
@@ -12,24 +12,24 @@ variable "project_id" {
 # Nodes
 
 variable "pool_name" {
-  type        = "string"
+  type        = string
   description = "Unique worker pool name (prepended to hostname)"
 }
 
 variable "worker_count" {
-  type        = "string"
+  type        = string
   default     = "1"
   description = "Number of workers, can be changed afterwards to delete or add nodes"
 }
 
 variable "type" {
-  type        = "string"
+  type        = string
   default     = "baremetal_0"
   description = "Packet instance type for workers, can be changed afterwards to recreate the nodes"
 }
 
 variable "clc_snippets" {
-  type        = "list"
+  type        = list(string)
   description = "Container Linux Config snippets"
   default     = []
 }
@@ -37,19 +37,19 @@ variable "clc_snippets" {
 # TODO: migrate to `templatefile` when Terraform `0.12` is out and use `{% for ~}`
 # to avoid specifying `--node-labels` again when the var is empty.
 variable "labels" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Custom labels to assign to worker nodes. Provide comma separated key=value pairs as labels. e.g. 'foo=oof,bar=,baz=zab'"
 }
 
 variable "taints" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Comma separated list of taints. eg. 'clusterType=staging:NoSchedule,nodeType=storage:NoSchedule'"
 }
 
 variable "ipxe_script_url" {
-  type = "string"
+  type = string
 
   # Note: iPXE-booting Flatcar on Packet over HTTPS is failing due to a bug in iPXE.
   # This patch is supposed to fix this: http://git.ipxe.org/ipxe.git/commitdiff/b6ffe28a2
@@ -65,41 +65,41 @@ variable "ipxe_script_url" {
 }
 
 variable "facility" {
-  type        = "string"
+  type        = string
   description = "Packet facility to deploy the cluster in"
 }
 
 variable "os_arch" {
-  type        = "string"
+  type        = string
   default     = "amd64"
   description = "Flatcar Container Linux architecture to install (amd64, arm64)"
 }
 
 variable "os_channel" {
-  type        = "string"
+  type        = string
   default     = "stable"
   description = "Flatcar Container Linux channel to install from (stable, beta, alpha, edge)"
 }
 
 variable "os_version" {
-  type        = "string"
+  type        = string
   default     = "current"
   description = "Flatcar Container Linux version to install (for example '2191.5.0' - see https://www.flatcar-linux.org/releases/), only for iPXE"
 }
 
 variable "cluster_domain_suffix" {
   description = "Queries for domains with the suffix will be answered by coredns. Default is cluster.local (e.g. foo.default.svc.cluster.local) "
-  type        = "string"
+  type        = string
   default     = "cluster.local"
 }
 
 variable "kubeconfig" {
   description = "Kubeconfig file"
-  type        = "string"
+  type        = string
 }
 
 variable "ssh_keys" {
-  type        = "list"
+  type        = list(string)
   description = "SSH public keys for user 'core'"
 }
 
@@ -109,37 +109,38 @@ CIDR IPv4 range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for coredns.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = "10.3.0.0/16"
 }
 
 variable "setup_raid" {
   description = "Attempt to create a RAID 0 from extra disks to be used for persistent container storage. Can't be used with setup_raid_hdd nor setup_raid_sdd. Valid values: \"true\", \"false\""
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
 variable "setup_raid_hdd" {
   description = "Attempt to create a RAID 0 from extra Hard Disk drives only, to be used for persistent container storage. Can't be used with setup_raid nor setup_raid_sdd. Valid values: \"true\", \"false\""
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
 variable "setup_raid_ssd" {
   description = "Attempt to create a RAID 0 from extra Solid State Drives only, to be used for persistent container storage.  Can't be used with setup_raid nor setup_raid_hdd. Valid values: \"true\", \"false\""
-  type        = "string"
+  type        = string
   default     = "false"
 }
 
 variable "setup_raid_ssd_fs" {
   description = "When set to \"true\" file system will be created on SSD RAID device and will be mounted on /mnt/node-local-ssd-storage. To use the raw device set it to \"false\". Valid values: \"true\", \"false\""
-  type        = "string"
+  type        = string
   default     = "true"
 }
 
 variable "reservation_ids" {
-  description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'worker-${index}' and the value is the reservation ID. Nodes not present in the map will use the value of `reservation_ids_default` variable. Example: reservation_ids = { worker-0 = \"<reservation_id>\" }"
-  type        = "map"
+  description = "Specify Packet hardware_reservation_id for instances. A map where the key format is 'worker-$${index}' and the value is the reservation ID. Nodes not present in the map will use the value of `reservation_ids_default` variable. Example: reservation_ids = { worker-0 = \"<reservation_id>\" }"
+  type        = map(string)
   default     = {}
 }
 
@@ -152,12 +153,14 @@ map. An empty string means "use no hardware reservation". `next-available` will
 choose any reservation that matches the worker pool's device type and facility.
 EOD
 
-  type    = "string"
+
+  type    = string
   default = ""
 }
 
 variable "disable_bgp" {
   description = "Disable BGP on nodes. Nodes won't be able to connect to Packet BGP peers. Note that BGP is used to receive internet traffic directed to Packet elastic IPs"
-  type        = "string"
+  type        = string
   default     = "false"
 }
+

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -16,7 +16,7 @@ variable "pool_name" {
   description = "Unique worker pool name (prepended to hostname)"
 }
 
-variable "count" {
+variable "worker_count" {
   type        = "string"
   default     = "1"
   description = "Number of workers, can be changed afterwards to delete or add nodes"

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -163,4 +163,3 @@ variable "disable_bgp" {
   type        = string
   default     = "false"
 }
-

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -17,8 +17,8 @@ variable "pool_name" {
 }
 
 variable "worker_count" {
-  type        = string
-  default     = "1"
+  type        = number
+  default     = 1
   description = "Number of workers, can be changed afterwards to delete or add nodes"
 }
 
@@ -116,26 +116,26 @@ EOD
 
 variable "setup_raid" {
   description = "Attempt to create a RAID 0 from extra disks to be used for persistent container storage. Can't be used with setup_raid_hdd nor setup_raid_sdd. Valid values: \"true\", \"false\""
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "setup_raid_hdd" {
   description = "Attempt to create a RAID 0 from extra Hard Disk drives only, to be used for persistent container storage. Can't be used with setup_raid nor setup_raid_sdd. Valid values: \"true\", \"false\""
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "setup_raid_ssd" {
   description = "Attempt to create a RAID 0 from extra Solid State Drives only, to be used for persistent container storage.  Can't be used with setup_raid nor setup_raid_hdd. Valid values: \"true\", \"false\""
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }
 
 variable "setup_raid_ssd_fs" {
   description = "When set to \"true\" file system will be created on SSD RAID device and will be mounted on /mnt/node-local-ssd-storage. To use the raw device set it to \"false\". Valid values: \"true\", \"false\""
-  type        = string
-  default     = "true"
+  type        = bool
+  default     = true
 }
 
 variable "reservation_ids" {
@@ -160,6 +160,6 @@ EOD
 
 variable "disable_bgp" {
   description = "Disable BGP on nodes. Nodes won't be able to connect to Packet BGP peers. Note that BGP is used to receive internet traffic directed to Packet elastic IPs"
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
 }

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,5 +1,5 @@
 resource "packet_device" "nodes" {
-  count            = "${var.count}"
+  count            = "${var.worker_count}"
   hostname         = "${var.cluster_name}-${var.pool_name}-worker-${count.index}"
   plan             = "${var.type}"
   facilities       = ["${var.facility}"]
@@ -33,7 +33,7 @@ data "template_file" "install" {
 }
 
 resource "packet_bgp_session" "bgp" {
-  count          = "${var.disable_bgp == "true" ? 0 : var.count}"
+  count          = "${var.disable_bgp == "true" ? 0 : var.worker_count}"
   device_id      = "${packet_device.nodes.*.id[count.index]}"
   address_family = "ipv4"
 }

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -1,63 +1,68 @@
 resource "packet_device" "nodes" {
-  count            = "${var.worker_count}"
+  count            = var.worker_count
   hostname         = "${var.cluster_name}-${var.pool_name}-worker-${count.index}"
-  plan             = "${var.type}"
-  facilities       = ["${var.facility}"]
-  operating_system = "${var.ipxe_script_url != "" ? "custom_ipxe" : format("flatcar_%s", var.os_channel)}"
+  plan             = var.type
+  facilities       = [var.facility]
+  operating_system = var.ipxe_script_url != "" ? "custom_ipxe" : format("flatcar_%s", var.os_channel)
   billing_cycle    = "hourly"
-  project_id       = "${var.project_id}"
-  ipxe_script_url  = "${var.ipxe_script_url}"
+  project_id       = var.project_id
+  ipxe_script_url  = var.ipxe_script_url
   always_pxe       = "false"
-  user_data        = "${var.ipxe_script_url != "" ? data.ct_config.install-ignitions.rendered : data.ct_config.ignitions.rendered}"
+  user_data        = var.ipxe_script_url != "" ? data.ct_config.install-ignitions.rendered : data.ct_config.ignitions.rendered
 
   # If not present in the map, it uses ${var.reservation_ids_default}.
-  hardware_reservation_id = "${lookup(var.reservation_ids, format("worker-%v", count.index), var.reservation_ids_default)}"
+  hardware_reservation_id = lookup(
+    var.reservation_ids,
+    format("worker-%v", count.index),
+    var.reservation_ids_default,
+  )
 }
 
 data "ct_config" "install-ignitions" {
-  content = "${data.template_file.install.rendered}"
+  content = data.template_file.install.rendered
 }
 
 # These configs are used for the fist boot, to run flatcar-install
 data "template_file" "install" {
-  template = "${file("${path.module}/cl/install.yaml.tmpl")}"
+  template = file("${path.module}/cl/install.yaml.tmpl")
 
-  vars {
-    os_channel           = "${var.os_channel}"
-    os_version           = "${var.os_version}"
-    os_arch              = "${var.os_arch}"
+  vars = {
+    os_channel           = var.os_channel
+    os_version           = var.os_version
+    os_arch              = var.os_arch
     flatcar_linux_oem    = "packet"
-    ssh_keys             = "${jsonencode("${var.ssh_keys}")}"
-    postinstall_ignition = "${data.ct_config.ignitions.rendered}"
+    ssh_keys             = jsonencode(var.ssh_keys)
+    postinstall_ignition = data.ct_config.ignitions.rendered
   }
 }
 
 resource "packet_bgp_session" "bgp" {
-  count          = "${var.disable_bgp == "true" ? 0 : var.worker_count}"
-  device_id      = "${packet_device.nodes.*.id[count.index]}"
+  count          = var.disable_bgp == "true" ? 0 : var.worker_count
+  device_id      = packet_device.nodes[count.index].id
   address_family = "ipv4"
 }
 
 data "ct_config" "ignitions" {
-  content  = "${data.template_file.configs.rendered}"
+  content  = data.template_file.configs.rendered
   platform = "packet"
-  snippets     = ["${var.clc_snippets}"]
+  snippets = var.clc_snippets
 }
 
 data "template_file" "configs" {
-  template = "${file("${path.module}/cl/worker.yaml.tmpl")}"
+  template = file("${path.module}/cl/worker.yaml.tmpl")
 
-  vars {
-    os_arch               = "${var.os_arch}"
-    kubeconfig            = "${indent(10, "${var.kubeconfig}")}"
-    ssh_keys              = "${jsonencode("${var.ssh_keys}")}"
-    k8s_dns_service_ip    = "${cidrhost(var.service_cidr, 10)}"
-    cluster_domain_suffix = "${var.cluster_domain_suffix}"
-    worker_labels         = "${var.labels}"
-    taints                = "${var.taints}"
-    setup_raid            = "${var.setup_raid}"
-    setup_raid_hdd        = "${var.setup_raid_hdd}"
-    setup_raid_ssd        = "${var.setup_raid_ssd}"
-    setup_raid_ssd_fs     = "${var.setup_raid_ssd_fs}"
+  vars = {
+    os_arch               = var.os_arch
+    kubeconfig            = indent(10, var.kubeconfig)
+    ssh_keys              = jsonencode(var.ssh_keys)
+    k8s_dns_service_ip    = cidrhost(var.service_cidr, 10)
+    cluster_domain_suffix = var.cluster_domain_suffix
+    worker_labels         = var.labels
+    taints                = var.taints
+    setup_raid            = var.setup_raid
+    setup_raid_hdd        = var.setup_raid_hdd
+    setup_raid_ssd        = var.setup_raid_ssd
+    setup_raid_ssd_fs     = var.setup_raid_ssd_fs
   }
 }
+

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -65,4 +65,3 @@ data "template_file" "configs" {
     setup_raid_ssd_fs     = var.setup_raid_ssd_fs
   }
 }
-

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -7,7 +7,7 @@ resource "packet_device" "nodes" {
   billing_cycle    = "hourly"
   project_id       = var.project_id
   ipxe_script_url  = var.ipxe_script_url
-  always_pxe       = "false"
+  always_pxe       = false
   user_data        = var.ipxe_script_url != "" ? data.ct_config.install-ignitions.rendered : data.ct_config.ignitions.rendered
 
   # If not present in the map, it uses ${var.reservation_ids_default}.
@@ -37,7 +37,7 @@ data "template_file" "install" {
 }
 
 resource "packet_bgp_session" "bgp" {
-  count          = var.disable_bgp == "true" ? 0 : var.worker_count
+  count          = var.disable_bgp == true ? 0 : var.worker_count
   device_id      = packet_device.nodes[count.index].id
   address_family = "ipv4"
 }


### PR DESCRIPTION
## Description

This PR is based and supersedes https://github.com/kinvolk/lokomotive-kubernetes/pull/45. It migrates the different providers and updates the documentation accordingly.

I would need some help here to test the providers I already tested and also to test the ones I wasn't able to test yet. 

The commits are organized as follows:
- preparatory commits, includes also fixes for some already existing problems, like https://github.com/kinvolk/lokomotive-kubernetes/pull/116.
- run terraform 0.12upgrade, just run it without fixing anything.
- fixes the problems introduced by the above.
- update documentation / examples / ci.
- use some features of Terraform 0.12, like array notation and  specific data types.

### Status
- Aws,  Azure, Google Cloud and Packet providers have been migrated and tested.
- Baremetal and kvm-libvirt have been migrated but not tested yet.
- DigitalOcean hasn't been migrated.

### Testing

Given that it is a quite large PR, I'm adding this table to check that all plaforms are tested.
Please add your name (so we can blame you later on [not true :rofl: ]) when you test a platform.

| Platform | Tester 1 | Tester 2 | Tester 3? |
|------------ |-------------|------------|-------------|
| AWS | @mauriciovasquezbernal  | | | 
| Azure | @mauriciovasquezbernal  | | |
| Bare Metal | | | |
| Google-Cloud | @mauriciovasquezbernal  | | |
| KVM-libvirt | @ipochi | | |
| Packet | @mauriciovasquezbernal  | @johananl  | |

### TODO

- [ ] Update bootkube module source once https://github.com/kinvolk/terraform-render-bootkube/pull/33 is merged.
- [ ] Update CI.
