### PR TITLE
Add BGP-related node labels

### DIFF
--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -78,26 +78,36 @@ systemd:
         ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
         ExecStartPre=/etc/kubernetes/configure-kubelet-cgroup-driver
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
-          --node-ip=$${COREOS_PACKET_IPV4_PRIVATE_0} \
-          --anonymous-auth=false \
-          --authentication-token-webhook \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/ca.crt \
-          --cluster_dns=${k8s_dns_service_ip} \
-          --cluster_domain=${cluster_domain_suffix} \
-          --cni-conf-dir=/etc/kubernetes/cni/net.d \
-          --config=/etc/kubernetes/kubelet.config \
-          --exit-on-lock-contention \
-          --kubeconfig=/etc/kubernetes/kubeconfig \
-          --lock-file=/var/run/lock/kubelet.lock \
-          --network-plugin=cni \
-          --node-labels=$${NODE_LABELS} \
-          --node-labels=lokomotive.alpha.kinvolk.io/public-ipv4=$${COREOS_PACKET_IPV4_PUBLIC_0} \
-          --pod-manifest-path=/etc/kubernetes/manifests \
-          --read-only-port=0 \
-          --register-with-taints=$${NODE_TAINTS} \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
+        # TODO: Workaround until https://github.com/coreos/afterburn/pull/358
+        # makes it into Flatcar. Then we can read COREOS_PACKET_IPV4_PRIVATE_GATEWAY_0
+        # from /run/metadata/flatcar and disable the template conditionals below.
+        ExecStart=/bin/sh -c \
+            "%{~ if bgp_node_labels != "" ~}
+            BGP_PEER_ADDRESS=$(ip route | grep '10.0.0.0/8' | awk {'print $3'}); \
+            %{~ endif ~}
+            /usr/lib/coreos/kubelet-wrapper \
+            --node-ip=$${COREOS_PACKET_IPV4_PRIVATE_0} \
+            --anonymous-auth=false \
+            --authentication-token-webhook \
+            --authorization-mode=Webhook \
+            --client-ca-file=/etc/kubernetes/ca.crt \
+            --cluster_dns=${k8s_dns_service_ip} \
+            --cluster_domain=${cluster_domain_suffix} \
+            --cni-conf-dir=/etc/kubernetes/cni/net.d \
+            --config=/etc/kubernetes/kubelet.config \
+            --exit-on-lock-contention \
+            --kubeconfig=/etc/kubernetes/kubeconfig \
+            --lock-file=/var/run/lock/kubelet.lock \
+            --network-plugin=cni \
+            --node-labels=$${NODE_LABELS} \
+            --node-labels=lokomotive.alpha.kinvolk.io/public-ipv4=$${COREOS_PACKET_IPV4_PUBLIC_0} \
+            %{~ if bgp_node_labels != "" ~}
+            --node-labels=$${BGP_NODE_LABELS},metallb.universe.tf/peer-address=$BGP_PEER_ADDRESS \
+            %{~ endif ~}
+            --pod-manifest-path=/etc/kubernetes/manifests \
+            --read-only-port=0 \
+            --register-with-taints=$${NODE_TAINTS} \
+            --volume-plugin-dir=/var/lib/kubelet/volumeplugins"
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=5
@@ -267,7 +277,8 @@ storage:
           KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube-${os_arch}
           KUBELET_IMAGE_TAG=v1.17.3
           KUBELET_IMAGE_ARGS="--exec=/usr/local/bin/kubelet"
-          NODE_LABELS="node.kubernetes.io/node,${worker_labels}"
+          NODE_LABELS="node.kubernetes.io/node,${node_labels}"
+          BGP_NODE_LABELS="${bgp_node_labels}"
           NODE_TAINTS="${taints}"
     - path: /etc/sysctl.d/max-user-watches.conf
       filesystem: root


### PR DESCRIPTION
When BGP is enabled for a worker pool, create node labels to be picked up by the "node peers" MetalLB feature.

https://github.com/metallb/metallb/issues/529