### PR TITLE
kubelet: Close health port in kubelet bootstrap pods

### DIFF
--- a/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -86,6 +86,7 @@ systemd:
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --config=/etc/kubernetes/kubelet.config \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \

--- a/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/aws/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -62,6 +62,7 @@ systemd:
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --config=/etc/kubernetes/kubelet.config \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \

--- a/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -82,6 +82,7 @@ systemd:
           --cluster_domain=${cluster_domain_suffix} \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \

--- a/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/azure/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -60,6 +60,7 @@ systemd:
           --cluster_domain=${cluster_domain_suffix} \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \

--- a/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -94,6 +94,7 @@ systemd:
           --cluster_domain=${cluster_domain_suffix} \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --hostname-override=${domain_name} \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \

--- a/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
+++ b/bare-metal/flatcar-linux/kubernetes/cl/worker.yaml.tmpl
@@ -67,6 +67,7 @@ systemd:
           --cluster_domain=${cluster_domain_suffix} \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --hostname-override=${domain_name} \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \

--- a/bootkube/resources/charts/kubelet/templates/kubelet-ds.yaml
+++ b/bootkube/resources/charts/kubelet/templates/kubelet-ds.yaml
@@ -43,6 +43,7 @@ spec:
           --network-plugin=cni \
           --pod-manifest-path=/etc/kubernetes/manifests \
           --read-only-port=0 \
+          --healthz-bind-address=$(HOST_IP) \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --node-labels=$(grep NODE_LABELS /etc/kubernetes/kubelet.env | cut -d'"' -f2) \
           --register-with-taints=$(grep NODE_TAINTS /etc/kubernetes/kubelet.env | cut -d'"' -f2)
@@ -56,6 +57,14 @@ spec:
               fieldPath: status.hostIP
         securityContext:
           privileged: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10248
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10248
         volumeMounts:
         - mountPath: /var/lib/cni
           name: coreos-var-lib-cni

--- a/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -83,6 +83,7 @@ systemd:
           --cluster_domain=${cluster_domain_suffix} \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \

--- a/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/google-cloud/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -56,6 +56,7 @@ systemd:
           --cluster_domain=${cluster_domain_suffix} \
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \

--- a/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -84,6 +84,7 @@ systemd:
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --config=/etc/kubernetes/kubelet.config \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --hostname-override=${etcd_domain} \

--- a/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/kvm-libvirt/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -63,6 +63,7 @@ systemd:
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --config=/etc/kubernetes/kubelet.config \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \

--- a/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/cl/controller.yaml.tmpl
@@ -121,6 +121,7 @@ systemd:
           --cni-conf-dir=/etc/kubernetes/cni/net.d \
           --config=/etc/kubernetes/kubelet.config \
           --exit-on-lock-contention \
+          --healthz-port=0 \
           --kubeconfig=/etc/kubernetes/kubeconfig \
           --lock-file=/var/run/lock/kubelet.lock \
           --network-plugin=cni \

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -96,6 +96,7 @@ systemd:
             --cni-conf-dir=/etc/kubernetes/cni/net.d \
             --config=/etc/kubernetes/kubelet.config \
             --exit-on-lock-contention \
+            --healthz-port=0 \
             --kubeconfig=/etc/kubernetes/kubeconfig \
             --lock-file=/var/run/lock/kubelet.lock \
             --network-plugin=cni \


### PR DESCRIPTION
Add livenessProbe and readinessProbe to self hosted kubelet.