### PR TITLE
packet: allow starting kubelet with --cloud-provider=external

### DIFF
--- a/docs/flatcar-linux/packet.md
+++ b/docs/flatcar-linux/packet.md
@@ -341,6 +341,7 @@ Lokomotive implements support for some [DNS providers](../dns/), if your provide
 | reservation_ids_default | Default hardware reservation ID for nodes not listed in the `reservation_ids` map. | "" | "next-available"|
 | clc_snippets [[1]](#clc-snippets-limitation) | Worker Container Linux Config snippets | [] | [example](../advanced/customization.md#usage) |
 | tags | Tags for Packet instances. The tags are not directly exposed to Kubernetes but can be fetched via Packet API | ["ManagedBy:Lokomotive", "CreatedBy:Unspecified"] | ["ManagedBy:Lokomotive", "CreatedBy:DevOpsTeam"] |
+| use-ccm | Run Kubelet with --cloud-provider=external flag. All nodes will be tainted until [CCM](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/) is deployed. | false | true |
 
 Documentation about Packet hardware reservation id can be found here: https://support.packet.com/kb/articles/reserved-hardware.
 

--- a/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
+++ b/packet/flatcar-linux/kubernetes/workers/cl/worker.yaml.tmpl
@@ -107,6 +107,9 @@ systemd:
             --pod-manifest-path=/etc/kubernetes/manifests \
             --read-only-port=0 \
             --register-with-taints=$${NODE_TAINTS} \
+            %{~ if use_ccm ~}
+            --cloud-provider=external \
+            %{~ endif ~}
             --volume-plugin-dir=/var/lib/kubelet/volumeplugins"
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always

--- a/packet/flatcar-linux/kubernetes/workers/variables.tf
+++ b/packet/flatcar-linux/kubernetes/workers/variables.tf
@@ -169,3 +169,9 @@ variable "tags" {
   type        = list(string)
   default     = ["ManagedBy:Lokomotive", "CreatedBy:Unspecified"]
 }
+
+variable "use_ccm" {
+  description = "Sets kubelet's --cloud-provider=external flag. This causes all nodes to be initially tainted and requires running Cloud Controller Manager (CCM) to untaint them."
+  type        = bool
+  default     = false
+}

--- a/packet/flatcar-linux/kubernetes/workers/workers.tf
+++ b/packet/flatcar-linux/kubernetes/workers/workers.tf
@@ -67,6 +67,7 @@ data "ct_config" "ignitions" {
       setup_raid_hdd        = var.setup_raid_hdd
       setup_raid_ssd        = var.setup_raid_ssd
       setup_raid_ssd_fs     = var.setup_raid_ssd_fs
+      use_ccm               = var.use_ccm
     }
   )
   platform = "packet"


### PR DESCRIPTION
To use CCM with Kubernetes we need to pass --cloud-provider=external
to Kubelet. We abstract this with variable "use_ccm" as it makes the
distribution more accessible without having specific knowledge about
CCM requirements in general.

The change is limited in scope to Packet but it is indifferent from
needs for CCM on other cloud providers.

Signed-off-by: Martin Polednik <m.polednik@gmail.com>