### PR TITLE
docs: Fix asset path for Packet documentation

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -233,7 +233,7 @@ In 5-10 minutes, the Kubernetes cluster will be ready.
 [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) on your system. Use the generated `kubeconfig` credentials to access the Kubernetes cluster and list nodes.
 
 ```
-$ export KUBECONFIG=/home/user/.secrets/clusters/tempest/auth/kubeconfig
+$ export KUBECONFIG=/home/user/.secrets/clusters/packet/auth/kubeconfig
 $ kubectl get nodes
 NAME                       STATUS  ROLES              AGE  VERSION
 supernova-controller-0     Ready   controller,master  10m  v1.14.1


### PR DESCRIPTION
In the "Verify" step of the Packet docs, the asset path is actually the one from the tempest documentation rather than the one defined in the example configuration above.

This commit changes the directory to the correct one.