### PR TITLE
aws: split variable os_image into os_name, os_channel, os_version

### DIFF
--- a/aws/flatcar-linux/kubernetes/ami.tf
+++ b/aws/flatcar-linux/kubernetes/ami.tf
@@ -1,11 +1,10 @@
 locals {
   # Pick a CoreOS Container Linux derivative
-  # coreos-stable -> CoreOS Container Linux AMI
-  # flatcar-stable -> Flatcar Container Linux AMI
   ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
 
-  flavor  = split("-", var.os_image)[0]
-  channel = split("-", var.os_image)[1]
+  flavor  = var.os_name
+  channel = var.os_channel
+  ver = var.os_version == "current" ? "" : var.os_version
 }
 
 data "aws_ami" "coreos" {
@@ -24,7 +23,7 @@ data "aws_ami" "coreos" {
 
   filter {
     name   = "name"
-    values = ["CoreOS-${local.flavor == "coreos" ? local.channel : "stable"}-*"]
+    values = ["CoreOS-${local.flavor == "coreos" ? local.channel : "stable"}-${local.flavor == "coreos" ? local.ver : ""}*"]
   }
 }
 
@@ -44,6 +43,6 @@ data "aws_ami" "flatcar" {
 
   filter {
     name   = "name"
-    values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-*"]
+    values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-${local.flavor == "flatcar" ? local.ver : ""}*"]
   }
 }

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -41,10 +41,22 @@ variable "worker_type" {
   description = "EC2 instance type for workers"
 }
 
-variable "os_image" {
+variable "os_name" {
   type        = string
-  default     = "flatcar-stable"
-  description = "AMI channel for a CoreOS Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
+  default     = "flatcar"
+  description = "Name of Operating System (coreos or flatcar)"
+}
+
+variable "os_channel" {
+  type        = string
+  default     = "stable"
+  description = "AMI channel for the OS (stable, beta, alpha, edge)"
+}
+
+variable "os_version" {
+  type        = string
+  default     = "current"
+  description = "Version of the OS (current or numeric version such as 2261.99.0)"
 }
 
 variable "disk_size" {

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -8,7 +8,9 @@ module "workers" {
   security_groups = [aws_security_group.worker.id]
   worker_count    = var.worker_count
   instance_type   = var.worker_type
-  os_image        = var.os_image
+  os_name         = var.os_name
+  os_channel      = var.os_channel
+  os_version      = var.os_version
   disk_size       = var.disk_size
   spot_price      = var.worker_price
   target_groups   = var.worker_target_groups

--- a/aws/flatcar-linux/kubernetes/workers/ami.tf
+++ b/aws/flatcar-linux/kubernetes/workers/ami.tf
@@ -1,11 +1,10 @@
 locals {
   # Pick a CoreOS Container Linux derivative
-  # coreos-stable -> CoreOS Container Linux AMI
-  # flatcar-stable -> Flatcar Container Linux AMI
   ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
 
-  flavor  = split("-", var.os_image)[0]
-  channel = split("-", var.os_image)[1]
+  flavor  = var.os_name
+  channel = var.os_channel
+  ver = var.os_version == "current" ? "" : var.os_version
 }
 
 data "aws_ami" "coreos" {
@@ -24,7 +23,7 @@ data "aws_ami" "coreos" {
 
   filter {
     name   = "name"
-    values = ["CoreOS-${local.flavor == "coreos" ? local.channel : "stable"}-*"]
+    values = ["CoreOS-${local.flavor == "coreos" ? local.channel : "stable"}-${local.flavor == "coreos" ? local.ver : ""}*"]
   }
 }
 
@@ -44,6 +43,6 @@ data "aws_ami" "flatcar" {
 
   filter {
     name   = "name"
-    values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-*"]
+    values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-${local.flavor == "flatcar" ? local.ver : ""}*"]
   }
 }

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -34,10 +34,22 @@ variable "instance_type" {
   description = "EC2 instance type"
 }
 
-variable "os_image" {
+variable "os_name" {
   type        = string
-  default     = "flatcar-stable"
-  description = "AMI channel for a CoreOS Container Linux derivative (coreos-stable, coreos-beta, coreos-alpha, flatcar-stable, flatcar-beta, flatcar-alpha)"
+  default     = "flatcar"
+  description = "Name of Operating System (coreos or flatcar)"
+}
+
+variable "os_channel" {
+  type        = string
+  default     = "stable"
+  description = "AMI channel for the OS (stable, beta, alpha, edge)"
+}
+
+variable "os_version" {
+  type        = string
+  default     = "current"
+  description = "Version of the OS (current or numeric version such as 2261.99.0)"
 }
 
 variable "disk_size" {

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -214,7 +214,9 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | worker_count | Number of workers | 1 | 3 |
 | controller_type | EC2 instance type for controllers | "t3.small" | See below |
 | worker_type | EC2 instance type for workers | "t3.small" | See below |
-| os_image | AMI channel for Flatcar Container Linux | "flatcar-stable" | "flatcar-stable", "flatcar-beta", "flatcar-alpha" |
+| os_name    | Name of the Operating System | "flatcar" | "flatcar", "coreos" |
+| os_channel | Channel for the OS           | "stable"  | "stable", "beta", "alpha", "edge" |
+| os_version | Version of the OS            | "current" | "current" or numeric version such as "2261.99.0" |
 | disk_size | Size of the EBS volume in GB | 40 | 100 |
 | disk_type | Type of the EBS volume | "gp2" | "standard", "gp2", "io1" |
 | disk_iops | IOPS of the EBS volume | 0 (i.e. auto) | 400 |


### PR DESCRIPTION
_(description updated to match the discussion in the PR)_

Before this patch, the variable os_image was composite in the form
'$os-$channel' such as 'flatcar-stable'.

This patch changes split the variable to follow the model in Packet.
We now have:
- os_name = coreos | flatcar
- os_channel = stable | beta | alpha | edge (like in Packet)
- os_version = current | 2261.99.0 (new feature, like in Packet)
