### PR TITLE
aws,packet: make tags more uniform

### DIFF
--- a/docs/flatcar-linux/aws.md
+++ b/docs/flatcar-linux/aws.md
@@ -223,7 +223,7 @@ Reference the DNS zone id with `"${aws_route53_zone.zone-for-clusters.zone_id}"`
 | service_cidr | CIDR IPv4 range to assign to Kubernetes services | "10.3.0.0/16" | "10.3.0.0/24" |
 | cluster_domain_suffix | FQDN suffix for Kubernetes services answered by coredns. | "cluster.local" | "k8s.example.com" |
 | certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |
-| tags | Optional details to tag on AWS resources | `{}` | `{"CreatedBy" = "Devops team"}` |
+| tags | Optional details to tag on AWS resources | `{"ManagedBy" = "Lokomotive", "CreatedBy" = "Unspecified"}` | `{"ManagedBy" = "Lokomotive", "CreatedBy" = "DevOps team"}` |
 
 Check the list of valid [instance types](https://aws.amazon.com/ec2/instance-types/).
 

--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -316,7 +316,7 @@ Lokomotive implements support for some [DNS providers](../dns/), if your provide
 | reservation_ids_default | Default hardware reservation ID for nodes not listed in the `reservation_ids` map. | "" | "next-available"|
 | certs_validity_period_hours | Validity of all the certificates in hours | 8760 | 17520 |
 | controller_clc_snippets [[1]](#clc-snippets-limitation) | Controller Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
-| tags | Tags for Packet instances. The tags are not directly exposed to Kubernetes but can be fetched via Packet API | [] | ["foo", "bar"] |
+| tags | Tags for Packet instances. The tags are not directly exposed to Kubernetes but can be fetched via Packet API | ["ManagedBy:Lokomotive", "CreatedBy:Unspecified"] | ["ManagedBy:Lokomotive", "CreatedBy:DevOpsTeam"] |
 
 
 #### Worker module
@@ -340,7 +340,7 @@ Lokomotive implements support for some [DNS providers](../dns/), if your provide
 | reservation_ids | Map Packet hardware reservation IDs to instances. | {} | { worker-0 = "55555f20-a1fb-55bd-1e11-11af11d11111" } |
 | reservation_ids_default | Default hardware reservation ID for nodes not listed in the `reservation_ids` map. | "" | "next-available"|
 | clc_snippets [[1]](#clc-snippets-limitation) | Worker Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
-| tags | Tags for Packet instances. The tags are not directly exposed to Kubernetes but can be fetched via Packet API | [] | ["foo", "bar"] |
+| tags | Tags for Packet instances. The tags are not directly exposed to Kubernetes but can be fetched via Packet API | ["ManagedBy:Lokomotive", "CreatedBy:Unspecified"] | ["ManagedBy:Lokomotive", "CreatedBy:DevOpsTeam"] |
 
 Documentation about Packet hardware reservation id can be found here: https://support.packet.com/kb/articles/reserved-hardware.
 

--- a/packet/flatcar-linux/kubernetes/variables.tf
+++ b/packet/flatcar-linux/kubernetes/variables.tf
@@ -179,5 +179,5 @@ variable "certs_validity_period_hours" {
 variable "tags" {
   description = "List of tags that will be propagated to master nodes"
   type        = list(string)
-  default     = []
+  default     = ["ManagedBy:Lokomotive", "CreatedBy:Unspecified"]
 }

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -167,5 +167,5 @@ variable "disable_bgp" {
 variable "tags" {
   description = "List of tags that will be propagated to nodes in this pool"
   type        = list(string)
-  default     = []
+  default     = ["ManagedBy:Lokomotive", "CreatedBy:Unspecified"]
 }


### PR DESCRIPTION
On Packet, tags are a list of strings.
On AWS, tags are a key-value map.

There are some default tags:
- ManagedBy = Lokomotive
- CreatedBy = Unspecified

and some suggestions:
- ManagedBy = Lokomotive
- CreatedBy = DevOpsTeam

-----

Related:
- https://github.com/kinvolk/lokomotive-kubernetes/pull/170
- https://github.com/kinvolk/lokomotive-kubernetes/pull/176