### PR TITLE
kubelet-ds: mount iscsiadm and /lib/modules into self-hosted kubelet

### DIFF
--- a/bootkube/resources/charts/kubelet/templates/kubelet-ds.yaml
+++ b/bootkube/resources/charts/kubelet/templates/kubelet-ds.yaml
@@ -93,6 +93,10 @@ spec:
         - name: os-release
           mountPath: /etc/os-release
           readOnly: true
+        - name: iscsiadm
+          mountPath: /usr/sbin/iscsiadm
+        - name: modules
+          mountPath: /lib/modules
       hostNetwork: true
       hostPID: true
       # Tolerate all the taints. This ensures that the pod runs on all the nodes.
@@ -137,6 +141,12 @@ spec:
         hostPath:
           path: /usr/lib/os-release
           type: File
+      - name: iscsiadm
+        hostPath:
+          path: /usr/sbin/iscsiadm
+      - name: modules
+        hostPath:
+          path: /lib/modules
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1


### PR DESCRIPTION
As this is done by the bootstrap kubelet as well and is required for
running OpenEBS.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>

Just a note, some OpenEBS issue involving CoreOS also suggests mouting `/etc/iscsi` into `kubelet`, so I guess if user has some custom iSCSI settings, kubelet will use them. I'm not sure if we need it for now though. Refs: https://github.com/openebs/openebs/issues/160#issuecomment-315104565