### PR TITLE
packet/flatcar-linux/kubernetes: add etcd records at the end

### DIFF
--- a/packet/flatcar-linux/kubernetes/controllers.tf
+++ b/packet/flatcar-linux/kubernetes/controllers.tf
@@ -4,16 +4,6 @@ locals {
   etcd_fqdn         = [for index, device in packet_device.controllers : format("%s-etcd%d.%s.", var.cluster_name, index, var.dns_zone)]
 
   dns_entries = concat(
-    # etcd
-    [
-      for index, device in packet_device.controllers :
-      {
-        name    = local.etcd_fqdn[index],
-        type    = "A",
-        ttl     = 300,
-        records = [device.access_private_ipv4],
-      }
-    ],
     [
       # apiserver public
       {
@@ -29,7 +19,17 @@ locals {
         ttl     = 300,
         records = packet_device.controllers.*.access_private_ipv4,
       },
-    ]
+    ],
+    # etcd
+    [
+      for index, device in packet_device.controllers :
+      {
+        name    = local.etcd_fqdn[index],
+        type    = "A",
+        ttl     = 300,
+        records = [device.access_private_ipv4],
+      }
+    ],
   )
 }
 


### PR DESCRIPTION
Otherwise, when adding controller node, all records are shifted by one,
which triggers re-creating them, which may cause the downtime and
currently produces conflicting records, which breaks adding controller
nodes.

With this commit, etcd records will be added at the end of the
collection and first two entries should always remain the same and be
updated in place.

Closes #181

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>