### PR TITLE
aws: add tags on AWS resources

### DIFF
--- a/aws/flatcar-linux/kubernetes/controllers.tf
+++ b/aws/flatcar-linux/kubernetes/controllers.tf
@@ -17,9 +17,9 @@ resource "aws_route53_record" "etcds" {
 resource "aws_instance" "controllers" {
   count = var.controller_count
 
-  tags = {
+  tags = merge(var.tags, {
     Name = "${var.cluster_name}-controller-${count.index}"
-  }
+  })
 
   instance_type = var.controller_type
 

--- a/aws/flatcar-linux/kubernetes/network.tf
+++ b/aws/flatcar-linux/kubernetes/network.tf
@@ -9,17 +9,17 @@ resource "aws_vpc" "network" {
   enable_dns_support               = true
   enable_dns_hostnames             = true
 
-  tags = {
+  tags = merge(var.tags, {
     "Name" = var.cluster_name
-  }
+  })
 }
 
 resource "aws_internet_gateway" "gateway" {
   vpc_id = aws_vpc.network.id
 
-  tags = {
+  tags = merge(var.tags, {
     "Name" = var.cluster_name
-  }
+  })
 }
 
 resource "aws_route_table" "default" {
@@ -35,9 +35,9 @@ resource "aws_route_table" "default" {
     gateway_id      = aws_internet_gateway.gateway.id
   }
 
-  tags = {
+  tags = merge(var.tags, {
     "Name" = var.cluster_name
-  }
+  })
 }
 
 # Subnets (one per availability zone)
@@ -53,9 +53,9 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch         = true
   assign_ipv6_address_on_creation = true
 
-  tags = {
+  tags = merge(var.tags, {
     "Name" = "${var.cluster_name}-public-${count.index}"
-  }
+  })
 }
 
 resource "aws_route_table_association" "public" {

--- a/aws/flatcar-linux/kubernetes/security.tf
+++ b/aws/flatcar-linux/kubernetes/security.tf
@@ -8,9 +8,9 @@ resource "aws_security_group" "controller" {
 
   vpc_id = aws_vpc.network.id
 
-  tags = {
+  tags = merge(var.tags, {
     "Name" = "${var.cluster_name}-controller"
-  }
+  })
 }
 
 resource "aws_security_group_rule" "controller-ssh" {
@@ -189,9 +189,9 @@ resource "aws_security_group" "worker" {
 
   vpc_id = aws_vpc.network.id
 
-  tags = {
+  tags = merge(var.tags, {
     "Name" = "${var.cluster_name}-worker"
-  }
+  })
 }
 
 resource "aws_security_group_rule" "worker-ssh" {

--- a/aws/flatcar-linux/kubernetes/variables.tf
+++ b/aws/flatcar-linux/kubernetes/variables.tf
@@ -101,6 +101,15 @@ variable "worker_clc_snippets" {
   default     = []
 }
 
+variable "tags" {
+  type        = map
+  default     = {
+    "ManagedBy" = "Lokomotive"
+    "CreatedBy" = "Unspecified"
+  }
+  description = "Optional details to tag on AWS resources"
+}
+
 # configuration
 
 variable "ssh_keys" {

--- a/aws/flatcar-linux/kubernetes/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers.tf
@@ -14,6 +14,7 @@ module "workers" {
   disk_size       = var.disk_size
   spot_price      = var.worker_price
   target_groups   = var.worker_target_groups
+  tags            = var.tags
 
   # configuration
   kubeconfig            = module.bootkube.kubeconfig-kubelet

--- a/aws/flatcar-linux/kubernetes/workers/variables.tf
+++ b/aws/flatcar-linux/kubernetes/workers/variables.tf
@@ -88,6 +88,15 @@ variable "clc_snippets" {
   default     = []
 }
 
+variable "tags" {
+  type        = map
+  default     = {
+    "ManagedBy" = "Lokomotive"
+    "CreatedBy" = "Unspecified"
+  }
+  description = "Optional details to tag on AWS resources"
+}
+
 # configuration
 
 variable "kubeconfig" {

--- a/aws/flatcar-linux/kubernetes/workers/workers.tf
+++ b/aws/flatcar-linux/kubernetes/workers/workers.tf
@@ -33,13 +33,23 @@ resource "aws_autoscaling_group" "workers" {
   # used. Disable wait to avoid issues and align with other clouds.
   wait_for_capacity_timeout = "0"
 
-  tags = [
-    {
-      key                 = "Name"
-      value               = "${var.name}-worker"
-      propagate_at_launch = true
-    },
-  ]
+  tags = flatten([
+    [
+      {
+        key                 = "Name"
+        value               = "${var.name}-worker"
+        propagate_at_launch = true
+      },
+    ], 
+    [
+      for tag in keys(var.tags):
+      {
+        key                 = tag == "Name" ? "X-Name" : tag
+        value               = var.tags[tag]
+        propagate_at_launch = true
+      }
+    ],
+  ])
 }
 
 # Worker template

--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -223,6 +223,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |
+| tags | Optional details to tag on AWS resources | `{}` | `{"CreatedBy" = "Devops team"}` |
 
 Check the list of valid [instance types](https://aws.amazon.com/ec2/instance-types/).
 


### PR DESCRIPTION
Ideas of possible use cases:
- when several people share the same AWS account, they can add add a tag `"CreatedBy"="Tom"` to know who created which cluster.
- when the terraform state is deleted and the user wants to manually delete AWS resources from the web console.