### PR TITLE
packet: fix DNS entries output

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -281,10 +281,10 @@ Lokomotive implements support for some [DNS providers](../dns/), if your provide
 
 ```bash
   # Create controller nodes (you could also create worker nodes to save time)
-  terraform apply -target=module.controller.packet_device.controllers
+  terraform apply -target=module.controller.null_resource.dns_entries
 
   # Get list of DNS entries to be created
-  terraform output dns_entries
+  terraform state show module.controller.null_resource.dns_entries
 
   # Create the DNS entries by hand
 

--- a/packet/flatcar-linux/kubernetes/outputs.tf
+++ b/packet/flatcar-linux/kubernetes/outputs.tf
@@ -7,32 +7,5 @@ output "kubeconfig" {
 }
 
 output "dns_entries" {
-  value = concat(
-    # etcd
-    [
-      for device in packet_device.controllers:
-      {
-        name    = local.etcd_fqdn[index(packet_device.controllers, device)],
-        type    = "A",
-        ttl     = 300,
-        records = [device.access_private_ipv4],
-      }
-    ],
-    [
-      # apiserver public
-      {
-        name    = local.api_external_fqdn
-        type    = "A",
-        ttl     = 300,
-        records = packet_device.controllers.*.access_public_ipv4,
-      },
-      # apiserver private
-      {
-        name    = local.api_fqdn,
-        type    = "A",
-        ttl     = 300,
-        records = packet_device.controllers.*.access_private_ipv4,
-      },
-    ]
-  )
+  value = local.dns_entries
 }


### PR DESCRIPTION
Create a null_resource to force the name of the domains to be computed,
otherwise they will be null on the output.

Also fix the documentation for the user to get the list of entries from the
null resource as the output from internal modules is nost saved on the state
on Terraform 0.12.