### PR TITLE
bootkube/resources/charts/kubelet: make /sys RW

### DIFF
--- a/bootkube/resources/charts/kubelet/templates/kubelet-ds.yaml
+++ b/bootkube/resources/charts/kubelet/templates/kubelet-ds.yaml
@@ -73,7 +73,6 @@ spec:
           mountPath: /run
         - name: sys
           mountPath: /sys
-          readOnly: true
         - name: mnt
           mountPath: /mnt
           mountPropagation: Bidirectional


### PR DESCRIPTION
As stated as requirement in
kubernetes/kubernetes#43704 (comment).

Also, bootstrap-kubelet also use writeable /sys from host, as this is
provided by the rkt stage1: https://coreos.com/rkt/docs/latest/running-fly-stage1.html#how-does-it-work

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>