### PR TITLE
Typo fix in kvm-libvirt.md

### DIFF
--- a/docs/flatcar-linux/kvm-libvirt.md
+++ b/docs/flatcar-linux/kvm-libvirt.md
@@ -188,7 +188,7 @@ module "worker-pool-one" {
     libvirt  = libvirt.default
   }
 
-  ssh_keys = "module.controller.ssh_keys
+  ssh_keys = "module.controller.ssh_keys"
 
   machine_domain = module.controller.machine_domain
   cluster_name = module.controller.cluster_name


### PR DESCRIPTION
Added a single " to make format valid