### PR TITLE
packet: pass tags to packet_device

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -316,6 +316,7 @@ Lokomotive implements support for some [DNS providers](../dns/), if your provide
 | reservation_ids_default | Default hardware reservation ID for nodes not listed in the `reservation_ids` map. | "" | "next-available"|
 | certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |
 | controller_clc_snippets [[1]](#clc-snippets-limitation) | Controller Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
+| tags | Tags for Packet instances. The tags are not directly exposed to Kubernetes but can be fetched via Packet API | [] | ["foo", "bar"] |
 
 
 #### Worker module
@@ -339,6 +340,7 @@ Lokomotive implements support for some [DNS providers](../dns/), if your provide
 | reservation_ids | Map Packet hardware reservation IDs to instances. | {} | { worker-0 = "55555f20-a1fb-55bd-1e11-11af11d11111" } |
 | reservation_ids_default | Default hardware reservation ID for nodes not listed in the `reservation_ids` map. | "" | "next-available"|
 | clc_snippets [[1]](#clc-snippets-limitation) | Worker Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
+| tags | Tags for Packet instances. The tags are not directly exposed to Kubernetes but can be fetched via Packet API | [] | ["foo", "bar"] |
 
 Documentation about Packet hardware reservation id can be found here: https://support.packet.com/kb/articles/reserved-hardware.
 

--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -58,6 +58,7 @@ resource "packet_device" "controllers" {
 
   ipxe_script_url = var.ipxe_script_url
   always_pxe      = false
+  tags            = var.tags
 }
 
 data "ct_config" "controller-install-ignitions" {

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -175,3 +175,9 @@ variable "certs_validity_period_hours" {
   type        = number
   default     = 8760
 }
+
+variable "tags" {
+  description = "List of tags that will be propagated to master nodes"
+  type        = list(string)
+  default     = []
+}

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -163,3 +163,9 @@ variable "disable_bgp" {
   type        = bool
   default     = false
 }
+
+variable "tags" {
+  description = "List of tags that will be propagated to nodes in this pool"
+  type        = list(string)
+  default     = []
+}

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -16,6 +16,8 @@ resource "packet_device" "nodes" {
     format("worker-%v", count.index),
     var.reservation_ids_default,
   )
+
+  tags = var.tags
 }
 
 data "ct_config" "install-ignitions" {


### PR DESCRIPTION
Some applications (such as autoscaler) may require Packet tags to be
set. To avoid having additional tooling to tag the instances we can
pass tags directly to packet_device.

Signed-off-by: Martin Polednik <m.polednik@gmail.com>