### PR TITLE
packet: Abstract DNS records

### DIFF
--- a/ci/packet-arm/packet-arm-cluster.tf.envsubst
+++ b/ci/packet-arm/packet-arm-cluster.tf.envsubst
@@ -2,7 +2,6 @@ module "controller" {
   source = "../../packet/flatcar-linux/kubernetes"
 
   dns_zone = "$AWS_DNS_ZONE"
-  dns_zone_id = "$AWS_DNS_ZONE_ID"
 
   ssh_keys = ["$PUB_KEY"]
 
@@ -23,6 +22,14 @@ module "controller" {
   ]
 
   node_private_cidr = "10.0.0.0/8"
+}
+
+module "dns" {
+  source = "../../dns/route53"
+
+  entries = module.controller.dns_entries
+
+  aws_zone_id = "$AWS_DNS_ZONE_ID"
 }
 
 module "worker-pool-1" {

--- a/ci/packet/packet-cluster.tf.envsubst
+++ b/ci/packet/packet-cluster.tf.envsubst
@@ -2,7 +2,6 @@ module "controller" {
   source = "../../packet/flatcar-linux/kubernetes"
 
   dns_zone = "$AWS_DNS_ZONE"
-  dns_zone_id = "$AWS_DNS_ZONE_ID"
 
   ssh_keys = ["$PUB_KEY"]
 
@@ -20,6 +19,14 @@ module "controller" {
   ]
 
   node_private_cidr = "10.0.0.0/8"
+}
+
+module "dns" {
+  source = "../../dns/route53"
+
+  entries = module.controller.dns_entries
+
+  aws_zone_id = "$AWS_DNS_ZONE_ID"
 }
 
 module "worker-pool-1" {

--- a/dns/route53/main.tf
+++ b/dns/route53/main.tf
@@ -1,0 +1,27 @@
+variable "entries" {
+  type = list(
+    object({
+      name    = string
+      type    = string
+      ttl     = number
+      records = list(string)
+    })
+  )
+}
+
+variable "aws_zone_id" {
+  type        = string
+  description = "AWS Route53 DNS Zone ID (e.g. Z3PAABBCFAKEC0)"
+}
+
+resource "aws_route53_record" "dns-records" {
+  count = length(var.entries)
+
+  # Route53 DNS Zone where record should be created
+  zone_id = var.aws_zone_id
+
+  name    = var.entries[count.index].name
+  type    = var.entries[count.index].type
+  ttl     = var.entries[count.index].ttl
+  records = var.entries[count.index].records
+}

--- a/dns/route53/require.tf
+++ b/dns/route53/require.tf
@@ -1,0 +1,9 @@
+# Terraform version and plugin versions
+
+terraform {
+  required_version = ">= 0.12.0"
+
+  required_providers {
+    aws = "2.31.0"
+  }
+}

--- a/docs/dns/route53.md
+++ b/docs/dns/route53.md
@@ -1,0 +1,43 @@
+# Route53 DNS provider
+
+This module uses the AWS Route53 service to setup the DNS entries required for the cluster.
+
+Include the following snippet in your configuration to use this module:
+
+```tf
+module "dns" {
+  source = "git::https://github.com/kinvolk/lokomotive-kubernetes//dns/route53?ref=<hash>"
+
+  entries = module.controller.dns_entries
+
+  aws_zone_id = "<zone_id>" # e.g. Z3PAABBCFAKEC0
+}
+```
+
+## AWS Credentials
+
+Login to your AWS IAM dashboard and find your IAM user. Select "Security Credentials" and create an access key. Save the id and secret to a file that can be referenced in configs.
+
+```
+[default]
+aws_access_key_id = xxx
+aws_secret_access_key = yyy
+```
+
+!!! tip
+    Other standard AWS authentication methods can be used instead of specifying `shared_credentials_file` under the provider's config. For more information see the [docs](https://www.terraform.io/docs/providers/aws/#authentication).
+
+Configure the AWS provider to use your access key credentials in a `providers.tf` file.
+
+```
+provider "aws" {
+  version = "2.31.0"
+  alias   = "default"
+
+  region                  = "eu-central-1"
+  shared_credentials_file = "/home/user/.config/aws/credentials"
+}
+```
+
+Additional configuration options are described in the `aws` provider [docs](https://www.terraform.io/docs/providers/aws/).
+

--- a/packet/flatcar-linux/kubernetes/bootkube.tf
+++ b/packet/flatcar-linux/kubernetes/bootkube.tf
@@ -3,9 +3,9 @@ module "bootkube" {
   cluster_name = var.cluster_name
 
   # Cannot use cyclic dependencies on controllers or their DNS records
-  api_servers          = [format("%s-private.%s", var.cluster_name, var.dns_zone)]
-  api_servers_external = [format("%s.%s", var.cluster_name, var.dns_zone)]
-  etcd_servers         = aws_route53_record.etcds.*.fqdn
+  api_servers          = [local.api_fqdn]
+  api_servers_external = [local.api_external_fqdn]
+  etcd_servers         = local.etcd_fqdn
   asset_dir            = var.asset_dir
   networking           = var.networking
   network_mtu          = var.network_mtu

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -1,39 +1,7 @@
-# Discrete DNS records for each controller's private IPv4 for etcd usage
-resource "aws_route53_record" "etcds" {
-  count = var.controller_count
-
-  # DNS Zone where record should be created
-  zone_id = var.dns_zone_id
-
-  name = format("%s-etcd%d.%s.", var.cluster_name, count.index, var.dns_zone)
-  type = "A"
-  ttl  = 300
-
-  # private IPv4 address for etcd
-  records = [packet_device.controllers[count.index].access_private_ipv4]
-}
-
-# DNS record for the API servers
-resource "aws_route53_record" "apiservers" {
-  zone_id = var.dns_zone_id
-
-  name = format("%s.%s.", var.cluster_name, var.dns_zone)
-  type = "A"
-  ttl  = "300"
-
-  # TODO - verify that a multi-controller setup actually works
-  records = packet_device.controllers.*.access_public_ipv4
-}
-
-resource "aws_route53_record" "apiservers_private" {
-  zone_id = var.dns_zone_id
-
-  name = format("%s-private.%s.", var.cluster_name, var.dns_zone)
-  type = "A"
-  ttl  = "300"
-
-  # TODO - verify that a multi-controller setup actually works
-  records = packet_device.controllers.*.access_private_ipv4
+locals {
+  api_external_fqdn = format("%s.%s.", var.cluster_name, var.dns_zone)
+  api_fqdn = format("%s-private.%s.", var.cluster_name, var.dns_zone)
+  etcd_fqdn = [for index, device in packet_device.controllers: format("%s-etcd%d.%s.", var.cluster_name, index, var.dns_zone)]
 }
 
 resource "packet_device" "controllers" {

--- a/packet/flatcar-linux/kubernetes/outputs.tf
+++ b/packet/flatcar-linux/kubernetes/outputs.tf
@@ -5,3 +5,34 @@ output "kubeconfig-admin" {
 output "kubeconfig" {
   value = module.bootkube.kubeconfig-kubelet
 }
+
+output "dns_entries" {
+  value = concat(
+    # etcd
+    [
+      for device in packet_device.controllers:
+      {
+        name    = local.etcd_fqdn[index(packet_device.controllers, device)],
+        type    = "A",
+        ttl     = 300,
+        records = [device.access_private_ipv4],
+      }
+    ],
+    [
+      # apiserver public
+      {
+        name    = local.api_external_fqdn
+        type    = "A",
+        ttl     = 300,
+        records = packet_device.controllers.*.access_public_ipv4,
+      },
+      # apiserver private
+      {
+        name    = local.api_fqdn,
+        type    = "A",
+        ttl     = 300,
+        records = packet_device.controllers.*.access_private_ipv4,
+      },
+    ]
+  )
+}

--- a/packet/flatcar-linux/kubernetes/require.tf
+++ b/packet/flatcar-linux/kubernetes/require.tf
@@ -10,6 +10,5 @@ terraform {
     template = "~> 2.1"
     tls      = "~> 2.0"
     packet   = "~> 2.7.3"
-    aws      = "2.31.0"
   }
 }

--- a/packet/flatcar-linux/kubernetes/ssh.tf
+++ b/packet/flatcar-linux/kubernetes/ssh.tf
@@ -68,7 +68,6 @@ resource "null_resource" "copy-controller-secrets" {
 resource "null_resource" "copy-assets-dir" {
   depends_on = [
     module.bootkube,
-    aws_route53_record.apiservers,
     null_resource.copy-controller-secrets,
   ]
 
@@ -93,7 +92,6 @@ resource "null_resource" "calico-host-endpoint-manifests" {
 
   depends_on = [
     module.bootkube,
-    aws_route53_record.apiservers,
     null_resource.copy-controller-secrets,
     null_resource.copy-assets-dir,
   ]
@@ -120,7 +118,6 @@ resource "null_resource" "calico-host-endpoint-manifests" {
 resource "null_resource" "bootkube-start" {
   depends_on = [
     module.bootkube,
-    aws_route53_record.apiservers,
     null_resource.copy-controller-secrets,
     null_resource.copy-assets-dir,
     null_resource.calico-host-endpoint-manifests,

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -7,12 +7,7 @@ variable "cluster_name" {
 
 variable "dns_zone" {
   type        = string
-  description = "AWS Route53 DNS Zone (e.g. aws.example.com)"
-}
-
-variable "dns_zone_id" {
-  type        = string
-  description = "AWS Route53 DNS Zone ID (e.g. Z3PAABBCFAKEC0)"
+  description = "DNS Zone (e.g. example.com)"
 }
 
 variable "project_id" {


### PR DESCRIPTION
Currently an AWS account is needed to deploy a cluster in Packet because the DNS provider is harcoded to be Route53. This is a limitation as some users do not have an AWS account.

This PR proposes a solution to that by abstracting the DNS provider concept. Now the user can choose which provider to use by defining a module like the following in their configuration:

```
module "dns" {
  source = "/home/mvb/lokomotive-kubernetes/dns/route53/"

  entries = module.controller.dns_entries
  aws_zone_id = "Z1QEP94KB3YNR3"
}
```

It is even possible to no use a DNS provider at all and create the DNS entries by hand by following this procedure:

```bash
  # Create controller nodes (you could also create worker nodes to save time)
  terraform apply -target=module.controller.packet_device.controllers

  # Get list of DNS entries to be created
  terraform output dns_entries

  # Create the DNS entries by hand

  # Finish deploying the cluster
  terraform apply
```

This PR creates a DNS provider module for Route53, more modules can be easily added in the future.