### PR TITLE
aws: remove dependency on coreos images

### DIFF
--- a/aws/flatcar-linux/kubernetes/ami.tf
+++ b/aws/flatcar-linux/kubernetes/ami.tf
@@ -1,6 +1,6 @@
 locals {
-  # Pick a CoreOS Container Linux derivative
-  ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
+  # Pick a Container Linux derivative
+  ami_id = "${element(concat(data.aws_ami.flatcar.*.image_id, data.aws_ami.coreos.*.image_id, list("")), 0)}"
 
   flavor  = var.os_name
   channel = var.os_channel
@@ -8,6 +8,8 @@ locals {
 }
 
 data "aws_ami" "coreos" {
+  count  = "${local.flavor == "coreos" ? 1 : 0}"
+
   most_recent = true
   owners      = ["595879546273"]
 
@@ -23,11 +25,13 @@ data "aws_ami" "coreos" {
 
   filter {
     name   = "name"
-    values = ["CoreOS-${local.flavor == "coreos" ? local.channel : "stable"}-${local.flavor == "coreos" ? local.ver : ""}*"]
+    values = ["CoreOS-${local.channel}-${local.ver}*"]
   }
 }
 
 data "aws_ami" "flatcar" {
+  count  = "${local.flavor == "flatcar" ? 1 : 0}"
+
   most_recent = true
   owners      = ["075585003325"]
 
@@ -43,6 +47,6 @@ data "aws_ami" "flatcar" {
 
   filter {
     name   = "name"
-    values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-${local.flavor == "flatcar" ? local.ver : ""}*"]
+    values = ["Flatcar-${local.channel}-${local.ver}*"]
   }
 }

--- a/aws/flatcar-linux/kubernetes/workers/ami.tf
+++ b/aws/flatcar-linux/kubernetes/workers/ami.tf
@@ -1,6 +1,6 @@
 locals {
-  # Pick a CoreOS Container Linux derivative
-  ami_id = local.flavor == "flatcar" ? data.aws_ami.flatcar.image_id : data.aws_ami.coreos.image_id
+  # Pick a Container Linux derivative
+  ami_id = "${element(concat(data.aws_ami.flatcar.*.image_id, data.aws_ami.coreos.*.image_id, list("")), 0)}"
 
   flavor  = var.os_name
   channel = var.os_channel
@@ -8,6 +8,8 @@ locals {
 }
 
 data "aws_ami" "coreos" {
+  count  = "${local.flavor == "coreos" ? 1 : 0}"
+
   most_recent = true
   owners      = ["595879546273"]
 
@@ -23,11 +25,13 @@ data "aws_ami" "coreos" {
 
   filter {
     name   = "name"
-    values = ["CoreOS-${local.flavor == "coreos" ? local.channel : "stable"}-${local.flavor == "coreos" ? local.ver : ""}*"]
+    values = ["CoreOS-${local.channel}-${local.ver}*"]
   }
 }
 
 data "aws_ami" "flatcar" {
+  count  = "${local.flavor == "flatcar" ? 1 : 0}"
+
   most_recent = true
   owners      = ["075585003325"]
 
@@ -43,6 +47,6 @@ data "aws_ami" "flatcar" {
 
   filter {
     name   = "name"
-    values = ["Flatcar-${local.flavor == "flatcar" ? local.channel : "stable"}-${local.flavor == "flatcar" ? local.ver : ""}*"]
+    values = ["Flatcar-${local.channel}-${local.ver}*"]
   }
 }


### PR DESCRIPTION
The end-of-life announcement for CoreOS Container Linux
(https://coreos.com/os/eol/) says that:

    > On or after September 1, [...] OS images will be removed from
    > AWS, Azure, and Google Compute Engine

Previously, the "aws_ami coreos" section was always evaluated, even if
the user selects flatcar. The CoreOS images were not used though. If the
CoreOS AMIs were deleted, that would break the deployment of Flatcar.

This patch removes this dependency using the terraform code pattern with
resources count = 0. See also:
https://github.com/hashicorp/terraform/issues/16726#issuecomment-346037079

-----

TODO:
- [x] Tests