### PR TITLE
ci/packet: use t1.small for controller nodes

### DIFF
--- a/ci/packet/packet-cluster.tf.envsubst
+++ b/ci/packet/packet-cluster.tf.envsubst
@@ -12,7 +12,6 @@ module "controller" {
   facility = "ams1"
 
   controller_count = 1
-  controller_type  = "c2.medium.x86"
 
   management_cidrs = [
     "0.0.0.0/0",       # Instances can be SSH-ed into from anywhere on the internet.


### PR DESCRIPTION
We first changed server type, then the location, but for other
pipelines, it seems that ams1 has no problem with t1.small availability.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>