### PR TITLE
ci: Ship helper script to select the terraform binary

### DIFF
--- a/ci/set-terraform-version
+++ b/ci/set-terraform-version
@@ -1,0 +1,2 @@
+#!/bin/sh
+ln -fs ~/.local/bin/terraform11 ~/.local/bin/terraform


### PR DESCRIPTION
When e.g. Terraform 0.11 instead of 0.12 is required, the symlink target `terraform11` can be changed to `terraform12`.